### PR TITLE
Phase 1: SQLite foundation module + queue task #24

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,0 +1,281 @@
+"""SQLite database module for ThreadHop.
+
+Handles DB initialization, schema migrations, and query helpers for persistent
+session metadata. Per ADR-001, this replaces config.json for all state except
+app-level settings (theme, sidebar_width).
+
+DB location: ~/.config/threadhop/sessions.db
+Journal mode: WAL (concurrent reads for TUI + skill plugin).
+
+Typical usage:
+
+    import db
+    conn = db.init_db()                 # creates file + runs migrations
+    db.set_setting(conn, "theme", "textual-dark")
+    theme = db.get_setting(conn, "theme")
+    rows = db.query_all(conn, "SELECT * FROM sessions WHERE status = ?", ("active",))
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator, Sequence
+
+# --- Paths ---
+DB_DIR = Path.home() / ".config" / "threadhop"
+DB_PATH = DB_DIR / "sessions.db"
+
+# --- Schema version ---
+# Each migration N in MIGRATIONS moves the DB from version N to N+1.
+# The DB's current version lives in PRAGMA user_version.
+SCHEMA_VERSION = 1
+
+
+# --- Migrations -----------------------------------------------------------
+
+def _migration_001_initial(conn: sqlite3.Connection) -> None:
+    """Phase 1 foundation: settings + sessions tables.
+
+    Schema mirrors ADR-001 in docs/DESIGN-DECISIONS.md. Additional tables
+    (messages, messages_fts, index_state, bookmarks, memory) arrive in
+    later migrations as their features land.
+
+    Statements are issued one at a time (not via executescript) so they
+    run inside the caller's BEGIN/COMMIT transaction — executescript
+    disregards isolation_level and commits on its own.
+    """
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS settings (
+            key   TEXT PRIMARY KEY,
+            value TEXT NOT NULL  -- JSON-encoded
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS sessions (
+            session_id    TEXT PRIMARY KEY,
+            session_path  TEXT NOT NULL,
+            project       TEXT,
+            cwd           TEXT,
+            custom_name   TEXT,
+            status        TEXT NOT NULL DEFAULT 'active',
+                -- active | in_progress | in_review | done | archived
+            sort_order    INTEGER,
+            last_viewed   REAL,
+            created_at    REAL,
+            modified_at   REAL
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sessions_sort_order ON sessions(sort_order)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sessions_modified_at ON sessions(modified_at)"
+    )
+
+
+# Ordered list; MIGRATIONS[i] moves schema from version i to i+1.
+MIGRATIONS: list = [
+    _migration_001_initial,
+]
+
+assert len(MIGRATIONS) == SCHEMA_VERSION, (
+    "SCHEMA_VERSION must equal len(MIGRATIONS)"
+)
+
+
+# --- Connection management ------------------------------------------------
+
+def connect(db_path: Path | str | None = None) -> sqlite3.Connection:
+    """Open a connection with WAL mode, row factory, and FK enforcement.
+
+    Ensures the parent directory exists. Uses isolation_level=None so callers
+    control transactions explicitly via BEGIN/COMMIT (see `transaction()`).
+    `check_same_thread=False` because the TUI's background worker may access
+    the DB from a different thread than the main loop — WAL makes this safe
+    for readers, and we funnel writes through the app's async loop.
+    """
+    path = Path(db_path) if db_path is not None else DB_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(
+        str(path),
+        isolation_level=None,
+        check_same_thread=False,
+    )
+    conn.row_factory = sqlite3.Row
+
+    # WAL: concurrent readers alongside a writer. Required by ADR-001.
+    conn.execute("PRAGMA journal_mode = WAL")
+    # NORMAL is the WAL-recommended durability level — faster than FULL,
+    # safe against crashes (only loses uncommitted transactions on power loss).
+    conn.execute("PRAGMA synchronous = NORMAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+# --- Schema version helpers ----------------------------------------------
+
+def get_schema_version(conn: sqlite3.Connection) -> int:
+    """Return the current schema version stored in PRAGMA user_version."""
+    row = conn.execute("PRAGMA user_version").fetchone()
+    # Row may be tuple-like or sqlite3.Row; index 0 works for both.
+    return int(row[0]) if row is not None else 0
+
+
+def _set_schema_version(conn: sqlite3.Connection, version: int) -> None:
+    """Write the schema version. PRAGMA doesn't accept parameter binding,
+    so the value is interpolated after an int() cast."""
+    conn.execute(f"PRAGMA user_version = {int(version)}")
+
+
+def apply_migrations(conn: sqlite3.Connection) -> int:
+    """Run any pending migrations in order. Returns the final schema version.
+
+    Each migration runs in its own transaction so a failure rolls back
+    cleanly without leaving the DB in a half-migrated state.
+    """
+    current = get_schema_version(conn)
+    if current > SCHEMA_VERSION:
+        raise RuntimeError(
+            f"DB schema version {current} is newer than code's {SCHEMA_VERSION}. "
+            "Upgrade ThreadHop or restore an older DB."
+        )
+    for i in range(current, SCHEMA_VERSION):
+        migration = MIGRATIONS[i]
+        conn.execute("BEGIN")
+        try:
+            migration(conn)
+            _set_schema_version(conn, i + 1)
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+    return SCHEMA_VERSION
+
+
+def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
+    """Open (creating if needed) the DB and apply any pending migrations.
+
+    This is the single entry point callers should use — it guarantees the
+    returned connection points at an up-to-date schema.
+    """
+    conn = connect(db_path)
+    apply_migrations(conn)
+    return conn
+
+
+# --- Query helpers --------------------------------------------------------
+
+def row_to_dict(row: sqlite3.Row | None) -> dict | None:
+    """Convert a sqlite3.Row to a plain dict. Returns None for None input."""
+    if row is None:
+        return None
+    return dict(row)
+
+
+def rows_to_dicts(rows: Sequence[sqlite3.Row]) -> list[dict]:
+    """Convert an iterable of sqlite3.Row objects to a list of dicts."""
+    return [dict(r) for r in rows]
+
+
+def query_one(
+    conn: sqlite3.Connection,
+    sql: str,
+    params: tuple | dict = (),
+) -> dict | None:
+    """Execute a parameterized SELECT and return the first row as a dict.
+
+    Returns None if no rows match. Always use `?` (or named) placeholders —
+    never string formatting — to prevent SQL injection.
+    """
+    row = conn.execute(sql, params).fetchone()
+    return row_to_dict(row)
+
+
+def query_all(
+    conn: sqlite3.Connection,
+    sql: str,
+    params: tuple | dict = (),
+) -> list[dict]:
+    """Execute a parameterized SELECT and return all matching rows as dicts."""
+    return rows_to_dicts(conn.execute(sql, params).fetchall())
+
+
+def execute(
+    conn: sqlite3.Connection,
+    sql: str,
+    params: tuple | dict = (),
+) -> sqlite3.Cursor:
+    """Execute a parameterized write (INSERT / UPDATE / DELETE)."""
+    return conn.execute(sql, params)
+
+
+def executemany(
+    conn: sqlite3.Connection,
+    sql: str,
+    seq_of_params: Sequence[tuple] | Sequence[dict],
+) -> sqlite3.Cursor:
+    """Bulk-execute a parameterized write for a sequence of parameter sets."""
+    return conn.executemany(sql, seq_of_params)
+
+
+@contextmanager
+def transaction(conn: sqlite3.Connection) -> Iterator[sqlite3.Connection]:
+    """Run a block inside an explicit transaction.
+
+    Commits on clean exit, rolls back on any exception. Use this when
+    grouping multiple writes that must succeed or fail together.
+    """
+    conn.execute("BEGIN")
+    try:
+        yield conn
+        conn.execute("COMMIT")
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+
+
+# --- Settings helpers -----------------------------------------------------
+# The settings table stores small app-level key/value pairs. Values are
+# JSON-encoded so callers can round-trip ints, bools, lists, dicts.
+
+def get_setting(
+    conn: sqlite3.Connection,
+    key: str,
+    default: Any = None,
+) -> Any:
+    """Return the JSON-decoded value for `key`, or `default` if not set."""
+    row = conn.execute(
+        "SELECT value FROM settings WHERE key = ?", (key,)
+    ).fetchone()
+    if row is None:
+        return default
+    try:
+        return json.loads(row["value"])
+    except (json.JSONDecodeError, TypeError):
+        # Tolerate legacy raw-string values written before this helper existed.
+        return row["value"]
+
+
+def set_setting(conn: sqlite3.Connection, key: str, value: Any) -> None:
+    """Upsert a setting. Value is JSON-encoded before storage."""
+    conn.execute(
+        "INSERT INTO settings (key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (key, json.dumps(value)),
+    )
+
+
+def delete_setting(conn: sqlite3.Connection, key: str) -> None:
+    """Remove a setting. No-op if the key doesn't exist."""
+    conn.execute("DELETE FROM settings WHERE key = ?", (key,))

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -54,6 +54,9 @@ _Enables instant search and cross-session context sharing. All TUI features._
 - [ ] **14. Real-time search panel (/) with FTS5 prefix matching** *(blocked by: #8, #9)*
   Press `/` to open search input. FTS5 prefix matching per keystroke (e.g., `rate* lim*`). Results show message snippet, session name, project, timestamp. Navigate with `j`/`k`, `Enter` to jump to source. Filter syntax: `project:`, `user:`, `assistant:`. _(ADR-002, ADR-007)_
 
+- [ ] **24. Data model hardening: CHECK constraints + Pydantic schemas** *(blocked by: #1; prereq for: #8)*
+  Add a migration introducing `CHECK (status IN ('active','in_progress','in_review','done','archived'))` on the `sessions` table so the enum is enforced at the DB layer, not just the app. Design Pydantic models as the validation boundary for JSONL transcript parsing — user/assistant messages, `tool_use` blocks, `tool_result` blocks — so the indexer in #8 folds over typed instances instead of raw dicts and malformed lines fail loudly. Use `Literal` types for enums (session status, message role, memory `type`). Define `Session`, `Message`, `Bookmark`, `MemoryEntry` shapes alongside their table migrations so the Python types and SQL schemas evolve together. Add `pydantic` to the script's PEP 723 dependency block. _(ADR-001, ADR-003, ADR-004)_
+
 ---
 
 ## Phase 3: Skill Plugin
@@ -104,8 +107,8 @@ _Automatic knowledge extraction._
 #1 SQLite DB ──┬──> #2 Migration ──> #7 Tests
                ├──> #3 Status ──┬──> #4 Keybinds (s/S)
                │                └──> #5 Archive (a/A)
-               └──> #8 Indexer ──> #9 Incremental ──> #14 Search ──> #23 Fuzzy
-                                                  └──> #14 Search
+               └──> #24 Data models ──> #8 Indexer ──> #9 Incremental ──> #14 Search ──> #23 Fuzzy
+                                                                      └──> #14 Search
 #6 Sidebar resize (independent)
 
 #10 Selection ──┬──> #11 Range select


### PR DESCRIPTION
## Summary
- Adds `db.py` — the SQLite foundation for Phase 1 (closes TASKS.md #1). WAL-mode DB at `~/.config/threadhop/sessions.db` with versioned migrations, parameterized query helpers, and a JSON-codec settings layer.
- Queues TASKS.md #24 — data model hardening (CHECK constraint on `sessions.status` + Pydantic schemas for JSONL parsing), slotted as a Phase 2 prereq for #8.

## What's in `db.py`
- **Schema (migration 001)** — `settings(key, value)` + `sessions(session_id, session_path, project, cwd, custom_name, status, sort_order, last_viewed, created_at, modified_at)` with indexes on `status`, `sort_order`, `modified_at`. Mirrors ADR-001.
- **Connection** — WAL journal mode, `synchronous=NORMAL`, `foreign_keys=ON`, `row_factory=sqlite3.Row`, `check_same_thread=False` (safe for the TUI's background worker under WAL).
- **Migrations** — `PRAGMA user_version` tracks schema version. `MIGRATIONS` is an ordered list of callables; `apply_migrations()` is idempotent, wraps each step in `BEGIN`/`COMMIT`/`ROLLBACK`, and refuses to run against a DB with a newer schema than the code.
- **Helpers** — `query_one` / `query_all` / `execute` / `executemany` (parameterized only), `row_to_dict` / `rows_to_dicts`, `transaction()` context manager.
- **Settings** — `get_setting` / `set_setting` / `delete_setting` with JSON encoding and `ON CONFLICT DO UPDATE` upsert.

## Design notes for reviewers
- Migrations use individual `conn.execute()` calls rather than `executescript()` on purpose — `executescript` disregards `isolation_level` and commits on its own, which would bypass the per-migration transaction wrapping.
- `from __future__ import annotations` is used so the module imports under older interpreters; the `threadhop` runtime is Python 3.12 via uv.
- Lands sibling to `threadhop` so `import db` works via `sys.path[0]` — no packaging required.

## Unblocks
- #2 config.json → SQLite migration
- #3 sessions.status field + grouped display
- #7 DB migration tests
- #8 JSONL indexer (via new #24)

## Test plan
- [x] Smoke-tested locally under both system Python and `uv run` Python 3.12: WAL enabled, tables/indexes present, settings JSON round-trip (str/int/dict/list), upsert, delete, rollback on exception, idempotent re-init, future-schema guard.
- [ ] Reviewer: sanity-check the schema matches ADR-001
- [ ] Reviewer: confirm branch name/placement works for downstream tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)