### PR TITLE
Task #2: Migrate config.json → SQLite (one-time, idempotent)

### DIFF
--- a/db.py
+++ b/db.py
@@ -279,3 +279,356 @@ def set_setting(conn: sqlite3.Connection, key: str, value: Any) -> None:
 def delete_setting(conn: sqlite3.Connection, key: str) -> None:
     """Remove a setting. No-op if the key doesn't exist."""
     conn.execute("DELETE FROM settings WHERE key = ?", (key,))
+
+
+# --- Session-row helpers --------------------------------------------------
+# Thin wrappers over the `sessions` table for the fields that get touched
+# by both the filesystem scan and the user's UI actions. Splitting these
+# keeps the callers honest about which fields they own:
+#   - filesystem scan owns: session_path, project, cwd, modified_at, created_at
+#   - user actions own:     custom_name, sort_order, last_viewed, status
+# upsert_session deliberately does NOT touch the user-owned fields so the
+# background refresh loop can refresh rows without clobbering renames.
+
+def upsert_session(
+    conn: sqlite3.Connection,
+    session_id: str,
+    session_path: str,
+    *,
+    project: str | None = None,
+    cwd: str | None = None,
+    created_at: float | None = None,
+    modified_at: float | None = None,
+) -> None:
+    """Ensure a row exists for `session_id` with fresh filesystem metadata.
+
+    On conflict, refreshes the filesystem-owned columns (path/project/cwd/
+    modified_at) but leaves custom_name, sort_order, last_viewed, and
+    status alone — those are owned by user actions and must survive a
+    routine rescan.
+    """
+    conn.execute(
+        """
+        INSERT INTO sessions (
+            session_id, session_path, project, cwd, created_at, modified_at
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(session_id) DO UPDATE SET
+            session_path = excluded.session_path,
+            project      = COALESCE(excluded.project, sessions.project),
+            cwd          = COALESCE(excluded.cwd, sessions.cwd),
+            modified_at  = COALESCE(excluded.modified_at, sessions.modified_at)
+        """,
+        (session_id, session_path, project, cwd, created_at, modified_at),
+    )
+
+
+def set_custom_name(
+    conn: sqlite3.Connection,
+    session_id: str,
+    name: str | None,
+) -> None:
+    """Set the user-chosen display name for a session. Empty string clears it."""
+    conn.execute(
+        "UPDATE sessions SET custom_name = ? WHERE session_id = ?",
+        (name or None, session_id),
+    )
+
+
+def set_last_viewed(
+    conn: sqlite3.Connection,
+    session_id: str,
+    timestamp: float,
+) -> None:
+    """Record the last time the user opened this session (for unread marking)."""
+    conn.execute(
+        "UPDATE sessions SET last_viewed = ? WHERE session_id = ?",
+        (timestamp, session_id),
+    )
+
+
+def set_session_order(conn: sqlite3.Connection, ordered_ids: list[str]) -> None:
+    """Rewrite sort_order so ordered_ids[0] is first, [1] second, ….
+
+    Sessions not in the list get sort_order = NULL (they'll be sorted to
+    the end by the UI's ordering pass). Runs inside a single transaction
+    so the list is never observed in a half-updated state.
+    """
+    with transaction(conn):
+        conn.execute("UPDATE sessions SET sort_order = NULL")
+        if ordered_ids:
+            conn.executemany(
+                "UPDATE sessions SET sort_order = ? WHERE session_id = ?",
+                [(i, sid) for i, sid in enumerate(ordered_ids)],
+            )
+
+
+def get_custom_names(conn: sqlite3.Connection) -> dict[str, str]:
+    """Return {session_id: custom_name} for every session with a custom name set."""
+    rows = conn.execute(
+        "SELECT session_id, custom_name FROM sessions "
+        "WHERE custom_name IS NOT NULL"
+    ).fetchall()
+    return {r["session_id"]: r["custom_name"] for r in rows}
+
+
+def get_last_viewed(conn: sqlite3.Connection) -> dict[str, float]:
+    """Return {session_id: last_viewed} for every session that's been opened."""
+    rows = conn.execute(
+        "SELECT session_id, last_viewed FROM sessions "
+        "WHERE last_viewed IS NOT NULL"
+    ).fetchall()
+    return {r["session_id"]: float(r["last_viewed"]) for r in rows}
+
+
+def get_session_order(conn: sqlite3.Connection) -> list[str]:
+    """Return session_ids sorted by sort_order (NULLs excluded)."""
+    rows = conn.execute(
+        "SELECT session_id FROM sessions "
+        "WHERE sort_order IS NOT NULL ORDER BY sort_order"
+    ).fetchall()
+    return [r["session_id"] for r in rows]
+
+
+# --- One-time config.json → SQLite migration (ADR-001) --------------------
+# Runs on first startup. Moves session-level keys out of config.json into
+# the `sessions` table. Keeps `theme` (and any future app-level keys like
+# `sidebar_width`) in config.json.
+
+# Settings-table flag marking the migration complete. Stored as True after
+# a successful run; checked at the top of `migrate_config_json_to_sqlite`
+# so subsequent calls are a cheap no-op (= idempotent).
+MIGRATION_FLAG = "config_migrated_v1"
+
+# Legacy session-level keys that must NOT remain in config.json after
+# migration. Anything else (theme, sidebar_width, unknown keys) is preserved.
+_MIGRATED_CONFIG_KEYS = ("session_names", "session_order", "last_viewed")
+
+
+def _rewrite_config_stripped(config_path: Path, raw: dict) -> None:
+    """Rewrite config.json with the legacy session-level keys removed.
+
+    Unknown keys are preserved — users and future features may add their
+    own app-level settings, and we don't want to silently drop them.
+    """
+    remaining = {k: v for k, v in raw.items() if k not in _MIGRATED_CONFIG_KEYS}
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(remaining, indent=2))
+
+
+def migrate_config_json_to_sqlite(
+    conn: sqlite3.Connection,
+    config_path: Path,
+    claude_projects_dir: Path,
+    *,
+    rewrite_config: bool = True,
+) -> dict:
+    """One-time migration per ADR-001: move session-level state from
+    config.json into the `sessions` table.
+
+    Moves:   session_names, session_order, last_viewed.
+    Keeps:   theme and any other app-level keys (sidebar_width, …).
+
+    **Idempotent** via the `config_migrated_v1` settings flag — subsequent
+    calls return `{"action": "skipped"}` without touching either store.
+
+    **Failure safety:**
+    * The DB writes (row inserts + flag-set) all happen inside a single
+      transaction. If any INSERT fails, the transaction rolls back and the
+      flag is not set, so the next run can retry.
+    * The config.json rewrite happens AFTER the DB transaction commits.
+      If the rewrite fails, the DB is already authoritative and the flag
+      is set; legacy keys may linger in config.json but will be ignored
+      by the TUI (which reads session-level state from SQLite now).
+    * In either failure mode, the original config.json content is
+      preserved — we only overwrite it at the very end of a successful
+      migration.
+
+    **Missing sessions:** any session_id referenced in config.json whose
+    JSONL file no longer exists on disk is skipped. We can't satisfy the
+    `session_path NOT NULL` constraint without a real path, and a
+    custom_name for a deleted session is invisible to the user anyway.
+
+    Args:
+        conn: Open DB connection with the schema applied.
+        config_path: Path to `config.json` (may or may not exist).
+        claude_projects_dir: `~/.claude/projects`; scanned to resolve
+            session_ids to their JSONL paths.
+        rewrite_config: When False, skip the config.json rewrite step.
+            Tests use this to inspect the pre-rewrite state; production
+            callers leave it True.
+
+    Returns:
+        A summary dict:
+            {"action": "migrated",  "migrated": [...], "skipped": [...]}
+            {"action": "skipped",   "reason": "..."}
+            {"action": "partial",   "reason": "...", "migrated": [...], "skipped": [...]}
+            {"action": "failed",    "reason": "..."}
+    """
+    # --- 1. Idempotency guard ---------------------------------------------
+    if get_setting(conn, MIGRATION_FLAG):
+        # If a prior run set the flag but failed to rewrite config.json
+        # (the "partial" outcome), try again here so the file eventually
+        # converges. This is purely a cleanup path; the DB is already
+        # authoritative.
+        if rewrite_config and config_path.exists():
+            try:
+                raw = json.loads(config_path.read_text())
+            except (OSError, json.JSONDecodeError):
+                raw = None
+            if isinstance(raw, dict) and any(
+                k in raw for k in _MIGRATED_CONFIG_KEYS
+            ):
+                try:
+                    _rewrite_config_stripped(config_path, raw)
+                except OSError:
+                    pass
+        return {"action": "skipped", "reason": "already migrated"}
+
+    # --- 2. Nothing to migrate? ------------------------------------------
+    # A missing config.json is a normal first-run state. Set the flag so
+    # we don't re-read the filesystem on every future launch.
+    if not config_path.exists():
+        set_setting(conn, MIGRATION_FLAG, True)
+        return {"action": "skipped", "reason": "no config.json"}
+
+    # --- 3. Read and validate the existing config ------------------------
+    try:
+        raw = json.loads(config_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        # Don't set the flag — a bad file today might be a good file
+        # tomorrow (the user may be fixing it manually).
+        return {"action": "failed", "reason": f"could not read config.json: {e}"}
+    if not isinstance(raw, dict):
+        return {"action": "failed", "reason": "config.json is not a JSON object"}
+
+    # Defensive coercion: a malformed legacy config shouldn't crash
+    # migration. Missing or wrong-typed keys become empty containers.
+    session_names = raw.get("session_names") or {}
+    session_order = raw.get("session_order") or []
+    last_viewed = raw.get("last_viewed") or {}
+    if not isinstance(session_names, dict):
+        session_names = {}
+    if not isinstance(session_order, list):
+        session_order = []
+    if not isinstance(last_viewed, dict):
+        last_viewed = {}
+
+    all_ids = set(session_names) | set(session_order) | set(last_viewed)
+
+    # Nothing to move into sessions rows, but we still want to drop the
+    # (possibly empty) legacy keys from config.json and mark the flag.
+    if not all_ids:
+        set_setting(conn, MIGRATION_FLAG, True)
+        if rewrite_config:
+            try:
+                _rewrite_config_stripped(config_path, raw)
+            except OSError as e:
+                return {
+                    "action": "partial",
+                    "reason": f"DB migrated but could not rewrite config.json: {e}",
+                    "migrated": [],
+                    "skipped": [],
+                }
+        return {"action": "migrated", "migrated": [], "skipped": []}
+
+    # --- 4. Resolve session_id → filesystem metadata ---------------------
+    # One scan of ~/.claude/projects builds the lookup; sessions whose
+    # JSONL is gone stay out of id_meta and get reported as `skipped`.
+    id_meta: dict[str, tuple[str, str, float, float]] = {}
+    try:
+        for proj_dir in claude_projects_dir.iterdir():
+            if not proj_dir.is_dir():
+                continue
+            for jsonl in proj_dir.glob("*.jsonl"):
+                sid = jsonl.stem
+                if sid in all_ids and sid not in id_meta:
+                    try:
+                        st = jsonl.stat()
+                    except OSError:
+                        continue
+                    id_meta[sid] = (
+                        str(jsonl),
+                        proj_dir.name,
+                        st.st_ctime,
+                        st.st_mtime,
+                    )
+    except OSError:
+        # Projects dir missing entirely — every session will be skipped.
+        pass
+
+    # Lower index = higher in the sidebar. Missing IDs get sort_order=NULL.
+    order_index = {sid: i for i, sid in enumerate(session_order)}
+
+    migrated: list[str] = []
+    skipped: list[str] = []
+
+    # --- 5. DB writes + flag in a single transaction ---------------------
+    try:
+        with transaction(conn):
+            for sid in sorted(all_ids):
+                meta = id_meta.get(sid)
+                if meta is None:
+                    skipped.append(sid)
+                    continue
+                path, project, ctime, mtime = meta
+
+                name = session_names.get(sid) or None
+                sort_order = order_index.get(sid)
+                last_viewed_ts = last_viewed.get(sid)
+                # Defensive: last_viewed should be numeric; drop garbage.
+                if not isinstance(last_viewed_ts, (int, float)):
+                    last_viewed_ts = None
+
+                # ON CONFLICT handling covers the (rare) case where a row
+                # was pre-populated by a concurrent writer or an earlier
+                # failed attempt — we overwrite the user-owned fields to
+                # match config.json, since config.json is the source of
+                # truth for this one-time import.
+                conn.execute(
+                    """
+                    INSERT INTO sessions (
+                        session_id, session_path, project,
+                        custom_name, sort_order, last_viewed,
+                        created_at, modified_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(session_id) DO UPDATE SET
+                        session_path = excluded.session_path,
+                        project      = COALESCE(excluded.project, sessions.project),
+                        custom_name  = excluded.custom_name,
+                        sort_order   = excluded.sort_order,
+                        last_viewed  = excluded.last_viewed,
+                        created_at   = COALESCE(sessions.created_at, excluded.created_at),
+                        modified_at  = COALESCE(excluded.modified_at, sessions.modified_at)
+                    """,
+                    (
+                        sid, path, project,
+                        name, sort_order, last_viewed_ts,
+                        ctime, mtime,
+                    ),
+                )
+                migrated.append(sid)
+
+            # Flag is part of the transaction so partial rollback can't
+            # leave us "migrated according to the flag, but missing rows".
+            set_setting(conn, MIGRATION_FLAG, True)
+    except Exception as e:
+        # Transaction rolled back. config.json is still the pristine
+        # original — we haven't touched it yet.
+        return {"action": "failed", "reason": str(e)}
+
+    # --- 6. Rewrite config.json (after DB commit) ------------------------
+    if rewrite_config:
+        try:
+            _rewrite_config_stripped(config_path, raw)
+        except OSError as e:
+            # The DB is already authoritative; leave a breadcrumb so the
+            # caller can log it. Next startup will retry the rewrite via
+            # the cleanup path at the top of this function.
+            return {
+                "action": "partial",
+                "reason": f"DB migrated but could not rewrite config.json: {e}",
+                "migrated": migrated,
+                "skipped": skipped,
+            }
+
+    return {"action": "migrated", "migrated": migrated, "skipped": skipped}

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,441 @@
+"""Tests for the one-time config.json → SQLite migration (ADR-001).
+
+Exercises `db.migrate_config_json_to_sqlite` end-to-end against a
+temporary config file, JSONL project tree, and SQLite database.
+
+Run from the repo root:
+
+    python -m unittest tests.test_migration -v
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Make the sibling `db` module importable when running from the repo root.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+import db  # noqa: E402
+
+
+def _make_session_file(projects_dir: Path, project: str, session_id: str) -> Path:
+    """Create a minimal JSONL file so the migration's path-resolution scan
+    has something real to discover for `session_id`."""
+    proj = projects_dir / project
+    proj.mkdir(parents=True, exist_ok=True)
+    f = proj / f"{session_id}.jsonl"
+    # Content doesn't matter — migration only uses the filename + stat().
+    f.write_text('{"sessionId":"' + session_id + '"}\n')
+    return f
+
+
+class MigrationTest(unittest.TestCase):
+    """End-to-end tests for migrate_config_json_to_sqlite."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.config_path = self.root / "config.json"
+        self.projects = self.root / "projects"
+        self.projects.mkdir()
+        self.db_path = self.root / "test.db"
+        self.conn = db.init_db(self.db_path)
+
+    def tearDown(self) -> None:
+        self.conn.close()
+        self._tmp.cleanup()
+
+    def _write_config(self, payload: dict) -> None:
+        self.config_path.write_text(json.dumps(payload))
+
+    # --- Happy path -------------------------------------------------------
+
+    def test_moves_session_names_order_and_last_viewed_into_sqlite(self) -> None:
+        """All three legacy session-level keys are preserved end-to-end."""
+        sid_a = "11111111-1111-1111-1111-111111111111"
+        sid_b = "22222222-2222-2222-2222-222222222222"
+        _make_session_file(self.projects, "-Users-alice-work", sid_a)
+        _make_session_file(self.projects, "-Users-alice-home", sid_b)
+
+        self._write_config({
+            "theme": "textual-light",
+            "session_names": {sid_a: "Pivot talk", sid_b: "Groceries"},
+            "session_order": [sid_b, sid_a],
+            "last_viewed": {sid_a: 100.0, sid_b: 200.0},
+        })
+
+        result = db.migrate_config_json_to_sqlite(
+            self.conn, self.config_path, self.projects
+        )
+
+        self.assertEqual(result["action"], "migrated")
+        self.assertCountEqual(result["migrated"], [sid_a, sid_b])
+        self.assertEqual(result["skipped"], [])
+
+        rows = db.query_all(
+            self.conn, "SELECT * FROM sessions ORDER BY sort_order"
+        )
+        # sid_b came first in session_order → sort_order 0, sid_a → 1.
+        self.assertEqual([r["session_id"] for r in rows], [sid_b, sid_a])
+        self.assertEqual(
+            {r["session_id"]: r["custom_name"] for r in rows},
+            {sid_a: "Pivot talk", sid_b: "Groceries"},
+        )
+        self.assertEqual(
+            {r["session_id"]: r["last_viewed"] for r in rows},
+            {sid_a: 100.0, sid_b: 200.0},
+        )
+
+    def test_keeps_app_level_keys_and_drops_legacy_keys_from_config(self) -> None:
+        """theme + unknown keys (sidebar_width) remain in config.json;
+        legacy session-level keys are removed."""
+        sid = "33333333-3333-3333-3333-333333333333"
+        _make_session_file(self.projects, "-Users-alice-work", sid)
+
+        self._write_config({
+            "theme": "textual-light",
+            "sidebar_width": 42,
+            "session_names": {sid: "foo"},
+            "session_order": [sid],
+            "last_viewed": {sid: 1.0},
+        })
+
+        db.migrate_config_json_to_sqlite(
+            self.conn, self.config_path, self.projects
+        )
+
+        remaining = json.loads(self.config_path.read_text())
+        self.assertEqual(remaining, {"theme": "textual-light", "sidebar_width": 42})
+
+    # --- Idempotency ------------------------------------------------------
+
+    def test_second_call_is_a_noop(self) -> None:
+        """Running migration twice yields identical state to running once."""
+        sid = "44444444-4444-4444-4444-444444444444"
+        _make_session_file(self.projects, "-Users-alice-work", sid)
+
+        self._write_config({
+            "theme": "textual-dark",
+            "session_names": {sid: "first"},
+        })
+
+        r1 = db.migrate_config_json_to_sqlite(
+            self.conn, self.config_path, self.projects
+        )
+        self.assertEqual(r1["action"], "migrated")
+
+        r2 = db.migrate_config_json_to_sqlite(
+            self.conn, self.config_path, self.projects
+        )
+        self.assertEqual(r2["action"], "skipped")
+        self.assertEqual(r2["reason"], "already migrated")
+
+        rows = db.query_all(self.conn, "SELECT * FROM sessions")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["custom_name"], "first")
+
+    def test_second_call_does_not_overwrite_post_migration_user_changes(self) -> None:
+        """After migration, the TUI may rename a session or update last_viewed.
+        A second migration call must NOT clobber those fresh values."""
+        sid = "55555555-5555-5555-5555-555555555555"
+        _make_session_file(self.projects, "-Users-alice-work", sid)
+
+        self._write_config({"session_names": {sid: "original"}})
+
+        db.migrate_config_json_to_sqlite(
+            self.conn, self.config_path, self.projects
+        )
+        # Simulate a user rename via the TUI's post-migration write path.
+        db.set_custom_name(self.conn, sid, "renamed by user")
+
+        # Second migration call — must be a no-op because the flag is set.
+        db.migrate_config_json_to_sqlite(
+            self.conn, self.config_path, self.projects
+        )
+
+        row = db.query_one(
+            self.conn, "SELECT custom_name FROM sessions WHERE session_id = ?",
+            (sid,),
+        )
+        self.assertEqual(row["custom_name"], "renamed by user")
+
+    # --- Failure preservation --------------------------------------------
+
+    def test_preserves_config_and_flag_when_db_write_fails(self) -> None:
+        """If the DB transaction fails, config.json is untouched and the
+        migration flag is NOT set — so the next run can retry."""
+        sid = "66666666-6666-6666-6666-666666666666"
+        _make_session_file(self.projects, "-Users-alice-work", sid)
+
+        original = {
+            "theme": "textual-dark",
+            "session_names": {sid: "preserved"},
+            "session_order": [sid],
+            "last_viewed": {sid: 12.0},
+        }
+        self._write_config(original)
+
+        # Sabotage the INSERT target so the transaction aborts. RENAME
+        # the table out from under the migration; we restore it before
+        # the assertions so the rest of the test can query cleanly.
+        self.conn.execute("ALTER TABLE sessions RENAME TO sessions_bak")
+        try:
+            result = db.migrate_config_json_to_sqlite(
+                self.conn, self.config_path, self.projects
+            )
+        finally:
+            self.conn.execute("ALTER TABLE sessions_bak RENAME TO sessions")
+
+        self.assertEqual(result["action"], "failed")
+        # config.json must be byte-for-byte identical.
+        self.assertEqual(
+            json.loads(self.config_path.read_text()), original
+        )
+        # No flag → next run retries migration.
+        self.assertIsNone(db.get_setting(self.conn, db.MIGRATION_FLAG))
+
+    def test_failed_migration_can_be_retried_successfully(self) -> None:
+        """After a failure, the next call should re-run and succeed."""
+        sid = "77777777-7777-7777-7777-777777777777"
+        _make_session_file(self.projects, "-Users-alice-work", sid)
+        self._write_config({"session_names": {sid: "retryable"}})
+
+        # Force failure.
+        self.conn.execute("ALTER TABLE sessions RENAME TO sessions_bak")
+        fail_result = db.migrate_config_json_to_sqlite(
+            self.conn, self.config_path, self.projects
+        )
+        self.conn.execute("ALTER TABLE sessions_bak RENAME TO sessions")
+        self.assertEqual(fail_result["action"], "failed")
+
+        # Retry — should now succeed.
+        retry_result = db.migrate_config_json_to_sqlite(
+            self.conn, self.config_path, self.projects
+        )
+        self.assertEqual(retry_result["action"], "migrated")
+        row = db.query_one(
+            self.conn, "SELECT custom_name FROM sessions WHERE session_id = ?",
+            (sid,),
+        )
+        self.assertEqual(row["custom_name"], "retryable")
+
+    # --- Edge cases -------------------------------------------------------
+
+    def test_skips_sessions_missing_from_disk(self) -> None:
+        """A session_id in config.json without a JSONL file on disk is
+        reported as skipped (we can't satisfy session_path NOT NULL)."""
+        live_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        ghost_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        _make_session_file(self.projects, "-Users-alice-work", live_id)
+
+        self._write_config({
+            "session_names": {live_id: "visible", ghost_id: "orphan"},
+            "session_order": [ghost_id, live_id],
+            "last_viewed": {ghost_id: 99.0},
+        })
+
+        result = db.migrate_config_json_to_sqlite(
+            self.conn, self.config_path, self.projects
+        )
+        self.assertEqual(result["action"], "migrated")
+        self.assertIn(live_id, result["migrated"])
+        self.assertIn(ghost_id, result["skipped"])
+
+        rows = db.query_all(self.conn, "SELECT session_id FROM sessions")
+        self.assertEqual([r["session_id"] for r in rows], [live_id])
+
+    def test_missing_config_json_sets_flag_without_error(self) -> None:
+        """First-ever launch with no config.json is a valid no-op; the
+        flag still gets set so we don't re-scan the filesystem later."""
+        # Note: we did NOT call _write_config.
+        result = db.migrate_config_json_to_sqlite(
+            self.conn, self.config_path, self.projects
+        )
+        self.assertEqual(result["action"], "skipped")
+        self.assertEqual(result["reason"], "no config.json")
+        self.assertTrue(db.get_setting(self.conn, db.MIGRATION_FLAG))
+
+    def test_empty_session_keys_still_clean_up_config(self) -> None:
+        """A config with only empty session-level containers migrates
+        cleanly: no rows inserted, and the legacy keys are dropped
+        from config.json."""
+        self._write_config({
+            "theme": "textual-dark",
+            "session_names": {},
+            "session_order": [],
+            "last_viewed": {},
+        })
+
+        result = db.migrate_config_json_to_sqlite(
+            self.conn, self.config_path, self.projects
+        )
+        self.assertEqual(result["action"], "migrated")
+        self.assertEqual(result["migrated"], [])
+
+        remaining = json.loads(self.config_path.read_text())
+        self.assertEqual(remaining, {"theme": "textual-dark"})
+
+    def test_malformed_config_fails_safely(self) -> None:
+        """An unreadable/invalid config.json returns 'failed' without
+        touching the DB or setting the flag."""
+        self.config_path.write_text("{not json")
+
+        result = db.migrate_config_json_to_sqlite(
+            self.conn, self.config_path, self.projects
+        )
+        self.assertEqual(result["action"], "failed")
+        # No rows, no flag.
+        rows = db.query_all(self.conn, "SELECT * FROM sessions")
+        self.assertEqual(rows, [])
+        self.assertIsNone(db.get_setting(self.conn, db.MIGRATION_FLAG))
+
+    def test_rewrite_config_false_leaves_file_untouched(self) -> None:
+        """rewrite_config=False is for callers who want to migrate DB state
+        but inspect the pre-rewrite config first (tests, dry-runs)."""
+        sid = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+        _make_session_file(self.projects, "-Users-alice-work", sid)
+        original = {"theme": "textual-dark", "session_names": {sid: "kept"}}
+        self._write_config(original)
+
+        result = db.migrate_config_json_to_sqlite(
+            self.conn, self.config_path, self.projects, rewrite_config=False
+        )
+        self.assertEqual(result["action"], "migrated")
+
+        # DB has the row…
+        row = db.query_one(
+            self.conn, "SELECT custom_name FROM sessions WHERE session_id = ?",
+            (sid,),
+        )
+        self.assertEqual(row["custom_name"], "kept")
+        # …but config.json is still the original.
+        self.assertEqual(json.loads(self.config_path.read_text()), original)
+
+    def test_cleanup_of_partial_previous_run(self) -> None:
+        """Simulate a prior partial-success state (DB migrated, flag set,
+        but config.json still has legacy keys). A subsequent call should
+        clean up the lingering legacy keys without touching DB rows."""
+        sid = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+        _make_session_file(self.projects, "-Users-alice-work", sid)
+        # Set the flag manually to simulate "already migrated".
+        db.set_setting(self.conn, db.MIGRATION_FLAG, True)
+        # Insert a pre-existing row with data (must NOT be overwritten).
+        db.upsert_session(
+            self.conn, sid, str(self.projects / "stub.jsonl")
+        )
+        db.set_custom_name(self.conn, sid, "established name")
+
+        # Leave legacy keys in config.json to simulate prior partial rewrite.
+        self._write_config({
+            "theme": "textual-dark",
+            "session_names": {sid: "would clobber"},
+            "session_order": [sid],
+        })
+
+        result = db.migrate_config_json_to_sqlite(
+            self.conn, self.config_path, self.projects
+        )
+        self.assertEqual(result["action"], "skipped")
+
+        # Legacy keys must have been cleaned up from config.json…
+        self.assertEqual(
+            json.loads(self.config_path.read_text()),
+            {"theme": "textual-dark"},
+        )
+        # …and the DB row must be unchanged (flag-guard prevents clobber).
+        row = db.query_one(
+            self.conn, "SELECT custom_name FROM sessions WHERE session_id = ?",
+            (sid,),
+        )
+        self.assertEqual(row["custom_name"], "established name")
+
+
+class SessionHelperTest(unittest.TestCase):
+    """Sanity tests for the session-row helpers the TUI calls post-migration."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.conn = db.init_db(self.root / "test.db")
+        self.sid = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+        db.upsert_session(
+            self.conn,
+            session_id=self.sid,
+            session_path=str(self.root / "fake.jsonl"),
+            project="-Users-alice-work",
+            cwd="/Users/alice/work",
+            modified_at=1234.5,
+        )
+
+    def tearDown(self) -> None:
+        self.conn.close()
+        self._tmp.cleanup()
+
+    def test_upsert_preserves_user_owned_fields(self) -> None:
+        """A rescan shouldn't clobber a user's rename or last_viewed."""
+        db.set_custom_name(self.conn, self.sid, "mine")
+        db.set_last_viewed(self.conn, self.sid, 555.0)
+
+        # Second upsert — simulates the background refresh loop.
+        db.upsert_session(
+            self.conn,
+            session_id=self.sid,
+            session_path=str(self.root / "fake.jsonl"),
+            project="-Users-alice-work",
+            modified_at=9999.0,
+        )
+        row = db.query_one(
+            self.conn, "SELECT * FROM sessions WHERE session_id = ?", (self.sid,)
+        )
+        self.assertEqual(row["custom_name"], "mine")
+        self.assertEqual(row["last_viewed"], 555.0)
+        # But the filesystem-owned modified_at DID update.
+        self.assertEqual(row["modified_at"], 9999.0)
+
+    def test_set_custom_name_empty_clears(self) -> None:
+        db.set_custom_name(self.conn, self.sid, "temp")
+        db.set_custom_name(self.conn, self.sid, "")
+        row = db.query_one(
+            self.conn, "SELECT custom_name FROM sessions WHERE session_id = ?",
+            (self.sid,),
+        )
+        self.assertIsNone(row["custom_name"])
+
+    def test_set_session_order_assigns_positions(self) -> None:
+        sid2 = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+        db.upsert_session(
+            self.conn, sid2, str(self.root / "two.jsonl"),
+            project="-Users-alice-home",
+        )
+
+        db.set_session_order(self.conn, [sid2, self.sid])
+
+        self.assertEqual(
+            db.get_session_order(self.conn), [sid2, self.sid]
+        )
+
+        # Re-order and confirm the first ID now comes second.
+        db.set_session_order(self.conn, [self.sid, sid2])
+        self.assertEqual(
+            db.get_session_order(self.conn), [self.sid, sid2]
+        )
+
+    def test_get_helpers_return_only_populated_rows(self) -> None:
+        """Sessions without a custom_name / last_viewed shouldn't appear
+        in the returned dicts (keeps the TUI reads sparse)."""
+        self.assertEqual(db.get_custom_names(self.conn), {})
+        self.assertEqual(db.get_last_viewed(self.conn), {})
+
+        db.set_custom_name(self.conn, self.sid, "hello")
+        db.set_last_viewed(self.conn, self.sid, 7.0)
+        self.assertEqual(db.get_custom_names(self.conn), {self.sid: "hello"})
+        self.assertEqual(db.get_last_viewed(self.conn), {self.sid: 7.0})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/threadhop
+++ b/threadhop
@@ -24,6 +24,11 @@ from textual.containers import Vertical, VerticalScroll
 from textual.widgets import Footer, Header, ListItem, ListView, Static, TextArea
 from textual.worker import Worker
 
+# Local package: SQLite DB module (init, migrations, session helpers).
+# Imported as a relative module because db.py sits next to this script.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import db  # noqa: E402
+
 
 def get_available_themes():
     """Get themes dynamically from Textual"""
@@ -35,20 +40,72 @@ def get_available_themes():
         return ["textual-dark", "textual-light"]
 
 
-def load_config():
+# App-level keys that live in config.json post-migration. Session-level
+# state (session_names, session_order, last_viewed) lives in SQLite per
+# ADR-001. Anything unknown is preserved on save so future settings
+# (sidebar_width, user-added keys) don't get silently dropped.
+APP_CONFIG_KEYS = {"theme", "sidebar_width"}
+
+
+def load_config(conn):
+    """Return the combined in-memory config.
+
+    App-level keys (`theme`, `sidebar_width`) come from config.json.
+    Session-level keys (`session_names`, `session_order`, `last_viewed`)
+    come from the SQLite `sessions` table — this is the ADR-001 split.
+
+    The returned dict keeps the same shape the TUI has always read so
+    the read paths (SessionItem construction, unread detection, reorder
+    logic) stay unchanged; only the persistence layer moved.
+    """
+    # 1. App-level from JSON.
+    config: dict = {}
     try:
         if CONFIG_FILE.exists():
-            return json.loads(CONFIG_FILE.read_text())
-    except:
+            raw = json.loads(CONFIG_FILE.read_text())
+            if isinstance(raw, dict):
+                config.update(raw)
+    except (OSError, json.JSONDecodeError):
         pass
-    return {"theme": "textual-dark", "session_names": {}, "session_order": []}
+
+    # Strip any legacy session-level keys that may linger (old config,
+    # partially-migrated state). SQLite is the source of truth now.
+    for key in ("session_names", "session_order", "last_viewed"):
+        config.pop(key, None)
+
+    config.setdefault("theme", "textual-dark")
+
+    # 2. Session-level from SQLite.
+    try:
+        config["session_names"] = db.get_custom_names(conn)
+        config["session_order"] = db.get_session_order(conn)
+        config["last_viewed"] = db.get_last_viewed(conn)
+    except Exception:
+        # A broken DB shouldn't prevent the app from starting; fall back
+        # to empty session state and let the user keep browsing.
+        config["session_names"] = {}
+        config["session_order"] = []
+        config["last_viewed"] = {}
+
+    return config
 
 
-def save_config(config):
+def save_app_config(config):
+    """Persist only app-level keys (theme, sidebar_width, unknown extras)
+    to config.json.
+
+    Session-level keys are deliberately excluded — they live in SQLite
+    now and are written through at each mutation site (rename, reorder,
+    view) rather than dumped wholesale here.
+    """
     try:
         CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-        CONFIG_FILE.write_text(json.dumps(config, indent=2))
-    except:
+        app_only = {
+            k: v for k, v in config.items()
+            if k not in ("session_names", "session_order", "last_viewed")
+        }
+        CONFIG_FILE.write_text(json.dumps(app_only, indent=2))
+    except OSError:
         pass
 
 
@@ -528,7 +585,20 @@ class ClaudeSessions(App):
         self._selected_session_id = None
         self._spinner_frame = 0
         self._renaming_session_id = None
-        self.config = load_config()
+
+        # Open the SQLite store and run the one-time config.json → SQLite
+        # migration (ADR-001). Both calls are idempotent — init_db applies
+        # pending schema migrations, and migrate_config_json_to_sqlite is
+        # guarded by a settings flag so only the first ever launch does
+        # real work.
+        self.conn = db.init_db()
+        db.migrate_config_json_to_sqlite(
+            self.conn, CONFIG_FILE, CLAUDE_PROJECTS
+        )
+
+        self.config = load_config(self.conn)
+        # Defensive defaults: load_config always returns these, but guard
+        # in case a future code path bypasses it.
         if "session_names" not in self.config:
             self.config["session_names"] = {}
         if "session_order" not in self.config:
@@ -826,6 +896,28 @@ class ClaudeSessions(App):
         for s in self.sessions:
             s["path"] = Path(s["path"])
 
+        # Keep the `sessions` table in step with the filesystem scan so
+        # user actions (rename, reorder, last_viewed) that target any
+        # currently-visible session can UPDATE a row that actually exists.
+        # upsert_session intentionally leaves user-owned columns
+        # (custom_name, sort_order, last_viewed, status) alone.
+        try:
+            with db.transaction(self.conn):
+                for s in self.sessions:
+                    db.upsert_session(
+                        self.conn,
+                        session_id=s["session_id"],
+                        session_path=str(s["path"]),
+                        project=s.get("project"),
+                        cwd=s.get("cwd"),
+                        modified_at=s.get("modified"),
+                    )
+        except Exception:
+            # A DB hiccup shouldn't break the TUI — we'll retry on the
+            # next refresh tick. Reads still work because the TUI uses
+            # in-memory self.sessions for display.
+            pass
+
         self._apply_stable_ordering()
         self._update_session_list(force_rebuild)
         self.refresh_transcript()
@@ -849,7 +941,11 @@ class ClaudeSessions(App):
 
         if final_order != saved_order:
             self.config["session_order"] = final_order
-            save_config(self.config)
+            # Session ordering lives in SQLite per ADR-001.
+            try:
+                db.set_session_order(self.conn, final_order)
+            except Exception:
+                pass
 
         order_index = {sid: i for i, sid in enumerate(final_order)}
         self.sessions.sort(key=lambda x: order_index.get(x["session_id"], 999999))
@@ -960,8 +1056,13 @@ class ClaudeSessions(App):
 
             if "last_viewed" not in self.config:
                 self.config["last_viewed"] = {}
-            self.config["last_viewed"][session_id] = datetime.now().timestamp()
-            save_config(self.config)
+            now_ts = datetime.now().timestamp()
+            self.config["last_viewed"][session_id] = now_ts
+            # last_viewed lives in SQLite per ADR-001.
+            try:
+                db.set_last_viewed(self.conn, session_id, now_ts)
+            except Exception:
+                pass
 
             if event.item.is_unread:
                 event.item.is_unread = False
@@ -989,7 +1090,8 @@ class ClaudeSessions(App):
             next_idx = 0
         self.theme = themes[next_idx]
         self.config["theme"] = self.theme
-        save_config(self.config)
+        # Theme stays in config.json (app-level setting per ADR-001).
+        save_app_config(self.config)
         self.notify(f"Theme: {self.theme}")
 
     def action_rename_session(self) -> None:
@@ -1119,7 +1221,11 @@ class ClaudeSessions(App):
                 self.config["session_names"][session_id] = input_text
             else:
                 self.config["session_names"].pop(session_id, None)
-            save_config(self.config)
+            # Custom names live in SQLite per ADR-001.
+            try:
+                db.set_custom_name(self.conn, session_id, input_text or None)
+            except Exception:
+                pass
             text_area.clear()
             self.query_one("#session-list", ListView).focus()
             self.load_sessions(force_rebuild=True)
@@ -1248,7 +1354,11 @@ class ClaudeSessions(App):
         )
 
         self.config["session_order"] = order
-        save_config(self.config)
+        # Manual reorder lives in SQLite per ADR-001.
+        try:
+            db.set_session_order(self.conn, order)
+        except Exception:
+            pass
 
         order_index = {sid: i for i, sid in enumerate(order)}
         self.sessions.sort(key=lambda x: order_index.get(x["session_id"], 999999))


### PR DESCRIPTION
## Summary

Implements task #2 — one-time, idempotent migration from `~/.config/threadhop/config.json` into the SQLite `sessions` table per ADR-001.

- Moves `session_names`, `session_order`, `last_viewed` out of `config.json` into SQLite
- Keeps `config.json` for app-level settings only (`theme`, `sidebar_width`)
- Migration is guarded by a `config_migrated_v1` flag stored *inside* the same DB transaction as the row inserts — partial rollback can't leave a "flagged but empty" state
- `config.json` is only rewritten **after** the DB transaction commits; if the DB step fails, the original config is byte-for-byte preserved and the next run retries
- Orphan sessions (`session_id` in config.json with no JSONL on disk) are reported as `skipped` — `session_path` is `NOT NULL` and a custom name for a deleted session is invisible to the user anyway

## What this unlocks

Pure foundation work. No user-visible change today, but enables:
- **Task #3**: session status field (`active | in_progress | in_review | done | archived`)
- **Task #8–9**: FTS5 message index (needs SQLite)
- **Task #18**: bookmarks with foreign keys to `sessions`
- **Task #19**: project memory ledger

## TUI wiring

- `App.__init__` opens DB + runs migration on startup (both idempotent)
- `load_config(conn)` returns the same dict shape the TUI has always read, but populates session-level keys from SQLite — read paths unchanged
- `save_app_config()` writes only app-level keys to `config.json`
- All 5 `save_config(self.config)` mutation sites (rename, reorder, last-viewed, theme, stable-ordering) now dual-write: in-memory cache + SQLite helper
- `_apply_session_data` upserts every scanned session into `sessions` so user actions always have a row to `UPDATE`
- `upsert_session` deliberately preserves user-owned columns across rescans (`custom_name`, `sort_order`, `last_viewed`, `status`)

## Test plan

- [x] `python -m unittest tests.test_migration -v` — 16/16 pass
  - [x] Happy path: all three legacy keys land in SQLite; `theme` + `sidebar_width` remain in `config.json`
  - [x] Idempotency: second call is a no-op; user changes made post-migration survive a second call
  - [x] Failure preservation: simulated DB failure → `config.json` byte-for-byte intact, flag unset, retry succeeds
  - [x] Edge cases: missing `config.json`, empty legacy containers, malformed JSON, orphan sessions, partial prior run cleanup, `rewrite_config=False`
  - [x] Session-helper sanity: `upsert` preserves user fields across rescans, `set_custom_name("")` clears, `sort_order` round-trips, `get_*` helpers return only populated rows
- [x] End-to-end smoke test: pre-SQLite `config.json` → first launch migrates → `config.json` shrinks to `{"theme": "nord"}` → TUI reconstructs identical in-memory shape → user rename + reorder persists in SQLite → second launch skipped, user edits preserved
- [ ] Manual run on a real `~/.config/threadhop/config.json` (reviewer to verify)

## References

- ADR-001 in `docs/DESIGN-DECISIONS.md`
- Task #2 in `docs/TASKS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)