### PR TITLE
Rewrite migration tests as pytest with expanded coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,63 @@
+"""Pytest configuration and shared fixtures for ThreadHop tests.
+
+Makes the project root importable so tests can `import db` without packaging,
+and provides fixtures for temp DB / config / project-tree isolation so no test
+ever touches ~/.config/threadhop or ~/.claude/projects.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# --- Import path -----------------------------------------------------------
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+
+# --- Fixtures --------------------------------------------------------------
+
+@pytest.fixture
+def config_path(tmp_path: Path) -> Path:
+    """Path to a temp config.json (not yet created). Each test owns its own."""
+    return tmp_path / "config.json"
+
+
+@pytest.fixture
+def projects_dir(tmp_path: Path) -> Path:
+    """Empty temp directory standing in for ~/.claude/projects."""
+    d = tmp_path / "projects"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    """Path to a temp sessions.db file (not yet created)."""
+    return tmp_path / "sessions.db"
+
+
+@pytest.fixture
+def conn(db_path: Path):
+    """Initialized DB connection pointed at a temp DB, schema applied."""
+    import db as db_mod
+
+    c = db_mod.init_db(db_path)
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+@pytest.fixture
+def write_config(config_path: Path):
+    """Helper: write a dict as JSON to config_path, return the raw text."""
+    def _write(data: dict) -> str:
+        raw = json.dumps(data)
+        config_path.write_text(raw)
+        return raw
+    return _write

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,441 +1,680 @@
-"""Tests for the one-time config.json → SQLite migration (ADR-001).
+"""Tests for the config.json -> SQLite migration (task #7 in docs/TASKS.md).
 
 Exercises `db.migrate_config_json_to_sqlite` end-to-end against a
 temporary config file, JSONL project tree, and SQLite database.
 
-Run from the repo root:
+Covers:
+  - session_names / session_order / last_viewed land in the sessions table
+  - theme / sidebar_width (and unknown top-level keys) are preserved in
+    config.json; legacy session-level keys are stripped
+  - idempotency: second call is a no-op, no duplicate rows, no clobbering
+    of post-migration user changes
+  - rollback: DB transaction failure leaves config.json and sessions table
+    in their pre-migration state; retry succeeds after recovery
+  - edge cases: missing config, empty config, malformed JSON, sessions
+    missing from disk, defensive coercion of bad types
+  - temp-dir isolation: nothing touches ~/.config/threadhop
 
-    python -m unittest tests.test_migration -v
+Run from the project root:
+
+    pytest tests/
+    pytest tests/test_migration.py -v
+    pytest tests/test_migration.py::TestIdempotency -v
 """
 
 from __future__ import annotations
 
 import json
-import sqlite3
-import sys
-import tempfile
-import unittest
 from pathlib import Path
 
-# Make the sibling `db` module importable when running from the repo root.
-REPO_ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(REPO_ROOT))
-import db  # noqa: E402
+import pytest
+
+import db
+
+
+# =========================================================================
+# Helpers
+# =========================================================================
+
+# Realistic UUID-style session ids. Named for readability in assertions.
+SID_A = "11111111-1111-1111-1111-111111111111"
+SID_B = "22222222-2222-2222-2222-222222222222"
+SID_C = "33333333-3333-3333-3333-333333333333"
+
+PROJECT = "-Users-alice-work"
+PROJECT_B = "-Users-alice-home"
+
+
+def _migrate(conn, config_path, projects_dir, **kw):
+    """Short alias for the migration function under test."""
+    return db.migrate_config_json_to_sqlite(conn, config_path, projects_dir, **kw)
 
 
 def _make_session_file(projects_dir: Path, project: str, session_id: str) -> Path:
     """Create a minimal JSONL file so the migration's path-resolution scan
-    has something real to discover for `session_id`."""
+    can discover `session_id`."""
     proj = projects_dir / project
     proj.mkdir(parents=True, exist_ok=True)
     f = proj / f"{session_id}.jsonl"
-    # Content doesn't matter — migration only uses the filename + stat().
     f.write_text('{"sessionId":"' + session_id + '"}\n')
     return f
 
 
-class MigrationTest(unittest.TestCase):
-    """End-to-end tests for migrate_config_json_to_sqlite."""
+# =========================================================================
+# Basic migration: values land in the right columns
+# =========================================================================
 
-    def setUp(self) -> None:
-        self._tmp = tempfile.TemporaryDirectory()
-        self.root = Path(self._tmp.name)
-        self.config_path = self.root / "config.json"
-        self.projects = self.root / "projects"
-        self.projects.mkdir()
-        self.db_path = self.root / "test.db"
-        self.conn = db.init_db(self.db_path)
+class TestBasicMigration:
+    def test_session_names_become_custom_name(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        _make_session_file(projects_dir, PROJECT, SID_A)
+        _make_session_file(projects_dir, PROJECT_B, SID_B)
 
-    def tearDown(self) -> None:
-        self.conn.close()
-        self._tmp.cleanup()
-
-    def _write_config(self, payload: dict) -> None:
-        self.config_path.write_text(json.dumps(payload))
-
-    # --- Happy path -------------------------------------------------------
-
-    def test_moves_session_names_order_and_last_viewed_into_sqlite(self) -> None:
-        """All three legacy session-level keys are preserved end-to-end."""
-        sid_a = "11111111-1111-1111-1111-111111111111"
-        sid_b = "22222222-2222-2222-2222-222222222222"
-        _make_session_file(self.projects, "-Users-alice-work", sid_a)
-        _make_session_file(self.projects, "-Users-alice-home", sid_b)
-
-        self._write_config({
+        write_config({
             "theme": "textual-light",
-            "session_names": {sid_a: "Pivot talk", sid_b: "Groceries"},
-            "session_order": [sid_b, sid_a],
-            "last_viewed": {sid_a: 100.0, sid_b: 200.0},
+            "session_names": {SID_A: "Pivot talk", SID_B: "Groceries"},
+            "session_order": [SID_B, SID_A],
+            "last_viewed": {SID_A: 100.0, SID_B: 200.0},
         })
 
-        result = db.migrate_config_json_to_sqlite(
-            self.conn, self.config_path, self.projects
-        )
+        result = _migrate(conn, config_path, projects_dir)
 
-        self.assertEqual(result["action"], "migrated")
-        self.assertCountEqual(result["migrated"], [sid_a, sid_b])
-        self.assertEqual(result["skipped"], [])
+        assert result["action"] == "migrated"
+        assert set(result["migrated"]) == {SID_A, SID_B}
+        assert result["skipped"] == []
+
+        names = {
+            r["session_id"]: r["custom_name"]
+            for r in db.query_all(conn, "SELECT session_id, custom_name FROM sessions")
+        }
+        assert names[SID_A] == "Pivot talk"
+        assert names[SID_B] == "Groceries"
+
+    def test_session_order_becomes_sort_order(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        _make_session_file(projects_dir, PROJECT, SID_A)
+        _make_session_file(projects_dir, PROJECT_B, SID_B)
+
+        write_config({
+            "session_names": {SID_A: "A", SID_B: "B"},
+            "session_order": [SID_B, SID_A],
+        })
+
+        _migrate(conn, config_path, projects_dir)
 
         rows = db.query_all(
-            self.conn, "SELECT * FROM sessions ORDER BY sort_order"
+            conn,
+            "SELECT session_id, sort_order FROM sessions "
+            "WHERE sort_order IS NOT NULL ORDER BY sort_order",
         )
-        # sid_b came first in session_order → sort_order 0, sid_a → 1.
-        self.assertEqual([r["session_id"] for r in rows], [sid_b, sid_a])
-        self.assertEqual(
-            {r["session_id"]: r["custom_name"] for r in rows},
-            {sid_a: "Pivot talk", sid_b: "Groceries"},
-        )
-        self.assertEqual(
-            {r["session_id"]: r["last_viewed"] for r in rows},
-            {sid_a: 100.0, sid_b: 200.0},
-        )
+        assert [r["session_id"] for r in rows] == [SID_B, SID_A]
 
-    def test_keeps_app_level_keys_and_drops_legacy_keys_from_config(self) -> None:
-        """theme + unknown keys (sidebar_width) remain in config.json;
-        legacy session-level keys are removed."""
-        sid = "33333333-3333-3333-3333-333333333333"
-        _make_session_file(self.projects, "-Users-alice-work", sid)
+    def test_last_viewed_is_migrated(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        _make_session_file(projects_dir, PROJECT, SID_A)
+        _make_session_file(projects_dir, PROJECT_B, SID_B)
 
-        self._write_config({
+        write_config({
+            "session_names": {SID_A: "A", SID_B: "B"},
+            "last_viewed": {SID_A: 100.0, SID_B: 200.0},
+        })
+
+        _migrate(conn, config_path, projects_dir)
+
+        lv = {
+            r["session_id"]: r["last_viewed"]
+            for r in db.query_all(conn, "SELECT session_id, last_viewed FROM sessions")
+        }
+        assert lv[SID_A] == 100.0
+        assert lv[SID_B] == 200.0
+
+    def test_session_without_name_or_last_viewed_gets_null(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        """A session that only appears in session_order (no name, no
+        last_viewed) is still created, with those fields NULL."""
+        _make_session_file(projects_dir, PROJECT, SID_A)
+        _make_session_file(projects_dir, PROJECT_B, SID_B)
+
+        write_config({
+            "session_names": {SID_A: "Named"},
+            "session_order": [SID_A, SID_B],
+            "last_viewed": {SID_A: 100.0},
+        })
+
+        _migrate(conn, config_path, projects_dir)
+
+        row_b = db.query_one(
+            conn, "SELECT custom_name, last_viewed FROM sessions WHERE session_id = ?",
+            (SID_B,),
+        )
+        assert row_b["custom_name"] is None
+        assert row_b["last_viewed"] is None
+
+    def test_session_path_and_project_are_set_from_disk(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        """Migration resolves session_path from the projects directory scan."""
+        f = _make_session_file(projects_dir, PROJECT, SID_A)
+
+        write_config({"session_names": {SID_A: "Foo"}})
+        _migrate(conn, config_path, projects_dir)
+
+        row = db.query_one(
+            conn, "SELECT session_path, project FROM sessions WHERE session_id = ?",
+            (SID_A,),
+        )
+        assert row["session_path"] == str(f)
+        assert row["project"] == PROJECT
+
+
+# =========================================================================
+# config.json preservation & slimming
+# =========================================================================
+
+class TestConfigPreservation:
+    def test_theme_and_sidebar_width_preserved(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        _make_session_file(projects_dir, PROJECT, SID_A)
+        write_config({
             "theme": "textual-light",
             "sidebar_width": 42,
-            "session_names": {sid: "foo"},
-            "session_order": [sid],
-            "last_viewed": {sid: 1.0},
+            "session_names": {SID_A: "foo"},
+            "session_order": [SID_A],
+            "last_viewed": {SID_A: 1.0},
         })
 
-        db.migrate_config_json_to_sqlite(
-            self.conn, self.config_path, self.projects
-        )
+        _migrate(conn, config_path, projects_dir)
 
-        remaining = json.loads(self.config_path.read_text())
-        self.assertEqual(remaining, {"theme": "textual-light", "sidebar_width": 42})
+        remaining = json.loads(config_path.read_text())
+        assert remaining == {"theme": "textual-light", "sidebar_width": 42}
 
-    # --- Idempotency ------------------------------------------------------
-
-    def test_second_call_is_a_noop(self) -> None:
-        """Running migration twice yields identical state to running once."""
-        sid = "44444444-4444-4444-4444-444444444444"
-        _make_session_file(self.projects, "-Users-alice-work", sid)
-
-        self._write_config({
+    def test_session_level_keys_removed_from_config(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        _make_session_file(projects_dir, PROJECT, SID_A)
+        write_config({
             "theme": "textual-dark",
-            "session_names": {sid: "first"},
+            "session_names": {SID_A: "x"},
+            "session_order": [SID_A],
+            "last_viewed": {SID_A: 1.0},
         })
 
-        r1 = db.migrate_config_json_to_sqlite(
-            self.conn, self.config_path, self.projects
-        )
-        self.assertEqual(r1["action"], "migrated")
+        _migrate(conn, config_path, projects_dir)
 
-        r2 = db.migrate_config_json_to_sqlite(
-            self.conn, self.config_path, self.projects
-        )
-        self.assertEqual(r2["action"], "skipped")
-        self.assertEqual(r2["reason"], "already migrated")
+        remaining = json.loads(config_path.read_text())
+        for key in db._MIGRATED_CONFIG_KEYS:
+            assert key not in remaining, f"{key} should have been stripped"
 
-        rows = db.query_all(self.conn, "SELECT * FROM sessions")
-        self.assertEqual(len(rows), 1)
-        self.assertEqual(rows[0]["custom_name"], "first")
-
-    def test_second_call_does_not_overwrite_post_migration_user_changes(self) -> None:
-        """After migration, the TUI may rename a session or update last_viewed.
-        A second migration call must NOT clobber those fresh values."""
-        sid = "55555555-5555-5555-5555-555555555555"
-        _make_session_file(self.projects, "-Users-alice-work", sid)
-
-        self._write_config({"session_names": {sid: "original"}})
-
-        db.migrate_config_json_to_sqlite(
-            self.conn, self.config_path, self.projects
-        )
-        # Simulate a user rename via the TUI's post-migration write path.
-        db.set_custom_name(self.conn, sid, "renamed by user")
-
-        # Second migration call — must be a no-op because the flag is set.
-        db.migrate_config_json_to_sqlite(
-            self.conn, self.config_path, self.projects
-        )
-
-        row = db.query_one(
-            self.conn, "SELECT custom_name FROM sessions WHERE session_id = ?",
-            (sid,),
-        )
-        self.assertEqual(row["custom_name"], "renamed by user")
-
-    # --- Failure preservation --------------------------------------------
-
-    def test_preserves_config_and_flag_when_db_write_fails(self) -> None:
-        """If the DB transaction fails, config.json is untouched and the
-        migration flag is NOT set — so the next run can retry."""
-        sid = "66666666-6666-6666-6666-666666666666"
-        _make_session_file(self.projects, "-Users-alice-work", sid)
-
-        original = {
-            "theme": "textual-dark",
-            "session_names": {sid: "preserved"},
-            "session_order": [sid],
-            "last_viewed": {sid: 12.0},
-        }
-        self._write_config(original)
-
-        # Sabotage the INSERT target so the transaction aborts. RENAME
-        # the table out from under the migration; we restore it before
-        # the assertions so the rest of the test can query cleanly.
-        self.conn.execute("ALTER TABLE sessions RENAME TO sessions_bak")
-        try:
-            result = db.migrate_config_json_to_sqlite(
-                self.conn, self.config_path, self.projects
-            )
-        finally:
-            self.conn.execute("ALTER TABLE sessions_bak RENAME TO sessions")
-
-        self.assertEqual(result["action"], "failed")
-        # config.json must be byte-for-byte identical.
-        self.assertEqual(
-            json.loads(self.config_path.read_text()), original
-        )
-        # No flag → next run retries migration.
-        self.assertIsNone(db.get_setting(self.conn, db.MIGRATION_FLAG))
-
-    def test_failed_migration_can_be_retried_successfully(self) -> None:
-        """After a failure, the next call should re-run and succeed."""
-        sid = "77777777-7777-7777-7777-777777777777"
-        _make_session_file(self.projects, "-Users-alice-work", sid)
-        self._write_config({"session_names": {sid: "retryable"}})
-
-        # Force failure.
-        self.conn.execute("ALTER TABLE sessions RENAME TO sessions_bak")
-        fail_result = db.migrate_config_json_to_sqlite(
-            self.conn, self.config_path, self.projects
-        )
-        self.conn.execute("ALTER TABLE sessions_bak RENAME TO sessions")
-        self.assertEqual(fail_result["action"], "failed")
-
-        # Retry — should now succeed.
-        retry_result = db.migrate_config_json_to_sqlite(
-            self.conn, self.config_path, self.projects
-        )
-        self.assertEqual(retry_result["action"], "migrated")
-        row = db.query_one(
-            self.conn, "SELECT custom_name FROM sessions WHERE session_id = ?",
-            (sid,),
-        )
-        self.assertEqual(row["custom_name"], "retryable")
-
-    # --- Edge cases -------------------------------------------------------
-
-    def test_skips_sessions_missing_from_disk(self) -> None:
-        """A session_id in config.json without a JSONL file on disk is
-        reported as skipped (we can't satisfy session_path NOT NULL)."""
-        live_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-        ghost_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
-        _make_session_file(self.projects, "-Users-alice-work", live_id)
-
-        self._write_config({
-            "session_names": {live_id: "visible", ghost_id: "orphan"},
-            "session_order": [ghost_id, live_id],
-            "last_viewed": {ghost_id: 99.0},
+    def test_unknown_app_level_keys_are_preserved(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        """Forward-compat: unknown top-level keys must survive migration so
+        newer config files aren't silently clobbered by an older migrator."""
+        _make_session_file(projects_dir, PROJECT, SID_A)
+        write_config({
+            "theme": "textual-light",
+            "future_setting": {"nested": "value"},
+            "experimental_flag": True,
+            "session_names": {SID_A: "foo"},
         })
 
-        result = db.migrate_config_json_to_sqlite(
-            self.conn, self.config_path, self.projects
-        )
-        self.assertEqual(result["action"], "migrated")
-        self.assertIn(live_id, result["migrated"])
-        self.assertIn(ghost_id, result["skipped"])
+        _migrate(conn, config_path, projects_dir)
 
-        rows = db.query_all(self.conn, "SELECT session_id FROM sessions")
-        self.assertEqual([r["session_id"] for r in rows], [live_id])
+        remaining = json.loads(config_path.read_text())
+        assert remaining["theme"] == "textual-light"
+        assert remaining["future_setting"] == {"nested": "value"}
+        assert remaining["experimental_flag"] is True
+        assert "session_names" not in remaining
 
-    def test_missing_config_json_sets_flag_without_error(self) -> None:
-        """First-ever launch with no config.json is a valid no-op; the
-        flag still gets set so we don't re-scan the filesystem later."""
-        # Note: we did NOT call _write_config.
-        result = db.migrate_config_json_to_sqlite(
-            self.conn, self.config_path, self.projects
-        )
-        self.assertEqual(result["action"], "skipped")
-        self.assertEqual(result["reason"], "no config.json")
-        self.assertTrue(db.get_setting(self.conn, db.MIGRATION_FLAG))
+    def test_missing_config_file_sets_flag(self, conn, config_path, projects_dir):
+        assert not config_path.exists()
 
-    def test_empty_session_keys_still_clean_up_config(self) -> None:
-        """A config with only empty session-level containers migrates
-        cleanly: no rows inserted, and the legacy keys are dropped
-        from config.json."""
-        self._write_config({
+        result = _migrate(conn, config_path, projects_dir)
+
+        assert result["action"] == "skipped"
+        assert result["reason"] == "no config.json"
+        assert db.get_setting(conn, db.MIGRATION_FLAG) is True
+        assert db.query_all(conn, "SELECT * FROM sessions") == []
+
+    def test_empty_session_keys_clean_up_config(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        write_config({
             "theme": "textual-dark",
             "session_names": {},
             "session_order": [],
             "last_viewed": {},
         })
 
-        result = db.migrate_config_json_to_sqlite(
-            self.conn, self.config_path, self.projects
-        )
-        self.assertEqual(result["action"], "migrated")
-        self.assertEqual(result["migrated"], [])
+        result = _migrate(conn, config_path, projects_dir)
 
-        remaining = json.loads(self.config_path.read_text())
-        self.assertEqual(remaining, {"theme": "textual-dark"})
+        assert result["action"] == "migrated"
+        assert result["migrated"] == []
+        remaining = json.loads(config_path.read_text())
+        assert remaining == {"theme": "textual-dark"}
 
-    def test_malformed_config_fails_safely(self) -> None:
-        """An unreadable/invalid config.json returns 'failed' without
-        touching the DB or setting the flag."""
-        self.config_path.write_text("{not json")
+    def test_config_with_only_app_settings(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        """Config that has no session-level keys at all is cleanly handled."""
+        write_config({"theme": "textual-dark", "sidebar_width": 36})
 
-        result = db.migrate_config_json_to_sqlite(
-            self.conn, self.config_path, self.projects
-        )
-        self.assertEqual(result["action"], "failed")
-        # No rows, no flag.
-        rows = db.query_all(self.conn, "SELECT * FROM sessions")
-        self.assertEqual(rows, [])
-        self.assertIsNone(db.get_setting(self.conn, db.MIGRATION_FLAG))
+        result = _migrate(conn, config_path, projects_dir)
 
-    def test_rewrite_config_false_leaves_file_untouched(self) -> None:
-        """rewrite_config=False is for callers who want to migrate DB state
-        but inspect the pre-rewrite config first (tests, dry-runs)."""
-        sid = "cccccccc-cccc-cccc-cccc-cccccccccccc"
-        _make_session_file(self.projects, "-Users-alice-work", sid)
-        original = {"theme": "textual-dark", "session_names": {sid: "kept"}}
-        self._write_config(original)
+        assert result["action"] == "migrated"
+        assert result["migrated"] == []
+        remaining = json.loads(config_path.read_text())
+        assert remaining == {"theme": "textual-dark", "sidebar_width": 36}
+        assert db.query_all(conn, "SELECT * FROM sessions") == []
 
-        result = db.migrate_config_json_to_sqlite(
-            self.conn, self.config_path, self.projects, rewrite_config=False
-        )
-        self.assertEqual(result["action"], "migrated")
+    def test_rewrite_config_false_leaves_file_untouched(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        _make_session_file(projects_dir, PROJECT, SID_A)
+        original = {"theme": "textual-dark", "session_names": {SID_A: "kept"}}
+        write_config(original)
 
-        # DB has the row…
+        result = _migrate(conn, config_path, projects_dir, rewrite_config=False)
+
+        assert result["action"] == "migrated"
         row = db.query_one(
-            self.conn, "SELECT custom_name FROM sessions WHERE session_id = ?",
-            (sid,),
+            conn, "SELECT custom_name FROM sessions WHERE session_id = ?",
+            (SID_A,),
         )
-        self.assertEqual(row["custom_name"], "kept")
-        # …but config.json is still the original.
-        self.assertEqual(json.loads(self.config_path.read_text()), original)
+        assert row["custom_name"] == "kept"
+        # config.json unchanged because rewrite_config=False.
+        assert json.loads(config_path.read_text()) == original
 
-    def test_cleanup_of_partial_previous_run(self) -> None:
-        """Simulate a prior partial-success state (DB migrated, flag set,
-        but config.json still has legacy keys). A subsequent call should
-        clean up the lingering legacy keys without touching DB rows."""
-        sid = "dddddddd-dddd-dddd-dddd-dddddddddddd"
-        _make_session_file(self.projects, "-Users-alice-work", sid)
-        # Set the flag manually to simulate "already migrated".
-        db.set_setting(self.conn, db.MIGRATION_FLAG, True)
-        # Insert a pre-existing row with data (must NOT be overwritten).
-        db.upsert_session(
-            self.conn, sid, str(self.projects / "stub.jsonl")
+
+# =========================================================================
+# Idempotency
+# =========================================================================
+
+class TestIdempotency:
+    def test_second_call_is_skipped(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        _make_session_file(projects_dir, PROJECT, SID_A)
+        write_config({"theme": "textual-dark", "session_names": {SID_A: "first"}})
+
+        r1 = _migrate(conn, config_path, projects_dir)
+        assert r1["action"] == "migrated"
+
+        r2 = _migrate(conn, config_path, projects_dir)
+        assert r2["action"] == "skipped"
+        assert r2["reason"] == "already migrated"
+
+        rows = db.query_all(conn, "SELECT * FROM sessions")
+        assert len(rows) == 1
+        assert rows[0]["custom_name"] == "first"
+
+    def test_no_duplicate_rows_on_second_call(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        _make_session_file(projects_dir, PROJECT, SID_A)
+        _make_session_file(projects_dir, PROJECT_B, SID_B)
+        payload = {
+            "session_names": {SID_A: "A", SID_B: "B"},
+            "session_order": [SID_A, SID_B],
+        }
+
+        write_config(payload)
+        _migrate(conn, config_path, projects_dir)
+
+        # Even if config.json is somehow restored, the flag prevents re-insert.
+        write_config(payload)
+        _migrate(conn, config_path, projects_dir)
+
+        count = db.query_one(conn, "SELECT COUNT(*) AS n FROM sessions")["n"]
+        assert count == 2
+
+    def test_second_call_does_not_clobber_user_changes(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        """After migration, the TUI may rename a session. A second migration
+        call must NOT overwrite that rename."""
+        _make_session_file(projects_dir, PROJECT, SID_A)
+        write_config({"session_names": {SID_A: "original"}})
+
+        _migrate(conn, config_path, projects_dir)
+        db.set_custom_name(conn, SID_A, "renamed by user")
+
+        # Second call — must be a no-op.
+        _migrate(conn, config_path, projects_dir)
+
+        row = db.query_one(
+            conn, "SELECT custom_name FROM sessions WHERE session_id = ?",
+            (SID_A,),
         )
-        db.set_custom_name(self.conn, sid, "established name")
+        assert row["custom_name"] == "renamed by user"
 
-        # Leave legacy keys in config.json to simulate prior partial rewrite.
-        self._write_config({
-            "theme": "textual-dark",
-            "session_names": {sid: "would clobber"},
-            "session_order": [sid],
+    def test_migration_flag_is_set(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        _make_session_file(projects_dir, PROJECT, SID_A)
+        write_config({"session_names": {SID_A: "x"}})
+
+        _migrate(conn, config_path, projects_dir)
+
+        assert db.get_setting(conn, db.MIGRATION_FLAG) is True
+
+    def test_pre_existing_row_is_updated_not_duplicated(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        """If a session row already exists (e.g. from a prior scan),
+        migration updates it via ON CONFLICT rather than creating a dupe."""
+        f = _make_session_file(projects_dir, PROJECT, SID_A)
+        db.upsert_session(conn, SID_A, str(f), project=PROJECT, modified_at=999.0)
+
+        write_config({
+            "session_names": {SID_A: "Named"},
+            "last_viewed": {SID_A: 100.0},
+            "session_order": [SID_A],
         })
 
-        result = db.migrate_config_json_to_sqlite(
-            self.conn, self.config_path, self.projects
-        )
-        self.assertEqual(result["action"], "skipped")
+        _migrate(conn, config_path, projects_dir)
 
-        # Legacy keys must have been cleaned up from config.json…
-        self.assertEqual(
-            json.loads(self.config_path.read_text()),
-            {"theme": "textual-dark"},
-        )
-        # …and the DB row must be unchanged (flag-guard prevents clobber).
+        rows = db.query_all(conn, "SELECT * FROM sessions")
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["custom_name"] == "Named"
+        assert row["last_viewed"] == 100.0
+        assert row["sort_order"] == 0
+
+    def test_partial_previous_run_cleanup(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        """Simulate a prior partial-success state (DB migrated + flag set,
+        but config.json still has legacy keys). Second call cleans up the
+        lingering keys without touching DB rows."""
+        _make_session_file(projects_dir, PROJECT, SID_A)
+        db.set_setting(conn, db.MIGRATION_FLAG, True)
+        db.upsert_session(conn, SID_A, str(projects_dir / PROJECT / f"{SID_A}.jsonl"))
+        db.set_custom_name(conn, SID_A, "established name")
+
+        # Legacy keys still in config.json.
+        write_config({
+            "theme": "textual-dark",
+            "session_names": {SID_A: "would clobber"},
+            "session_order": [SID_A],
+        })
+
+        result = _migrate(conn, config_path, projects_dir)
+
+        assert result["action"] == "skipped"
+        # Legacy keys cleaned up.
+        assert json.loads(config_path.read_text()) == {"theme": "textual-dark"}
+        # DB row not clobbered.
         row = db.query_one(
-            self.conn, "SELECT custom_name FROM sessions WHERE session_id = ?",
-            (sid,),
+            conn, "SELECT custom_name FROM sessions WHERE session_id = ?",
+            (SID_A,),
         )
-        self.assertEqual(row["custom_name"], "established name")
+        assert row["custom_name"] == "established name"
 
 
-class SessionHelperTest(unittest.TestCase):
+# =========================================================================
+# Rollback on failure
+# =========================================================================
+
+class TestRollbackOnFailure:
+    def test_db_failure_preserves_config_and_unsets_flag(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        """If the DB transaction fails, config.json is untouched and the
+        migration flag is NOT set — so the next run can retry."""
+        _make_session_file(projects_dir, PROJECT, SID_A)
+        original = {
+            "theme": "textual-dark",
+            "session_names": {SID_A: "preserved"},
+            "session_order": [SID_A],
+            "last_viewed": {SID_A: 12.0},
+        }
+        write_config(original)
+
+        # Sabotage the INSERT target so the transaction aborts.
+        conn.execute("ALTER TABLE sessions RENAME TO sessions_bak")
+        try:
+            result = _migrate(conn, config_path, projects_dir)
+        finally:
+            conn.execute("ALTER TABLE sessions_bak RENAME TO sessions")
+
+        assert result["action"] == "failed"
+        assert json.loads(config_path.read_text()) == original
+        assert db.get_setting(conn, db.MIGRATION_FLAG) is None
+
+    def test_failed_migration_can_be_retried(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        _make_session_file(projects_dir, PROJECT, SID_A)
+        write_config({"session_names": {SID_A: "retryable"}})
+
+        # Fail.
+        conn.execute("ALTER TABLE sessions RENAME TO sessions_bak")
+        fail_result = _migrate(conn, config_path, projects_dir)
+        conn.execute("ALTER TABLE sessions_bak RENAME TO sessions")
+        assert fail_result["action"] == "failed"
+
+        # Retry.
+        retry_result = _migrate(conn, config_path, projects_dir)
+        assert retry_result["action"] == "migrated"
+        row = db.query_one(
+            conn, "SELECT custom_name FROM sessions WHERE session_id = ?",
+            (SID_A,),
+        )
+        assert row["custom_name"] == "retryable"
+
+    def test_malformed_json_fails_safely(self, conn, config_path, projects_dir):
+        config_path.write_text("{not json")
+
+        result = _migrate(conn, config_path, projects_dir)
+
+        assert result["action"] == "failed"
+        assert db.query_all(conn, "SELECT * FROM sessions") == []
+        assert db.get_setting(conn, db.MIGRATION_FLAG) is None
+
+    def test_non_object_config_fails_safely(self, conn, config_path, projects_dir):
+        config_path.write_text("[1, 2, 3]")
+
+        result = _migrate(conn, config_path, projects_dir)
+
+        assert result["action"] == "failed"
+        assert "not a JSON object" in result["reason"]
+        assert db.query_all(conn, "SELECT * FROM sessions") == []
+
+
+# =========================================================================
+# Edge cases: defensive coercion, missing files, bad types
+# =========================================================================
+
+class TestEdgeCases:
+    def test_sessions_missing_from_disk_are_skipped(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        """A session_id in config.json without a JSONL file on disk is
+        reported as skipped (session_path is NOT NULL)."""
+        live_id = SID_A
+        ghost_id = SID_B
+        _make_session_file(projects_dir, PROJECT, live_id)
+
+        write_config({
+            "session_names": {live_id: "visible", ghost_id: "orphan"},
+            "session_order": [ghost_id, live_id],
+            "last_viewed": {ghost_id: 99.0},
+        })
+
+        result = _migrate(conn, config_path, projects_dir)
+
+        assert result["action"] == "migrated"
+        assert live_id in result["migrated"]
+        assert ghost_id in result["skipped"]
+        rows = db.query_all(conn, "SELECT session_id FROM sessions")
+        assert [r["session_id"] for r in rows] == [live_id]
+
+    def test_malformed_session_names_coerced_to_empty(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        """If session_names is an array instead of a dict, migration should
+        coerce it to empty rather than crash."""
+        write_config({
+            "theme": "textual-dark",
+            "session_names": ["not", "a", "dict"],
+        })
+
+        result = _migrate(conn, config_path, projects_dir)
+
+        # No sessions to migrate, but the legacy key is still stripped.
+        assert result["action"] == "migrated"
+        assert result["migrated"] == []
+        remaining = json.loads(config_path.read_text())
+        assert "session_names" not in remaining
+
+    def test_non_numeric_last_viewed_is_dropped(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        """A non-numeric last_viewed value should be treated as NULL rather
+        than crashing the migration."""
+        _make_session_file(projects_dir, PROJECT, SID_A)
+        write_config({
+            "session_names": {SID_A: "foo"},
+            "last_viewed": {SID_A: "not-a-timestamp"},
+        })
+
+        result = _migrate(conn, config_path, projects_dir)
+
+        assert result["action"] == "migrated"
+        row = db.query_one(
+            conn, "SELECT last_viewed FROM sessions WHERE session_id = ?",
+            (SID_A,),
+        )
+        assert row["last_viewed"] is None
+
+    def test_empty_projects_dir_skips_all(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        """If the projects directory is empty, all sessions are skipped."""
+        write_config({
+            "session_names": {SID_A: "foo", SID_B: "bar"},
+        })
+
+        result = _migrate(conn, config_path, projects_dir)
+
+        assert result["action"] == "migrated"
+        assert result["migrated"] == []
+        assert set(result["skipped"]) == {SID_A, SID_B}
+
+    def test_missing_projects_dir_skips_all(
+        self, conn, config_path, tmp_path, write_config
+    ):
+        """If the projects directory doesn't exist at all, migration still
+        completes gracefully (all sessions are skipped)."""
+        nonexistent = tmp_path / "no-such-dir"
+        write_config({"session_names": {SID_A: "foo"}})
+
+        result = _migrate(conn, config_path, nonexistent)
+
+        assert result["action"] == "migrated"
+        assert result["skipped"] == [SID_A]
+
+
+# =========================================================================
+# Session-row helper smoke tests (post-migration TUI write path)
+# =========================================================================
+
+class TestSessionHelpers:
     """Sanity tests for the session-row helpers the TUI calls post-migration."""
 
-    def setUp(self) -> None:
-        self._tmp = tempfile.TemporaryDirectory()
-        self.root = Path(self._tmp.name)
-        self.conn = db.init_db(self.root / "test.db")
-        self.sid = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+    @pytest.fixture(autouse=True)
+    def _seed_session(self, conn, tmp_path):
+        self.sid = SID_A
         db.upsert_session(
-            self.conn,
+            conn,
             session_id=self.sid,
-            session_path=str(self.root / "fake.jsonl"),
-            project="-Users-alice-work",
+            session_path=str(tmp_path / "fake.jsonl"),
+            project=PROJECT,
             cwd="/Users/alice/work",
             modified_at=1234.5,
         )
 
-    def tearDown(self) -> None:
-        self.conn.close()
-        self._tmp.cleanup()
+    def test_upsert_preserves_user_owned_fields(self, conn, tmp_path):
+        db.set_custom_name(conn, self.sid, "mine")
+        db.set_last_viewed(conn, self.sid, 555.0)
 
-    def test_upsert_preserves_user_owned_fields(self) -> None:
-        """A rescan shouldn't clobber a user's rename or last_viewed."""
-        db.set_custom_name(self.conn, self.sid, "mine")
-        db.set_last_viewed(self.conn, self.sid, 555.0)
-
-        # Second upsert — simulates the background refresh loop.
+        # Second upsert — simulates a background refresh.
         db.upsert_session(
-            self.conn,
+            conn,
             session_id=self.sid,
-            session_path=str(self.root / "fake.jsonl"),
-            project="-Users-alice-work",
+            session_path=str(tmp_path / "fake.jsonl"),
+            project=PROJECT,
             modified_at=9999.0,
         )
-        row = db.query_one(
-            self.conn, "SELECT * FROM sessions WHERE session_id = ?", (self.sid,)
-        )
-        self.assertEqual(row["custom_name"], "mine")
-        self.assertEqual(row["last_viewed"], 555.0)
-        # But the filesystem-owned modified_at DID update.
-        self.assertEqual(row["modified_at"], 9999.0)
 
-    def test_set_custom_name_empty_clears(self) -> None:
-        db.set_custom_name(self.conn, self.sid, "temp")
-        db.set_custom_name(self.conn, self.sid, "")
         row = db.query_one(
-            self.conn, "SELECT custom_name FROM sessions WHERE session_id = ?",
+            conn, "SELECT * FROM sessions WHERE session_id = ?", (self.sid,)
+        )
+        assert row["custom_name"] == "mine"
+        assert row["last_viewed"] == 555.0
+        assert row["modified_at"] == 9999.0  # filesystem-owned DID update
+
+    def test_set_custom_name_empty_clears(self, conn):
+        db.set_custom_name(conn, self.sid, "temp")
+        db.set_custom_name(conn, self.sid, "")
+
+        row = db.query_one(
+            conn, "SELECT custom_name FROM sessions WHERE session_id = ?",
             (self.sid,),
         )
-        self.assertIsNone(row["custom_name"])
+        assert row["custom_name"] is None
 
-    def test_set_session_order_assigns_positions(self) -> None:
-        sid2 = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+    def test_set_session_order_assigns_positions(self, conn, tmp_path):
+        sid2 = SID_B
         db.upsert_session(
-            self.conn, sid2, str(self.root / "two.jsonl"),
-            project="-Users-alice-home",
+            conn, sid2, str(tmp_path / "two.jsonl"), project=PROJECT_B,
         )
 
-        db.set_session_order(self.conn, [sid2, self.sid])
+        db.set_session_order(conn, [sid2, self.sid])
+        assert db.get_session_order(conn) == [sid2, self.sid]
 
-        self.assertEqual(
-            db.get_session_order(self.conn), [sid2, self.sid]
-        )
+        db.set_session_order(conn, [self.sid, sid2])
+        assert db.get_session_order(conn) == [self.sid, sid2]
 
-        # Re-order and confirm the first ID now comes second.
-        db.set_session_order(self.conn, [self.sid, sid2])
-        self.assertEqual(
-            db.get_session_order(self.conn), [self.sid, sid2]
-        )
+    def test_get_helpers_return_only_populated_rows(self, conn):
+        assert db.get_custom_names(conn) == {}
+        assert db.get_last_viewed(conn) == {}
 
-    def test_get_helpers_return_only_populated_rows(self) -> None:
-        """Sessions without a custom_name / last_viewed shouldn't appear
-        in the returned dicts (keeps the TUI reads sparse)."""
-        self.assertEqual(db.get_custom_names(self.conn), {})
-        self.assertEqual(db.get_last_viewed(self.conn), {})
-
-        db.set_custom_name(self.conn, self.sid, "hello")
-        db.set_last_viewed(self.conn, self.sid, 7.0)
-        self.assertEqual(db.get_custom_names(self.conn), {self.sid: "hello"})
-        self.assertEqual(db.get_last_viewed(self.conn), {self.sid: 7.0})
+        db.set_custom_name(conn, self.sid, "hello")
+        db.set_last_viewed(conn, self.sid, 7.0)
+        assert db.get_custom_names(conn) == {self.sid: "hello"}
+        assert db.get_last_viewed(conn) == {self.sid: 7.0}
 
 
-if __name__ == "__main__":
-    unittest.main()
+# =========================================================================
+# Temp-dir isolation sanity check
+# =========================================================================
+
+class TestIsolation:
+    def test_real_config_dir_is_untouched(
+        self, conn, config_path, projects_dir, write_config
+    ):
+        """Regression check: if the user has a real config.json, the test
+        suite must not modify it."""
+        real_config = Path.home() / ".config" / "threadhop" / "config.json"
+        before = real_config.stat().st_mtime if real_config.exists() else None
+        before_bytes = real_config.read_bytes() if real_config.exists() else None
+
+        _make_session_file(projects_dir, PROJECT, SID_A)
+        write_config({
+            "theme": "textual-dark",
+            "session_names": {SID_A: "test"},
+        })
+        _migrate(conn, config_path, projects_dir)
+
+        after = real_config.stat().st_mtime if real_config.exists() else None
+        after_bytes = real_config.read_bytes() if real_config.exists() else None
+
+        assert before == after
+        assert before_bytes == after_bytes


### PR DESCRIPTION
## Summary
- Replaces the unittest-based `test_migration.py` with a pytest suite using fixtures (`conftest.py`) for isolated temp DB, config.json, and projects directory
- Adds new test scenarios beyond the original 14-test suite: forward-compatible unknown key preservation, asymmetric session data, defensive coercion of malformed types (bad `session_names` type, non-numeric `last_viewed`), empty/missing projects directory, config-only-app-settings edge case, and a real `~/.config/threadhop` isolation sanity check
- 32 tests total, all passing, organized into 6 test classes: `TestBasicMigration`, `TestConfigPreservation`, `TestIdempotency`, `TestRollbackOnFailure`, `TestEdgeCases`, `TestSessionHelpers`, `TestIsolation`

## Test plan
- [x] `pytest tests/ -v` passes (32/32)
- [x] All tests use `tmp_path` fixtures — no test touches `~/.config/threadhop` or `~/.claude/projects`
- [x] `TestIsolation::test_real_config_dir_is_untouched` explicitly asserts the real config file's mtime/bytes are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)