### PR TITLE
Add incremental indexing with byte-offset tracking (task #9)

### DIFF
--- a/db.py
+++ b/db.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from contextlib import contextmanager
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterator, Sequence
 
@@ -31,7 +32,7 @@ DB_PATH = DB_DIR / "sessions.db"
 # --- Schema version ---
 # Each migration N in MIGRATIONS moves the DB from version N to N+1.
 # The DB's current version lives in PRAGMA user_version.
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 
 # --- Migrations -----------------------------------------------------------
@@ -155,10 +156,44 @@ def _migration_002_messages(conn: sqlite3.Connection) -> None:
     )
 
 
+def _migration_003_index_state(conn: sqlite3.Connection) -> None:
+    """Task #9: incremental indexing support.
+
+    - ``index_state``: tracks byte offset per session so the refresh
+      cycle only parses newly-appended JSONL bytes.
+    - ``messages.message_id``: stores the Claude API ``message.id``
+      (shared across streaming chunks).  Needed for cross-batch chunk
+      merging — when an assistant response spans two refresh cycles,
+      the second batch must look up and UPDATE the row created by the
+      first batch.
+    """
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS index_state (
+            session_id       TEXT PRIMARY KEY,
+            file_path        TEXT NOT NULL,
+            last_byte_offset INTEGER NOT NULL DEFAULT 0,
+            last_indexed_at  REAL NOT NULL
+        )
+        """
+    )
+
+    # ALTER TABLE doesn't support IF NOT EXISTS, so guard with a
+    # column-presence check to keep the migration idempotent.
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(messages)").fetchall()}
+    if "message_id" not in cols:
+        conn.execute("ALTER TABLE messages ADD COLUMN message_id TEXT")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_messages_message_id "
+            "ON messages(message_id)"
+        )
+
+
 # Ordered list; MIGRATIONS[i] moves schema from version i to i+1.
 MIGRATIONS: list = [
     _migration_001_initial,
     _migration_002_messages,
+    _migration_003_index_state,
 ]
 
 assert len(MIGRATIONS) == SCHEMA_VERSION, (
@@ -486,6 +521,56 @@ def get_session_statuses(conn: sqlite3.Connection) -> dict[str, str]:
         "SELECT session_id, status FROM sessions"
     ).fetchall()
     return {r["session_id"]: r["status"] for r in rows}
+
+
+# --- Index-state helpers ---------------------------------------------------
+
+def get_index_state(
+    conn: sqlite3.Connection,
+    session_id: str,
+) -> dict | None:
+    """Return the index state for a session, or None if never indexed."""
+    return query_one(
+        conn,
+        "SELECT * FROM index_state WHERE session_id = ?",
+        (session_id,),
+    )
+
+
+def upsert_index_state(
+    conn: sqlite3.Connection,
+    session_id: str,
+    file_path: str,
+    last_byte_offset: int,
+    last_indexed_at: float,
+) -> None:
+    """Insert or update the index state for a session."""
+    conn.execute(
+        """
+        INSERT INTO index_state (
+            session_id, file_path, last_byte_offset, last_indexed_at
+        ) VALUES (?, ?, ?, ?)
+        ON CONFLICT(session_id) DO UPDATE SET
+            file_path        = excluded.file_path,
+            last_byte_offset = excluded.last_byte_offset,
+            last_indexed_at  = excluded.last_indexed_at
+        """,
+        (session_id, file_path, last_byte_offset, last_indexed_at),
+    )
+
+
+def delete_index_state(conn: sqlite3.Connection, session_id: str) -> None:
+    """Remove the index state for a session (used on truncation/rotation)."""
+    conn.execute("DELETE FROM index_state WHERE session_id = ?", (session_id,))
+
+
+def delete_session_messages(conn: sqlite3.Connection, session_id: str) -> None:
+    """Delete all indexed messages for a session.
+
+    The FTS table is kept in sync automatically via the ``messages_ad``
+    trigger created in migration 002.
+    """
+    conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
 
 
 # --- One-time config.json → SQLite migration (ADR-001) --------------------

--- a/indexer.py
+++ b/indexer.py
@@ -352,6 +352,231 @@ def index_all(
     return results
 
 
+# --- Incremental indexing (task #9) ----------------------------------------
+
+
+def index_session_incremental(
+    conn: sqlite3.Connection,
+    session_id: str,
+    session_path: str | Path,
+) -> None:
+    """Incrementally index new JSONL content for a session.
+
+    Called from the TUI's 5-second refresh cycle.  Reads only bytes
+    appended since the last index, parses new lines, applies the same
+    chunk-merging logic as ``parse_messages``, and upserts into the
+    ``messages`` + ``messages_fts`` tables.
+
+    Edge cases:
+
+    * **File truncation / rotation**: ``file_size < last_offset``
+      triggers deletion of all indexed messages for the session and a
+      full re-index from byte 0.
+    * **Partial line at EOF**: the read stops at the last complete
+      newline; the incomplete trailing bytes are picked up on the next
+      refresh.
+    * **Chunk boundary**: if new bytes begin with a continuation of a
+      previous assistant message chunk (same ``message.id``), the
+      existing row is updated by appending the new text.
+    """
+    from datetime import datetime as _dt
+
+    file_path = Path(session_path)
+    if not file_path.exists():
+        return
+
+    try:
+        file_size = file_path.stat().st_size
+    except OSError:
+        return
+
+    state = db.get_index_state(conn, session_id)
+    last_offset = state["last_byte_offset"] if state else 0
+
+    # --- Truncation / rotation detection ---
+    if file_size < last_offset:
+        with db.transaction(conn):
+            db.delete_session_messages(conn, session_id)
+            db.delete_index_state(conn, session_id)
+        last_offset = 0
+
+    if file_size == last_offset:
+        return  # Nothing new
+
+    # --- Read new bytes ---
+    try:
+        with open(file_path, "rb") as f:
+            f.seek(last_offset)
+            new_bytes = f.read()
+    except OSError:
+        return
+
+    # --- Partial line at EOF ---
+    last_newline = new_bytes.rfind(b"\n")
+    if last_newline == -1:
+        return  # No complete line yet
+    processable = new_bytes[: last_newline + 1]
+    new_offset = last_offset + last_newline + 1
+
+    # --- Parse raw lines ---
+    raw_lines = processable.decode("utf-8", errors="replace").split("\n")
+    # split() on "line1\nline2\n" → ["line1", "line2", ""] — drop trailing empty
+    if raw_lines and raw_lines[-1] == "":
+        raw_lines.pop()
+
+    if not raw_lines:
+        db.upsert_index_state(
+            conn, session_id, str(file_path), new_offset,
+            _dt.now().timestamp(),
+        )
+        return
+
+    # --- Group messages with chunk merging (ADR-003) ---
+    # Reuses the same extraction helpers as parse_messages but reads from
+    # a byte range instead of the full file.
+
+    parsed_groups: list[dict] = []
+    current_chunk: dict | None = None
+    current_chunk_parts: list[str] = []
+
+    def _flush_chunk() -> None:
+        nonlocal current_chunk, current_chunk_parts
+        if current_chunk is not None:
+            current_chunk["text"] = "\n\n".join(
+                p for p in current_chunk_parts if p
+            ).strip()
+            if current_chunk["text"]:
+                parsed_groups.append(current_chunk)
+            current_chunk = None
+            current_chunk_parts = []
+
+    for raw_line in raw_lines:
+        if not raw_line.strip():
+            continue
+        try:
+            msg = json.loads(raw_line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+        mtype = msg.get("type")
+        if mtype not in ("user", "assistant"):
+            continue
+
+        if mtype == "user":
+            _flush_chunk()
+
+            text = _extract_user_text(msg)
+            if not text:
+                continue
+
+            uid = msg.get("uuid")
+            sid = msg.get("sessionId") or session_id
+            if not uid:
+                continue
+
+            parsed_groups.append({
+                "uuid": uid,
+                "session_id": sid,
+                "role": "user",
+                "text": text,
+                "timestamp": msg.get("timestamp"),
+                "cwd": msg.get("cwd"),
+                "parent_uuid": msg.get("parentUuid"),
+                "is_sidechain": 1 if msg.get("isSidechain") else 0,
+                "message_id": msg.get("message", {}).get("id"),
+            })
+            continue
+
+        # --- assistant line ---
+        mid = msg.get("message", {}).get("id")
+        parts = _extract_assistant_blocks(msg)
+
+        # Continuing the same logical message → accumulate.
+        if (
+            mid is not None
+            and current_chunk is not None
+            and current_chunk.get("message_id") == mid
+        ):
+            current_chunk_parts.extend(parts)
+            continue
+
+        # Different message.id → flush previous and start fresh.
+        _flush_chunk()
+
+        uid = msg.get("uuid")
+        sid = msg.get("sessionId") or session_id
+        if not uid:
+            continue
+
+        current_chunk = {
+            "uuid": uid,
+            "session_id": sid,
+            "role": "assistant",
+            "text": "",  # populated by _flush_chunk
+            "timestamp": msg.get("timestamp"),
+            "cwd": msg.get("cwd"),
+            "parent_uuid": msg.get("parentUuid"),
+            "is_sidechain": 1 if msg.get("isSidechain") else 0,
+            "message_id": mid,
+        }
+        current_chunk_parts = list(parts)
+
+    # Flush the last chunk.
+    _flush_chunk()
+
+    if not parsed_groups:
+        db.upsert_index_state(
+            conn, session_id, str(file_path), new_offset,
+            _dt.now().timestamp(),
+        )
+        return
+
+    # --- Write to DB ---
+    with db.transaction(conn):
+        _ensure_session_stub(conn, session_id, file_path)
+
+        for group in parsed_groups:
+            if not group["text"]:
+                continue
+
+            # Cross-batch chunk merging: if this assistant message.id was
+            # partially indexed in a previous refresh, append new text to
+            # the existing row instead of inserting a duplicate.
+            if group["role"] == "assistant" and group.get("message_id"):
+                existing = db.query_one(
+                    conn,
+                    "SELECT uuid, text FROM messages "
+                    "WHERE message_id = ? AND session_id = ?",
+                    (group["message_id"], group["session_id"]),
+                )
+                if existing:
+                    merged = existing["text"] + "\n\n" + group["text"]
+                    conn.execute(
+                        "UPDATE messages SET text = ? WHERE uuid = ?",
+                        (merged, existing["uuid"]),
+                    )
+                    continue
+
+            conn.execute(
+                "INSERT OR IGNORE INTO messages "
+                "(uuid, session_id, role, text, timestamp, cwd, "
+                "parent_uuid, is_sidechain, message_id) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    group["uuid"], group["session_id"],
+                    group["role"], group["text"],
+                    group["timestamp"], group["cwd"],
+                    group["parent_uuid"], group["is_sidechain"],
+                    group.get("message_id"),
+                ),
+            )
+
+        db.upsert_index_state(
+            conn, session_id, str(file_path), new_offset,
+            _dt.now().timestamp(),
+        )
+
+
 if __name__ == "__main__":  # pragma: no cover
     # Manual sweep entry point: `python indexer.py`
     conn = db.init_db()

--- a/tests/test_incremental_index.py
+++ b/tests/test_incremental_index.py
@@ -1,0 +1,479 @@
+"""Tests for incremental JSONL indexing (task #9).
+
+Exercises ``indexer.index_session_incremental`` end-to-end: basic indexing,
+incremental appends, chunk merging within and across batches, file
+truncation re-index, partial line at EOF, and FTS search.
+
+Run from the repo root::
+
+    python -m pytest tests/test_incremental_index.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import db
+import indexer
+
+
+# --- JSONL line builders ---------------------------------------------------
+
+def _user_line(uuid: str, text: str, session_id: str = "test-session") -> str:
+    """Build a minimal user JSONL line."""
+    return json.dumps({
+        "type": "user",
+        "uuid": uuid,
+        "sessionId": session_id,
+        "timestamp": "2026-04-16T10:00:00Z",
+        "message": {"id": f"umsg_{uuid}", "content": [{"type": "text", "text": text}]},
+    })
+
+
+def _assistant_line(
+    uuid: str, message_id: str, text: str, session_id: str = "test-session",
+) -> str:
+    """Build a minimal assistant JSONL line."""
+    return json.dumps({
+        "type": "assistant",
+        "uuid": uuid,
+        "sessionId": session_id,
+        "timestamp": "2026-04-16T10:00:01Z",
+        "message": {
+            "id": message_id,
+            "content": [{"type": "text", "text": text}],
+        },
+    })
+
+
+def _tool_use_line(
+    uuid: str, message_id: str, tool_name: str, session_id: str = "test-session",
+) -> str:
+    """Build an assistant line containing only a tool_use block (no text)."""
+    return json.dumps({
+        "type": "assistant",
+        "uuid": uuid,
+        "sessionId": session_id,
+        "timestamp": "2026-04-16T10:00:02Z",
+        "message": {
+            "id": message_id,
+            "content": [{"type": "tool_use", "name": tool_name, "input": {}}],
+        },
+    })
+
+
+def _tool_result_line(uuid: str, session_id: str = "test-session") -> str:
+    """Build a user line that is a tool result (should be skipped)."""
+    return json.dumps({
+        "type": "user",
+        "uuid": uuid,
+        "sessionId": session_id,
+        "timestamp": "2026-04-16T10:00:03Z",
+        "toolUseResult": {"type": "tool_result", "content": "ok"},
+    })
+
+
+def _title_line(title: str) -> str:
+    return json.dumps({"type": "ai-title", "aiTitle": title})
+
+
+# --- Fixtures --------------------------------------------------------------
+
+SID = "test-session"
+
+
+class _SessionHelper:
+    """Wraps a temp session file + conn for incremental index tests."""
+
+    def __init__(self, conn, tmp_path):
+        self.conn = conn
+        self.jsonl = tmp_path / f"{SID}.jsonl"
+        # Ensure a sessions row exists so the indexer can INSERT messages.
+        db.upsert_session(
+            conn, SID, str(self.jsonl),
+            project="test", created_at=time.time(), modified_at=time.time(),
+        )
+
+    def write(self, *lines: str) -> None:
+        self.jsonl.write_text("\n".join(lines) + "\n")
+
+    def append(self, *lines: str) -> None:
+        with open(self.jsonl, "a") as f:
+            for line in lines:
+                f.write(line + "\n")
+
+    def index(self) -> None:
+        indexer.index_session_incremental(self.conn, SID, str(self.jsonl))
+
+    def messages(self) -> list[dict]:
+        return db.query_all(
+            self.conn,
+            "SELECT * FROM messages WHERE session_id = ? ORDER BY rowid",
+            (SID,),
+        )
+
+    def fts_search(self, query: str) -> list[dict]:
+        return db.query_all(
+            self.conn,
+            """
+            SELECT m.* FROM messages m
+            JOIN messages_fts ON messages_fts.rowid = m.rowid
+            WHERE messages_fts MATCH ?
+            ORDER BY m.rowid
+            """,
+            (query,),
+        )
+
+
+# --- Basic indexing --------------------------------------------------------
+
+def test_indexes_user_and_assistant_messages(conn, tmp_path):
+    h = _SessionHelper(conn, tmp_path)
+    h.write(
+        _user_line("u1", "Hello world"),
+        _assistant_line("a1", "msg_1", "Hi there"),
+    )
+    h.index()
+
+    msgs = h.messages()
+    assert len(msgs) == 2
+    assert msgs[0]["role"] == "user"
+    assert msgs[0]["text"] == "Hello world"
+    assert msgs[1]["role"] == "assistant"
+    assert msgs[1]["text"] == "Hi there"
+
+
+def test_skips_non_message_types(conn, tmp_path):
+    h = _SessionHelper(conn, tmp_path)
+    h.write(
+        _title_line("My Session"),
+        _user_line("u1", "Question"),
+    )
+    h.index()
+
+    msgs = h.messages()
+    assert len(msgs) == 1
+    assert msgs[0]["text"] == "Question"
+
+
+def test_skips_tool_result_lines(conn, tmp_path):
+    h = _SessionHelper(conn, tmp_path)
+    h.write(
+        _user_line("u1", "Do something"),
+        _tool_result_line("tr1"),
+        _assistant_line("a1", "msg_1", "Done"),
+    )
+    h.index()
+
+    msgs = h.messages()
+    assert len(msgs) == 2
+    assert msgs[0]["role"] == "user"
+    assert msgs[1]["role"] == "assistant"
+
+
+def test_strips_system_reminders(conn, tmp_path):
+    h = _SessionHelper(conn, tmp_path)
+    text_with_reminder = "Hello <system-reminder>secret</system-reminder> world"
+    h.write(_user_line("u1", text_with_reminder))
+    h.index()
+
+    msgs = h.messages()
+    assert len(msgs) == 1
+    assert msgs[0]["text"] == "Hello  world"
+
+
+# --- Chunk merging (ADR-003) -----------------------------------------------
+
+def test_merges_consecutive_assistant_chunks(conn, tmp_path):
+    """Multiple assistant lines with the same message.id → one row."""
+    h = _SessionHelper(conn, tmp_path)
+    h.write(
+        _user_line("u1", "Question"),
+        _assistant_line("a1", "msg_1", "Part one"),
+        _assistant_line("a2", "msg_1", "part two"),
+        _assistant_line("a3", "msg_1", "part three"),
+    )
+    h.index()
+
+    msgs = h.messages()
+    assert len(msgs) == 2  # 1 user + 1 merged assistant
+    assistant = [m for m in msgs if m["role"] == "assistant"]
+    assert len(assistant) == 1
+    assert "Part one" in assistant[0]["text"]
+    assert "part two" in assistant[0]["text"]
+    assert "part three" in assistant[0]["text"]
+    assert assistant[0]["uuid"] == "a1"  # first uuid is PK
+
+
+def test_does_not_merge_different_message_ids(conn, tmp_path):
+    h = _SessionHelper(conn, tmp_path)
+    h.write(
+        _assistant_line("a1", "msg_1", "First response"),
+        _user_line("u1", "Follow-up"),
+        _assistant_line("a2", "msg_2", "Second response"),
+    )
+    h.index()
+
+    msgs = h.messages()
+    assert len(msgs) == 3
+
+
+def test_tool_use_abbreviation_in_chunk(conn, tmp_path):
+    """Assistant chunk with tool_use gets abbreviated inline."""
+    h = _SessionHelper(conn, tmp_path)
+    h.write(
+        _user_line("u1", "Read a file"),
+        _tool_use_line("a1", "msg_1", "Read"),
+    )
+    h.index()
+
+    msgs = h.messages()
+    # tool_use alone gets abbreviated by _extract_assistant_blocks
+    assistant = [m for m in msgs if m["role"] == "assistant"]
+    assert len(assistant) == 1
+    assert "Reading" in assistant[0]["text"]
+
+
+# --- Incremental indexing --------------------------------------------------
+
+def test_incremental_append_indexes_only_new_lines(conn, tmp_path):
+    h = _SessionHelper(conn, tmp_path)
+    h.write(_user_line("u1", "First"))
+    h.index()
+    assert len(h.messages()) == 1
+
+    h.append(
+        _user_line("u2", "Second"),
+        _assistant_line("a1", "msg_1", "Reply"),
+    )
+    h.index()
+
+    msgs = h.messages()
+    assert len(msgs) == 3
+    assert msgs[0]["text"] == "First"
+    assert msgs[1]["text"] == "Second"
+    assert msgs[2]["text"] == "Reply"
+
+
+def test_incremental_updates_byte_offset(conn, tmp_path):
+    h = _SessionHelper(conn, tmp_path)
+    h.write(_user_line("u1", "Hello"))
+    h.index()
+
+    state = db.get_index_state(conn, SID)
+    assert state is not None
+    assert state["last_byte_offset"] > 0
+    first_offset = state["last_byte_offset"]
+
+    h.append(_user_line("u2", "World"))
+    h.index()
+
+    state = db.get_index_state(conn, SID)
+    assert state["last_byte_offset"] > first_offset
+
+
+def test_no_new_bytes_is_noop(conn, tmp_path):
+    h = _SessionHelper(conn, tmp_path)
+    h.write(_user_line("u1", "Only message"))
+    h.index()
+    state1 = db.get_index_state(conn, SID)
+
+    h.index()
+    state2 = db.get_index_state(conn, SID)
+
+    assert state1["last_byte_offset"] == state2["last_byte_offset"]
+    assert len(h.messages()) == 1
+
+
+# --- Cross-batch chunk merging ---------------------------------------------
+
+def test_chunk_merge_across_batches(conn, tmp_path):
+    """Assistant chunk split across two index runs → merged into one row."""
+    h = _SessionHelper(conn, tmp_path)
+    h.write(
+        _user_line("u1", "Question"),
+        _assistant_line("a1", "msg_1", "Part one"),
+    )
+    h.index()
+    assert len(h.messages()) == 2
+
+    # Append continuation of the same assistant message
+    h.append(_assistant_line("a2", "msg_1", "part two"))
+    h.index()
+
+    msgs = h.messages()
+    assert len(msgs) == 2  # still 2, not 3
+    assistant = [m for m in msgs if m["role"] == "assistant"][0]
+    assert "Part one" in assistant["text"]
+    assert "part two" in assistant["text"]
+
+
+# --- Edge cases ------------------------------------------------------------
+
+def test_file_truncation_triggers_reindex(conn, tmp_path):
+    """If file shrinks, all messages are deleted and file re-indexed."""
+    h = _SessionHelper(conn, tmp_path)
+    h.write(
+        _user_line("u1", "Original first"),
+        _user_line("u2", "Original second"),
+    )
+    h.index()
+    assert len(h.messages()) == 2
+    old_offset = db.get_index_state(conn, SID)["last_byte_offset"]
+
+    # Truncate: write a shorter file
+    h.write(_user_line("u3", "After truncation"))
+    new_size = h.jsonl.stat().st_size
+    assert new_size < old_offset
+
+    h.index()
+    msgs = h.messages()
+    assert len(msgs) == 1
+    assert msgs[0]["text"] == "After truncation"
+
+
+def test_partial_line_at_eof_is_not_indexed(conn, tmp_path):
+    """An incomplete trailing line is ignored until the next refresh."""
+    h = _SessionHelper(conn, tmp_path)
+    h.write(_user_line("u1", "Complete"))
+    # Append partial line (no trailing newline)
+    with open(h.jsonl, "a") as f:
+        f.write('{"type":"user","uuid":"u2","sessionId":"test-session","message":')
+    h.index()
+
+    msgs = h.messages()
+    assert len(msgs) == 1
+    assert msgs[0]["text"] == "Complete"
+
+    # Now complete the line
+    with open(h.jsonl, "a") as f:
+        f.write('{"id":"m2","content":[{"type":"text","text":"Was partial"}]}}\n')
+    h.index()
+
+    msgs = h.messages()
+    assert len(msgs) == 2
+    assert msgs[1]["text"] == "Was partial"
+
+
+def test_nonexistent_file_is_noop(conn, tmp_path):
+    """Indexing a missing file does nothing and doesn't crash."""
+    indexer.index_session_incremental(
+        conn, SID, str(tmp_path / "nonexistent.jsonl"),
+    )
+    assert len(db.query_all(conn, "SELECT * FROM messages WHERE session_id = ?", (SID,))) == 0
+
+
+def test_empty_file_is_noop(conn, tmp_path):
+    h = _SessionHelper(conn, tmp_path)
+    h.jsonl.write_text("")
+    h.index()
+    assert len(h.messages()) == 0
+
+
+def test_malformed_json_lines_are_skipped(conn, tmp_path):
+    h = _SessionHelper(conn, tmp_path)
+    h.write(
+        "not valid json",
+        _user_line("u1", "Valid message"),
+        "{malformed}",
+    )
+    h.index()
+
+    msgs = h.messages()
+    assert len(msgs) == 1
+    assert msgs[0]["text"] == "Valid message"
+
+
+# --- FTS search ------------------------------------------------------------
+
+def test_fts_search_finds_indexed_messages(conn, tmp_path):
+    h = _SessionHelper(conn, tmp_path)
+    h.write(
+        _user_line("u1", "How do I configure rate limiting?"),
+        _assistant_line("a1", "msg_1", "Use a token bucket algorithm"),
+    )
+    h.index()
+
+    results = h.fts_search("rate limiting")
+    assert len(results) == 1
+    assert results[0]["uuid"] == "u1"
+
+    results = h.fts_search("token bucket")
+    assert len(results) == 1
+    assert results[0]["uuid"] == "a1"
+
+
+def test_fts_prefix_search(conn, tmp_path):
+    h = _SessionHelper(conn, tmp_path)
+    h.write(_user_line("u1", "authentication middleware refactor"))
+    h.index()
+
+    results = h.fts_search("auth*")
+    assert len(results) == 1
+
+
+def test_fts_updates_on_chunk_merge(conn, tmp_path):
+    """FTS stays correct when a message is updated via cross-batch merge."""
+    h = _SessionHelper(conn, tmp_path)
+    h.write(_assistant_line("a1", "msg_1", "Initial content about databases"))
+    h.index()
+    assert len(h.fts_search("databases")) == 1
+
+    h.append(_assistant_line("a2", "msg_1", "and caching strategies"))
+    h.index()
+
+    assert len(h.fts_search("databases")) == 1
+    assert len(h.fts_search("caching")) == 1
+
+
+def test_fts_cleaned_on_truncation_reindex(conn, tmp_path):
+    """After truncation, old FTS entries are gone."""
+    h = _SessionHelper(conn, tmp_path)
+    h.write(_user_line("u1", "zebra unicorn"))
+    h.index()
+    assert len(h.fts_search("zebra")) == 1
+
+    h.write(_user_line("u2", "apple banana"))
+    h.index()
+
+    assert len(h.fts_search("zebra")) == 0
+    assert len(h.fts_search("apple")) == 1
+
+
+# --- Migration test --------------------------------------------------------
+
+def test_migration_003_from_v2(tmp_path):
+    """Verify migration 003 correctly adds index_state and message_id column."""
+    db_path = tmp_path / "test.db"
+
+    # Start with a v2 database (migrations 001+002 only)
+    conn = db.connect(db_path)
+    conn.execute("BEGIN")
+    db._migration_001_initial(conn)
+    db._migration_002_messages(conn)
+    db._set_schema_version(conn, 2)
+    conn.execute("COMMIT")
+    assert db.get_schema_version(conn) == 2
+
+    # Verify message_id column does NOT exist yet
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(messages)").fetchall()}
+    assert "message_id" not in cols
+
+    # Apply pending migration
+    db.apply_migrations(conn)
+    assert db.get_schema_version(conn) == 3
+
+    # Verify index_state table exists
+    tables = {
+        r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    assert "index_state" in tables
+
+    # Verify message_id column was added
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(messages)").fetchall()}
+    assert "message_id" in cols
+
+    conn.close()

--- a/threadhop
+++ b/threadhop
@@ -28,6 +28,7 @@ from textual.worker import Worker
 # Imported as a relative module because db.py sits next to this script.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import db  # noqa: E402
+import indexer  # noqa: E402
 
 
 def get_available_themes():
@@ -962,6 +963,18 @@ class ClaudeSessions(App):
                     )
         except:
             pass
+
+        # --- Incremental indexing (task #9) ---
+        # Piggyback on the 5s refresh cycle: for each discovered session,
+        # index only the bytes appended since the last run.  Errors in one
+        # session's indexing must not affect others or the refresh cycle.
+        for s in sessions:
+            try:
+                indexer.index_session_incremental(
+                    self.conn, s["session_id"], s["path"],
+                )
+            except Exception:
+                pass
 
         return {"sessions": sessions}
 


### PR DESCRIPTION
## Summary
- **Migration 003**: Creates `index_state` table (`session_id` PK, `file_path`, `last_byte_offset`, `last_indexed_at`) and adds `message_id` column to `messages` for cross-batch chunk merging
- **`indexer.index_session_incremental()`**: Seeks to `last_byte_offset`, reads only new bytes appended since last index, applies ADR-003 chunk merging, handles file truncation (full re-index), partial lines at EOF, and cross-batch chunk boundaries
- **TUI integration**: Piggybacked on the 5-second refresh cycle in `_gather_session_data()` with per-session error isolation
- **21 new tests**: Basic indexing, incremental appends, chunk merging within/across batches, truncation re-index, partial EOF, FTS search, and migration 003

## Test plan
- [x] All 53 tests pass (21 new + 32 existing)
- [ ] Manual: run `./threadhop` and verify sessions get indexed (check `~/.config/threadhop/sessions.db` for `index_state` rows)
- [ ] Manual: verify active session gets incrementally indexed on each refresh tick (byte offset advances)

🤖 Generated with [Claude Code](https://claude.com/claude-code)