### PR TITLE
Add message selection mode to TranscriptView

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,24 +24,54 @@ threadhop --days 7                     # last 7 days only
 
 ## Keybindings
 
+### Navigation
+
 | Key | Action |
 |-----|--------|
-| `j`/`k` | Navigate sessions |
-| `h`/`l` | Focus session list / transcript |
-| `Enter` | Reply / Send message |
-| `Escape` | Cancel reply |
-| `g` | Copy session ID to clipboard |
+| `j` / `k` | Navigate sessions (in session list) |
+| `h` / `l` | Focus session list / transcript |
+| `left` / `right` | Focus session list / transcript |
+| `PageUp` / `PageDn` | Scroll transcript |
+| `Home` / `End` | Jump to top / bottom of transcript |
+
+### Sessions
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Focus reply input (or send if already focused) |
+| `/` | Focus reply input |
+| `Alt+Enter` | Insert newline in reply |
+| `Alt+j` / `Alt+k` | Navigate sessions while reply input is focused |
+| `Escape` | Cancel reply / exit selection mode |
 | `n` | Rename session |
-| `J`/`K` | Reorder sessions |
-| `t`/`T` | Cycle themes |
-| `r` | Refresh |
+| `g` | Copy `claude -r <id>` to clipboard |
+| `J` / `K` | Reorder sessions (move up/down) |
+| `Shift+Up` / `Shift+Down` | Reorder sessions (move up/down) |
+| `s` / `S` | Cycle session status forward / backward |
+| `a` | Toggle archive on selected session |
+| `A` | Show / hide archived sessions |
+
+### Message Selection (focus transcript first with `l`)
+
+| Key | Action |
+|-----|--------|
+| `m` | Enter / exit selection mode (starts at last message) |
+| `j` / `k` or `Down` / `Up` | Move selection between messages |
+| `Escape` | Exit selection mode |
+
+### Display
+
+| Key | Action |
+|-----|--------|
+| `t` / `T` | Cycle theme forward / backward |
+| `[` / `]` | Shrink / grow sidebar |
+| `r` | Refresh session list |
 | `q` | Quit |
 
 ## Roadmap
 
 - Cross-session search (SQLite FTS5, per-keystroke)
-- Message selection, copy, and export with source labels
-- Session tags — in progress / in review / done / archived
+- Range selection (`v`), clipboard copy (`y`), and temp-file export (`e`) with source labels
 - Project memory — append-only ledger of decisions, TODOs, ADRs
 - Handoff generation — compress a session into a brief via `/threadhop:handoff`
 - Codex support

--- a/threadhop
+++ b/threadhop
@@ -303,11 +303,11 @@ class TranscriptView(VerticalScroll):
             event.stop()
             event.prevent_default()
         elif self._selection_mode:
-            if event.key == "j":
+            if event.key in ("j", "down"):
                 self._select_next()
                 event.stop()
                 event.prevent_default()
-            elif event.key == "k":
+            elif event.key in ("k", "up"):
                 self._select_previous()
                 event.stop()
                 event.prevent_default()
@@ -321,9 +321,9 @@ class TranscriptView(VerticalScroll):
         if not messages:
             return
         self._selection_mode = True
-        self._selected_index = 0
+        # Start at the last message — recent context is usually what you want
+        self._selected_index = len(messages) - 1
         self._update_selection(messages)
-        self.border_title = "Transcript ── SELECT (j/k move, m/Esc exit)"
         self.app.notify("Selection mode: j/k to navigate, m or Esc to exit")
 
     def _exit_selection_mode(self):

--- a/threadhop
+++ b/threadhop
@@ -249,23 +249,35 @@ class SessionStatusHeader(ListItem):
         yield Static(f"── {label} ", classes="status-header")
 
 
-class UserMessage(Static):
+class _SelectableMessage(Static):
+    """Base for message widgets that participate in selection mode.
+
+    can_focus is deliberately False — focus stays on the parent
+    TranscriptView so its on_key handler receives all keypresses.
+    Highlighting is driven purely by the .message-selected CSS class.
+    """
+    can_focus = False
+
+
+class UserMessage(_SelectableMessage):
     """A user message in the transcript"""
-    can_focus = True
+    pass
 
 
-class AssistantMessage(Static):
+class AssistantMessage(_SelectableMessage):
     """An assistant message in the transcript"""
-    can_focus = True
+    pass
 
 
-class ToolMessage(Static):
+class ToolMessage(_SelectableMessage):
     """A tool call/result in the transcript"""
-    can_focus = True
+    pass
 
 
 class TranscriptView(VerticalScroll):
     """Shows full conversation from selected session"""
+
+    can_focus = True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -311,7 +323,8 @@ class TranscriptView(VerticalScroll):
         self._selection_mode = True
         self._selected_index = 0
         self._update_selection(messages)
-        self.border_title = "Transcript [SELECT]"
+        self.border_title = "Transcript ── SELECT (j/k move, m/Esc exit)"
+        self.app.notify("Selection mode: j/k to navigate, m or Esc to exit")
 
     def _exit_selection_mode(self):
         self._clear_selection()
@@ -342,6 +355,10 @@ class TranscriptView(VerticalScroll):
                 widget.scroll_visible()
             else:
                 widget.remove_class("message-selected")
+        # Update position counter in border title
+        total = len(messages)
+        pos = self._selected_index + 1
+        self.border_title = f"Transcript ── SELECT {pos}/{total} (j/k move, m/Esc exit)"
 
     def _clear_selection(self):
         for widget in self._get_message_widgets():
@@ -677,9 +694,13 @@ class ClaudeSessions(App):
         background: $accent;
     }
 
-    .message-selected {
-        background: $accent 25%;
+    /* Selection highlight — must override per-type border-left */
+    UserMessage.message-selected,
+    AssistantMessage.message-selected,
+    ToolMessage.message-selected {
+        background: $warning 20%;
         border-left: thick $warning;
+        tint: $warning 8%;
     }
 
     ToastRack {


### PR DESCRIPTION
## Summary
- Adds selection mode to `TranscriptView`: press `m` to enter (starts at last message), `j`/`k`/arrows to navigate, `Escape` or `m` to exit
- Selected message highlighted with `.message-selected` CSS (type-qualified selectors override per-type borders)
- Focus stays on `TranscriptView` via `_SelectableMessage` base class (`can_focus=False`) so all keypresses reach the `on_key` handler
- Border title shows position counter (`SELECT 3/40`) during navigation
- Toast notification with keybind hints on mode enter
- Selection auto-exits on transcript reload
- README keybindings section updated with all 28 current shortcuts, grouped by category

Implements Phase 2 task #5 per ADR-006 and ADR-008.

## Test plan
- [ ] Focus transcript (`l` or `→`), press `m` — last message highlights, border shows `SELECT N/N`
- [ ] `j`/`k` or `↓`/`↑` — selection moves, counter updates, auto-scrolls into view
- [ ] `Escape` or `m` — highlight clears, border reverts to `Transcript`
- [ ] Switch sessions while in selection mode — mode exits cleanly
- [ ] `j`/`k` in selection mode do NOT move the session list cursor
- [ ] Empty transcript: pressing `m` does nothing (no crash)
- [ ] README keybindings table matches actual app bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)