### PR TITLE
Fix selection mode killed by 5s refresh (regression)

### DIFF
--- a/threadhop
+++ b/threadhop
@@ -506,10 +506,9 @@ class TranscriptView(VerticalScroll):
 
     async def load_transcript(self, session_path: Path, force: bool = False):
         """Load and display full conversation from transcript"""
-        if self._selection_mode:
-            self._exit_selection_mode()
-
         if not session_path or not session_path.exists():
+            if self._selection_mode:
+                self._exit_selection_mode()
             await self._clear_and_show("No transcript available")
             return
 
@@ -520,10 +519,15 @@ class TranscriptView(VerticalScroll):
                 and session_path == self.current_path
                 and mtime == self._last_mtime
             ):
+                # File unchanged — keep selection mode alive
                 return
             self._last_mtime = mtime
         except:
             pass
+
+        # Transcript is actually reloading — exit selection mode now
+        if self._selection_mode:
+            self._exit_selection_mode()
 
         self.current_path = session_path
 


### PR DESCRIPTION
## Summary
- PR #14 (range selection refactor) moved `_exit_selection_mode()` to the top of `load_transcript`, before the mtime early-return check
- This caused the 5-second background refresh to exit selection mode every tick, even when the transcript file hadn't changed — the exact bug PR #12 originally fixed
- Restores the correct guard order: early-return on unchanged mtime first (preserving selection), exit selection only when the transcript actually reloads

## Test plan
- [x] Open a session, press `m` to enter selection mode
- [x] Wait >5 seconds — selection should persist (not get cleared)
- [x] Navigate with `j`/`k` — selection highlight should stay intact across refresh cycles
- [ ] Switch sessions — selection mode should exit (transcript reloads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)