### PR TITLE
Copy export path to clipboard on export

### DIFF
--- a/threadhop
+++ b/threadhop
@@ -600,9 +600,18 @@ class TranscriptView(VerticalScroll):
 
             count = len(selected)
             noun = "message" if count == 1 else "messages"
-            # Show full path so user can copy it for use in other sessions
+
+            # Copy the export path to clipboard so the user can paste it
+            # directly into another session (e.g. "Read /tmp/threadhop/...")
+            try:
+                subprocess.run(
+                    ["pbcopy"], input=str(export_path).encode(), check=True,
+                )
+            except Exception:
+                pass
+
             app.notify(
-                f"Exported {count} {noun} → {export_path}",
+                f"Exported {count} {noun} → {export_path} (path copied)",
                 timeout=10,
             )
         except Exception as e:


### PR DESCRIPTION
## Summary
- After exporting selected messages to a temp file via `e`, the full export path is now also copied to clipboard via `pbcopy`
- Notification updated to show "(path copied)" to confirm the clipboard action
- Users can immediately paste the path into another session (e.g. `Read /tmp/threadhop/...`)

## Test plan
- [ ] Enter selection mode (`m`), select messages, press `e`
- [ ] Verify file is written to `/tmp/threadhop/`
- [ ] Paste from clipboard — verify it's the full export path
- [ ] Verify notification shows "(path copied)" suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)