### PR TITLE
Preserve search highlights across 5s refresh + cross-project sessions (fix #14)

### DIFF
--- a/threadhop
+++ b/threadhop
@@ -299,6 +299,22 @@ class TranscriptView(VerticalScroll):
         # handler so the match position is visible inside long messages.
         self._pending_scroll_terms: list[str] | None = None
 
+        # Active highlight state — survives transcript reloads so the
+        # 5-second refresh cycle doesn't wipe out search highlights when
+        # the session file's mtime changes (e.g. claude is actively
+        # writing to it). Set in _scroll_to_uuid, cleared by a sidebar
+        # selection (App.on_list_view_highlighted).
+        self._active_highlight_uuid: str | None = None
+        self._active_highlight_terms: list[str] | None = None
+
+        # Foreign-session lock: non-None while showing a transcript
+        # whose source session isn't in the sidebar (cross-project or
+        # out-of-view search jump). Tells App.refresh_transcript to
+        # leave this transcript alone on auto-refresh ticks — otherwise
+        # the refresh would reload whatever the sidebar highlights and
+        # yank the user back to the original view.
+        self._foreign_session_path: Path | None = None
+
     def _get_message_widgets(self):
         """Return all message widgets in order."""
         return [
@@ -723,15 +739,28 @@ class TranscriptView(VerticalScroll):
         # Await mount to ensure all widgets are in the DOM before scrolling
         await self.mount_all(widgets)
 
-        # If the search panel queued a jump-to-source, honor it here —
-        # after the widgets are mounted. Otherwise scroll to the newest
-        # message as usual.
+        # Decide the post-mount scroll behavior, in priority order:
+        #
+        # 1. Search just handed us a jump-to-source → honor it.
+        # 2. A previous jump is still "active" (highlight state survived
+        #    into this reload, e.g. the 5-second refresh hit while the
+        #    user is still reading a match) → re-apply the highlight
+        #    so it isn't lost on every tick.
+        # 3. Normal reload → scroll to the bottom (live tail).
         if self._pending_scroll_uuid is not None:
             target = self._pending_scroll_uuid
             terms = self._pending_scroll_terms
             self._pending_scroll_uuid = None
             self._pending_scroll_terms = None
             self._scroll_to_uuid(target, terms)
+        elif (
+            self._active_highlight_uuid is not None
+            and self._active_highlight_terms
+        ):
+            self._scroll_to_uuid(
+                self._active_highlight_uuid,
+                self._active_highlight_terms,
+            )
         else:
             self.scroll_end(animate=False)
 
@@ -793,6 +822,14 @@ class TranscriptView(VerticalScroll):
                         pass
 
                 self.set_timer(1.5, clear_flash)
+
+                # Remember so we can re-apply after a refresh-driven
+                # reload (file mtime changed) without losing the match
+                # anchor. Cleared by sidebar navigation.
+                self._active_highlight_uuid = uuid
+                self._active_highlight_terms = (
+                    list(search_terms) if search_terms else None
+                )
                 return True
         return False
 
@@ -2224,11 +2261,20 @@ class ClaudeSessions(App):
                                 pass
 
     def refresh_transcript(self) -> None:
+        transcript = self.query_one("#transcript-scroll", TranscriptView)
+
+        # Foreign-session lock: the user jumped from search to a session
+        # that isn't in the sidebar. The sidebar highlight still points
+        # at the ORIGINAL session, so reloading from it here would yank
+        # the transcript panel back to that original — wiping out what
+        # the user is actually reading. Skip the refresh in that case.
+        if transcript._foreign_session_path is not None:
+            return
+
         list_view = self.query_one("#session-list", ListView)
         if list_view.highlighted_child and isinstance(
             list_view.highlighted_child, SessionItem
         ):
-            transcript = self.query_one("#transcript-scroll", TranscriptView)
             # Schedule the async load
             self.call_later(
                 transcript.load_transcript,
@@ -2242,6 +2288,15 @@ class ClaudeSessions(App):
     async def on_list_view_selected(self, event: ListView.Selected) -> None:
         if isinstance(event.item, SessionItem):
             transcript = self.query_one("#transcript-scroll", TranscriptView)
+
+            # Explicit sidebar selection (click / Enter) always ends a
+            # foreign-session search jump, even when the user re-selects
+            # the row that was already highlighted — Highlighted doesn't
+            # fire in that case, but Selected does.
+            transcript._foreign_session_path = None
+            transcript._active_highlight_uuid = None
+            transcript._active_highlight_terms = None
+
             await transcript.load_transcript(event.item.session_data["path"])
 
     async def on_list_view_highlighted(self, event: ListView.Highlighted) -> None:
@@ -2249,6 +2304,17 @@ class ClaudeSessions(App):
             session_id = event.item.session_data.get("session_id")
             self._selected_session_id = session_id
             transcript = self.query_one("#transcript-scroll", TranscriptView)
+
+            # Manual sidebar navigation ends any in-progress search-jump
+            # context. Clear the foreign-session lock AND the active
+            # highlight state so the 5s auto-refresh can resume and new
+            # reloads don't try to re-apply stale highlights. The
+            # search-flow sets these fresh after this handler runs, via
+            # queue_scroll_to_uuid, so same-sidebar jumps aren't broken.
+            transcript._foreign_session_path = None
+            transcript._active_highlight_uuid = None
+            transcript._active_highlight_terms = None
+
             await transcript.load_transcript(event.item.session_data["path"])
 
             if "last_viewed" not in self.config:
@@ -2423,7 +2489,9 @@ class ClaudeSessions(App):
                 break
 
         if target_idx is not None:
-            # Case 1 & 2: session is in the sidebar.
+            # Case 1 & 2: session is in the sidebar. Clear any stale
+            # foreign-session lock from a previous cross-project jump.
+            transcript._foreign_session_path = None
             if list_view.index == target_idx:
                 transcript._pending_scroll_uuid = None
                 transcript._pending_scroll_terms = None
@@ -2456,6 +2524,10 @@ class ClaudeSessions(App):
             return
 
         self._selected_session_id = session_id
+        # Lock the foreign session in so the 5s refresh tick doesn't
+        # reload the sidebar's selection over the top of this panel.
+        # Cleared by the user selecting anything in the sidebar.
+        transcript._foreign_session_path = session_path
         transcript.queue_scroll_to_uuid(message_uuid, search_terms)
         # load_transcript is async; schedule and let the pending scroll
         # fire at the end of the load.


### PR DESCRIPTION
Follow-up to #22. Feedback: search highlights + scroll position vanish ~5 seconds after jumping, reverting to the pre-search view.

## Root cause

Two interacting failure modes from the 5-second `auto_refresh_background` cycle:

### 1. Cross-project jump reverts
`refresh_transcript()` reloads using `list_view.highlighted_child.session_data["path"]`. After a cross-project search jump, the sidebar still highlights the ORIGINAL session, so the refresh tick silently reloads that one over the top of the foreign transcript — the user is yanked back to where they started.

### 2. Same-session with active claude rebuilds widgets
When the session file's mtime changes (claude appended a new message), `load_transcript` skips its mtime short-circuit and rebuilds all message widgets from scratch. The highlights lived only in the widget contents, so they're wiped on every reload.

## Fix
Hoist the jump context onto `TranscriptView` so reloads can restore it:

- **`_foreign_session_path`**: set when the jumped-to session isn't in the sidebar. `refresh_transcript()` early-returns when it's set, leaving the panel alone. Cleared by sidebar `Highlighted` (arrow keys) or `Selected` (click).
- **`_active_highlight_uuid` / `_active_highlight_terms`**: remembered by `_scroll_to_uuid` after a successful jump. `load_transcript` re-applies them post-mount when no new pending scroll is queued, so a refresh-driven reload restores the inline highlights + scroll position instead of jumping to the tail. Cleared by sidebar nav, same as above.

## Decision tree in `load_transcript`
1. Pending scroll from a fresh jump? → apply, stash as active.
2. Active highlight from a prior jump? → re-apply (refresh didn't undo our work).
3. Neither? → normal behavior, `scroll_end` for live-tail.

## Test plan
- [x] `pytest tests/ -q` → 53 passed
- [x] Headless pilot — same-session: force a reload after jump, verify `_active_highlight_*` state is preserved and re-applied ✓
- [x] Headless pilot — cross-project: jump to `beta` session from `alpha`-scoped sidebar, tick `refresh_transcript()`, verify foreign transcript still visible (uuids don't change) ✓
- [ ] Manual smoke test in a real terminal with an active claude session

🤖 Generated with [Claude Code](https://claude.com/claude-code)