### PR TITLE
Observer core function + cleaned-transcript prompt (task #18)

### DIFF
--- a/indexer.py
+++ b/indexer.py
@@ -355,6 +355,132 @@ def index_all(
 # --- Incremental indexing (task #9) ----------------------------------------
 
 
+def parse_byte_range(
+    raw_bytes: bytes,
+    *,
+    fallback_session_id: str | None = None,
+) -> list[dict]:
+    """Parse a JSONL byte range into cleaned message groups.
+
+    Applies ADR-003 chunk-merging (consecutive assistant lines sharing
+    ``message.id`` collapse into one row), strips ``<system-reminder>``
+    blocks, skips tool-result user lines, and abbreviates ``tool_use``
+    blocks. Empty rows (a line that reduced to nothing after cleaning)
+    are dropped.
+
+    Callers are expected to trim any trailing partial line before
+    calling — see ``index_session_incremental`` for how to do that with
+    a byte offset. Malformed JSON lines are silently skipped.
+
+    Returns one dict per logical message with the same shape
+    ``index_session_incremental`` writes to ``messages``::
+
+        {"uuid", "session_id", "role", "text", "timestamp",
+         "cwd", "parent_uuid", "is_sidechain", "message_id"}
+
+    ``fallback_session_id`` is substituted when a line omits its own
+    ``sessionId`` (rare, but happens on older transcripts).
+
+    Extracted as a public helper so the observer (ADR-018) can reuse
+    the exact rendering the FTS index uses — "observer sees what the
+    user sees."
+    """
+    raw_lines = raw_bytes.decode("utf-8", errors="replace").split("\n")
+    # split() on "line1\nline2\n" → ["line1", "line2", ""] — drop trailing empty.
+    if raw_lines and raw_lines[-1] == "":
+        raw_lines.pop()
+
+    groups: list[dict] = []
+    current_chunk: dict | None = None
+    current_chunk_parts: list[str] = []
+
+    def _flush_chunk() -> None:
+        nonlocal current_chunk, current_chunk_parts
+        if current_chunk is not None:
+            current_chunk["text"] = "\n\n".join(
+                p for p in current_chunk_parts if p
+            ).strip()
+            if current_chunk["text"]:
+                groups.append(current_chunk)
+            current_chunk = None
+            current_chunk_parts = []
+
+    for raw_line in raw_lines:
+        if not raw_line.strip():
+            continue
+        try:
+            msg = json.loads(raw_line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+        mtype = msg.get("type")
+        if mtype not in ("user", "assistant"):
+            continue
+
+        if mtype == "user":
+            _flush_chunk()
+
+            text = _extract_user_text(msg)
+            if not text:
+                continue
+
+            uid = msg.get("uuid")
+            sid = msg.get("sessionId") or fallback_session_id
+            if not uid:
+                continue
+
+            groups.append({
+                "uuid": uid,
+                "session_id": sid,
+                "role": "user",
+                "text": text,
+                "timestamp": msg.get("timestamp"),
+                "cwd": msg.get("cwd"),
+                "parent_uuid": msg.get("parentUuid"),
+                "is_sidechain": 1 if msg.get("isSidechain") else 0,
+                "message_id": msg.get("message", {}).get("id"),
+            })
+            continue
+
+        # --- assistant line ---
+        mid = msg.get("message", {}).get("id")
+        parts = _extract_assistant_blocks(msg)
+
+        # Continuing the same logical message → accumulate.
+        if (
+            mid is not None
+            and current_chunk is not None
+            and current_chunk.get("message_id") == mid
+        ):
+            current_chunk_parts.extend(parts)
+            continue
+
+        # Different message.id → flush previous and start fresh.
+        _flush_chunk()
+
+        uid = msg.get("uuid")
+        sid = msg.get("sessionId") or fallback_session_id
+        if not uid:
+            continue
+
+        current_chunk = {
+            "uuid": uid,
+            "session_id": sid,
+            "role": "assistant",
+            "text": "",  # populated by _flush_chunk
+            "timestamp": msg.get("timestamp"),
+            "cwd": msg.get("cwd"),
+            "parent_uuid": msg.get("parentUuid"),
+            "is_sidechain": 1 if msg.get("isSidechain") else 0,
+            "message_id": mid,
+        }
+        current_chunk_parts = list(parts)
+
+    # Flush the last chunk.
+    _flush_chunk()
+    return groups
+
+
 def index_session_incremental(
     conn: sqlite3.Connection,
     session_id: str,
@@ -363,9 +489,9 @@ def index_session_incremental(
     """Incrementally index new JSONL content for a session.
 
     Called from the TUI's 5-second refresh cycle.  Reads only bytes
-    appended since the last index, parses new lines, applies the same
-    chunk-merging logic as ``parse_messages``, and upserts into the
-    ``messages`` + ``messages_fts`` tables.
+    appended since the last index, parses new lines via
+    ``parse_byte_range``, and upserts into the ``messages`` +
+    ``messages_fts`` tables.
 
     Edge cases:
 
@@ -418,111 +544,9 @@ def index_session_incremental(
     processable = new_bytes[: last_newline + 1]
     new_offset = last_offset + last_newline + 1
 
-    # --- Parse raw lines ---
-    raw_lines = processable.decode("utf-8", errors="replace").split("\n")
-    # split() on "line1\nline2\n" → ["line1", "line2", ""] — drop trailing empty
-    if raw_lines and raw_lines[-1] == "":
-        raw_lines.pop()
-
-    if not raw_lines:
-        db.upsert_index_state(
-            conn, session_id, str(file_path), new_offset,
-            _dt.now().timestamp(),
-        )
-        return
-
-    # --- Group messages with chunk merging (ADR-003) ---
-    # Reuses the same extraction helpers as parse_messages but reads from
-    # a byte range instead of the full file.
-
-    parsed_groups: list[dict] = []
-    current_chunk: dict | None = None
-    current_chunk_parts: list[str] = []
-
-    def _flush_chunk() -> None:
-        nonlocal current_chunk, current_chunk_parts
-        if current_chunk is not None:
-            current_chunk["text"] = "\n\n".join(
-                p for p in current_chunk_parts if p
-            ).strip()
-            if current_chunk["text"]:
-                parsed_groups.append(current_chunk)
-            current_chunk = None
-            current_chunk_parts = []
-
-    for raw_line in raw_lines:
-        if not raw_line.strip():
-            continue
-        try:
-            msg = json.loads(raw_line)
-        except (json.JSONDecodeError, ValueError):
-            continue
-
-        mtype = msg.get("type")
-        if mtype not in ("user", "assistant"):
-            continue
-
-        if mtype == "user":
-            _flush_chunk()
-
-            text = _extract_user_text(msg)
-            if not text:
-                continue
-
-            uid = msg.get("uuid")
-            sid = msg.get("sessionId") or session_id
-            if not uid:
-                continue
-
-            parsed_groups.append({
-                "uuid": uid,
-                "session_id": sid,
-                "role": "user",
-                "text": text,
-                "timestamp": msg.get("timestamp"),
-                "cwd": msg.get("cwd"),
-                "parent_uuid": msg.get("parentUuid"),
-                "is_sidechain": 1 if msg.get("isSidechain") else 0,
-                "message_id": msg.get("message", {}).get("id"),
-            })
-            continue
-
-        # --- assistant line ---
-        mid = msg.get("message", {}).get("id")
-        parts = _extract_assistant_blocks(msg)
-
-        # Continuing the same logical message → accumulate.
-        if (
-            mid is not None
-            and current_chunk is not None
-            and current_chunk.get("message_id") == mid
-        ):
-            current_chunk_parts.extend(parts)
-            continue
-
-        # Different message.id → flush previous and start fresh.
-        _flush_chunk()
-
-        uid = msg.get("uuid")
-        sid = msg.get("sessionId") or session_id
-        if not uid:
-            continue
-
-        current_chunk = {
-            "uuid": uid,
-            "session_id": sid,
-            "role": "assistant",
-            "text": "",  # populated by _flush_chunk
-            "timestamp": msg.get("timestamp"),
-            "cwd": msg.get("cwd"),
-            "parent_uuid": msg.get("parentUuid"),
-            "is_sidechain": 1 if msg.get("isSidechain") else 0,
-            "message_id": mid,
-        }
-        current_chunk_parts = list(parts)
-
-    # Flush the last chunk.
-    _flush_chunk()
+    parsed_groups = parse_byte_range(
+        processable, fallback_session_id=session_id,
+    )
 
     if not parsed_groups:
         db.upsert_index_state(

--- a/observer.py
+++ b/observer.py
@@ -8,12 +8,16 @@ indicator, and CLI query commands). It is an **orchestrator**, not just a
   1. Read the per-session ``observation_state`` row to find where the last
      run left off (``source_byte_offset``).
   2. Open the source JSONL, seek to that offset, read to EOF.
-  3. Count *message turns* in the new bytes (user lines + assistant
-     ``message.id`` groups — streaming chunks are one turn, not many).
+  3. Parse the new bytes via ``indexer.parse_byte_range`` — same pipeline
+     that feeds the FTS index and the TUI. Tool outputs are already
+     filtered out, ``<system-reminder>`` blocks stripped, ``tool_use``
+     blocks rendered as one-line abbreviations, streaming chunks merged.
+     The observer sees exactly what the user sees.
   4. If fewer than ``BATCH_THRESHOLD`` new turns accumulated, return early —
      Haiku with two turns of context tends to hallucinate or extract trivia.
-  5. Assemble the prompt: ``prompts/observer.md`` + the chunk + the output
-     file path (``~/.config/threadhop/observations/<session_id>.jsonl``).
+  5. Format the cleaned turns as a readable role-labelled transcript and
+     splice it into ``prompts/observer.md`` along with the output file
+     path (``~/.config/threadhop/observations/<session_id>.jsonl``).
   6. Invoke ``claude -p --model haiku --permission-mode acceptEdits`` — the
      Haiku process appends JSONL observations to the output file itself
      (``acceptEdits`` is the minimum permission required for file append).
@@ -41,6 +45,7 @@ from pathlib import Path
 from typing import Any
 
 import db
+import indexer
 
 
 # --- Configuration --------------------------------------------------------
@@ -67,44 +72,32 @@ _TYPE_ORDER = ("decision", "todo", "done", "adr", "observation", "conflict")
 # --- Helpers --------------------------------------------------------------
 
 
-def _count_message_turns(raw: bytes) -> int:
-    """Count distinct user/assistant turns in a JSONL byte range.
+def _format_transcript(turns: list[dict]) -> str:
+    """Render cleaned message turns as a role-labelled transcript.
 
-    Mirrors ADR-003 chunk-merging: consecutive assistant lines sharing the
-    same ``message.id`` are one logical turn. User lines carrying a
-    ``toolUseResult`` are tool output (not user speech) and don't count.
-    Malformed JSON lines are skipped silently — the observer shouldn't
-    refuse to run just because one line is corrupt.
+    Each turn becomes a markdown-ish block::
+
+        ### user · 2026-04-17T10:00:00Z
+        <cleaned text>
+
+        ### assistant · 2026-04-17T10:00:01Z
+        <cleaned text with [Editing foo.py] style tool-use abbreviations>
+
+    Chosen over JSONL-per-turn because field names repeated per line would
+    waste tokens on no new information, and Haiku reasons more reliably
+    about a transcript-shaped input. Timestamps are kept so the prompt's
+    ``ts`` field requirement (ADR-018) has an authoritative source.
     """
-    turns = 0
-    last_assistant_mid: str | None = None
-
-    for line in raw.decode("utf-8", errors="replace").splitlines():
-        if not line.strip():
+    blocks: list[str] = []
+    for turn in turns:
+        role = turn.get("role", "user")
+        ts = turn.get("timestamp") or ""
+        header = f"### {role} · {ts}" if ts else f"### {role}"
+        text = (turn.get("text") or "").strip()
+        if not text:
             continue
-        try:
-            msg = json.loads(line)
-        except (json.JSONDecodeError, ValueError):
-            continue
-
-        mtype = msg.get("type")
-        if mtype == "user":
-            # Tool results arrive as ``type: "user"`` with ``toolUseResult``
-            # — they're machine output, not a user turn.
-            if msg.get("toolUseResult") is not None:
-                continue
-            turns += 1
-            last_assistant_mid = None
-        elif mtype == "assistant":
-            mid = msg.get("message", {}).get("id")
-            # Group streaming chunks: only the *first* chunk of a new
-            # message.id counts as a turn.
-            if mid is None or mid != last_assistant_mid:
-                turns += 1
-                last_assistant_mid = mid
-        # Other line types (summary, ai-title, system) don't contribute.
-
-    return turns
+        blocks.append(f"{header}\n{text}")
+    return "\n\n".join(blocks)
 
 
 def _read_new_bytes(
@@ -193,22 +186,20 @@ def _summary_message(turns: int, by_type: dict[str, int]) -> str:
     return f"Processed {turns} {turns_label}. {tail}."
 
 
-def _build_prompt(template: str, chunk: bytes, obs_path: Path) -> str:
-    """Splice the conversation chunk and output path into the prompt.
+def _build_prompt(template: str, transcript: str, obs_path: Path) -> str:
+    """Splice the cleaned transcript and output path into the prompt.
 
     Kept as plain string concat rather than a template engine — the
     observer prompt is a markdown file curated as part of the app, and
-    the only substitutions are the chunk body and the file path.
+    the only substitutions are the transcript body and the file path.
     """
-    chunk_text = chunk.decode("utf-8", errors="replace")
     return (
         f"{template.rstrip()}\n\n"
         "---\n\n"
         "## Conversation chunk\n\n"
         "<session_chunk>\n"
-        f"{chunk_text}"
-        + ("" if chunk_text.endswith("\n") else "\n")
-        + "</session_chunk>\n\n"
+        f"{transcript.strip()}\n"
+        "</session_chunk>\n\n"
         "## Output file\n\n"
         f"Append observations to: {obs_path}\n"
     )
@@ -335,7 +326,16 @@ def observe_session(
         offset = 0
 
     new_bytes, new_offset = _read_new_bytes(source_path, offset)
-    turns = _count_message_turns(new_bytes)
+
+    # Parse the new bytes through the same pipeline the FTS index uses
+    # (indexer.parse_byte_range): tool outputs dropped, system-reminders
+    # stripped, tool_use abbreviated, streaming chunks merged. This keeps
+    # Haiku's input token count small and ensures the observer reasons
+    # about the same view of the conversation the user reads in the TUI.
+    message_turns = indexer.parse_byte_range(
+        new_bytes, fallback_session_id=session_id,
+    )
+    turns = len(message_turns)
 
     # Ensure the observations directory exists before we risk any writes.
     db.OBS_DIR.mkdir(parents=True, exist_ok=True)
@@ -377,7 +377,8 @@ def observe_session(
             "error": f"read prompt {prompt_path}: {e}",
             "message": f"Could not read observer prompt: {e}",
         }
-    prompt = _build_prompt(prompt_template, new_bytes, obs_path)
+    transcript = _format_transcript(message_turns)
+    prompt = _build_prompt(prompt_template, transcript, obs_path)
 
     # --- Step 5: invoke claude -p -----------------------------------------
     # ``shutil.which`` gives a precise error before we pay for the fork.

--- a/observer.py
+++ b/observer.py
@@ -1,0 +1,484 @@
+"""Observer core function — extracts typed observations from session JSONL.
+
+This is the single observer used by every entry point (CLI ``threadhop
+observe``, the ``/threadhop:observe`` skill, ``/threadhop:handoff``, the TUI
+indicator, and CLI query commands). It is an **orchestrator**, not just a
+``claude -p`` wrapper — per ADR-018:
+
+  1. Read the per-session ``observation_state`` row to find where the last
+     run left off (``source_byte_offset``).
+  2. Open the source JSONL, seek to that offset, read to EOF.
+  3. Count *message turns* in the new bytes (user lines + assistant
+     ``message.id`` groups — streaming chunks are one turn, not many).
+  4. If fewer than ``BATCH_THRESHOLD`` new turns accumulated, return early —
+     Haiku with two turns of context tends to hallucinate or extract trivia.
+  5. Assemble the prompt: ``prompts/observer.md`` + the chunk + the output
+     file path (``~/.config/threadhop/observations/<session_id>.jsonl``).
+  6. Invoke ``claude -p --model haiku --permission-mode acceptEdits`` — the
+     Haiku process appends JSONL observations to the output file itself
+     (``acceptEdits`` is the minimum permission required for file append).
+  7. Diff the observation file line count before/after to compute how many
+     new entries were written, then advance ``source_byte_offset`` and
+     ``entry_count`` in SQLite via ``db.upsert_observation_state``.
+
+Per ADR-019: per-session observation files. Per ADR-020: observer and
+reflector share one file — the reflector appends ``type: "conflict"``
+entries to the same JSONL.
+
+Public API::
+
+    observe_session(conn, session_id, ...) -> dict
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import db
+
+
+# --- Configuration --------------------------------------------------------
+
+# Minimum human/assistant turns in a new chunk before extraction runs.
+# Below this, observer returns early — two-turn chunks don't contain enough
+# context for Haiku to distinguish a real decision from idle chatter, and
+# paying for the call just to get zero entries is wasteful.
+BATCH_THRESHOLD = 3
+
+# Location of the shared observer prompt. Bundled with the app — the runtime
+# does not need anything in ``~/.config/threadhop/prompts/``.
+PROMPT_PATH = Path(__file__).resolve().parent / "prompts" / "observer.md"
+
+# Default subprocess timeout. Haiku usually responds in seconds, but the
+# first call of a session can pay an auth/warmup cost, and extremely large
+# chunks (first-time catch-up on a long transcript) take longer.
+DEFAULT_TIMEOUT_SEC = 180.0
+
+# Known observation types, in display order for the summary line.
+_TYPE_ORDER = ("decision", "todo", "done", "adr", "observation", "conflict")
+
+
+# --- Helpers --------------------------------------------------------------
+
+
+def _count_message_turns(raw: bytes) -> int:
+    """Count distinct user/assistant turns in a JSONL byte range.
+
+    Mirrors ADR-003 chunk-merging: consecutive assistant lines sharing the
+    same ``message.id`` are one logical turn. User lines carrying a
+    ``toolUseResult`` are tool output (not user speech) and don't count.
+    Malformed JSON lines are skipped silently — the observer shouldn't
+    refuse to run just because one line is corrupt.
+    """
+    turns = 0
+    last_assistant_mid: str | None = None
+
+    for line in raw.decode("utf-8", errors="replace").splitlines():
+        if not line.strip():
+            continue
+        try:
+            msg = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+        mtype = msg.get("type")
+        if mtype == "user":
+            # Tool results arrive as ``type: "user"`` with ``toolUseResult``
+            # — they're machine output, not a user turn.
+            if msg.get("toolUseResult") is not None:
+                continue
+            turns += 1
+            last_assistant_mid = None
+        elif mtype == "assistant":
+            mid = msg.get("message", {}).get("id")
+            # Group streaming chunks: only the *first* chunk of a new
+            # message.id counts as a turn.
+            if mid is None or mid != last_assistant_mid:
+                turns += 1
+                last_assistant_mid = mid
+        # Other line types (summary, ai-title, system) don't contribute.
+
+    return turns
+
+
+def _read_new_bytes(
+    source_path: Path, offset: int
+) -> tuple[bytes, int]:
+    """Read from ``offset`` to the last complete newline.
+
+    Mirrors the indexer's partial-line guard: if the session is actively
+    being written, the tail may be mid-line — stop at the last ``\\n`` so
+    the trailing partial line is picked up on the next run.
+
+    Returns ``(processable_bytes, new_offset)``. ``new_offset`` is
+    unchanged if no complete line is available yet.
+    """
+    try:
+        with open(source_path, "rb") as f:
+            f.seek(offset)
+            raw = f.read()
+    except OSError:
+        return b"", offset
+
+    if not raw:
+        return b"", offset
+    last_newline = raw.rfind(b"\n")
+    if last_newline == -1:
+        return b"", offset
+    return raw[: last_newline + 1], offset + last_newline + 1
+
+
+def _count_obs_lines(obs_path: Path) -> int:
+    """Count non-empty lines in the observation JSONL (entry count)."""
+    if not obs_path.exists():
+        return 0
+    count = 0
+    with open(obs_path, "rb") as f:
+        for line in f:
+            if line.strip():
+                count += 1
+    return count
+
+
+def _count_new_entries_by_type(
+    obs_path: Path, skip_lines: int
+) -> dict[str, int]:
+    """Parse observation lines after ``skip_lines``, grouping by ``type``.
+
+    ``skip_lines`` is the line count recorded before the extraction ran;
+    anything past it was written by the current invocation (the file is
+    append-only per ADR-020, so this diff is safe).
+    """
+    counts: dict[str, int] = {}
+    if not obs_path.exists():
+        return counts
+    with open(obs_path) as f:
+        for i, line in enumerate(f):
+            if i < skip_lines:
+                continue
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            t = entry.get("type")
+            if isinstance(t, str):
+                counts[t] = counts.get(t, 0) + 1
+    return counts
+
+
+def _summary_message(turns: int, by_type: dict[str, int]) -> str:
+    """Format the human-readable summary line returned to the caller."""
+    parts: list[str] = []
+    for key in _TYPE_ORDER:
+        n = by_type.get(key, 0)
+        if n:
+            label = key if n == 1 else f"{key}s"
+            parts.append(f"{n} {label}")
+    # Extras Haiku invented (unlikely but defensive).
+    for key, n in by_type.items():
+        if key in _TYPE_ORDER or not n:
+            continue
+        parts.append(f"{n} {key}")
+    tail = ", ".join(parts) if parts else "no new observations"
+    turns_label = "turn" if turns == 1 else "turns"
+    return f"Processed {turns} {turns_label}. {tail}."
+
+
+def _build_prompt(template: str, chunk: bytes, obs_path: Path) -> str:
+    """Splice the conversation chunk and output path into the prompt.
+
+    Kept as plain string concat rather than a template engine — the
+    observer prompt is a markdown file curated as part of the app, and
+    the only substitutions are the chunk body and the file path.
+    """
+    chunk_text = chunk.decode("utf-8", errors="replace")
+    return (
+        f"{template.rstrip()}\n\n"
+        "---\n\n"
+        "## Conversation chunk\n\n"
+        "<session_chunk>\n"
+        f"{chunk_text}"
+        + ("" if chunk_text.endswith("\n") else "\n")
+        + "</session_chunk>\n\n"
+        "## Output file\n\n"
+        f"Append observations to: {obs_path}\n"
+    )
+
+
+# --- Main entry point -----------------------------------------------------
+
+
+def observe_session(
+    conn: sqlite3.Connection,
+    session_id: str,
+    *,
+    source_path: str | Path | None = None,
+    batch_threshold: int = BATCH_THRESHOLD,
+    claude_bin: str = "claude",
+    timeout: float = DEFAULT_TIMEOUT_SEC,
+    prompt_path: Path | None = None,
+) -> dict[str, Any]:
+    """Run one observer extraction pass for ``session_id``.
+
+    Args:
+        conn: Open DB connection with the schema applied.
+        session_id: Claude Code session UUID to observe.
+        source_path: Override for the source JSONL. Normally resolved from
+            the ``observation_state`` row (on resume) or the ``sessions``
+            row (on first observation). Passing this explicitly is mostly
+            useful for tests.
+        batch_threshold: Minimum number of new message turns required for
+            a Haiku call. Below this, the function returns without
+            invoking Claude and without advancing ``source_byte_offset``.
+        claude_bin: Name or path of the ``claude`` CLI binary. Tests pass
+            a fake shim that writes the expected observation JSONL.
+        timeout: Subprocess timeout for the Haiku call (seconds).
+        prompt_path: Override for the observer prompt file location.
+            Defaults to ``prompts/observer.md`` next to this module.
+
+    Returns:
+        A summary dict::
+
+            {
+              "status":  "extracted" | "up_to_date" | "below_threshold"
+                         | "no_source" | "failed",
+              "turns":   <int>,
+              "new_entries": <int>,
+              "by_type": {"decision": N, "todo": M, ...},
+              "source_byte_offset": <int>,  # post-run cursor
+              "entry_count": <int>,         # total lines in obs file
+              "obs_path": <str>,
+              "message": <human-readable summary>,
+              # on status == "failed":
+              "error": <str>,
+              "stderr": <str>,   # present when stderr was captured
+            }
+
+        Never raises on expected failures (subprocess error, missing
+        source file, etc.) — callers branch on ``status``.
+    """
+    prompt_path = prompt_path or PROMPT_PATH
+
+    # --- Step 1: load state, or seed it from the sessions table -----------
+    state = db.get_observation_state(conn, session_id)
+
+    if state is None:
+        # First observation for this session. Resolve source_path from
+        # the sessions row unless the caller supplied one.
+        if source_path is None:
+            sess = db.get_session(conn, session_id)
+            if sess is None or not sess.get("session_path"):
+                return {
+                    "status": "no_source",
+                    "turns": 0,
+                    "new_entries": 0,
+                    "by_type": {},
+                    "source_byte_offset": 0,
+                    "entry_count": 0,
+                    "obs_path": "",
+                    "message": (
+                        f"No source JSONL known for session {session_id}"
+                    ),
+                }
+            source_path = sess["session_path"]
+        source_path = Path(source_path)
+        obs_path = db.OBS_DIR / f"{session_id}.jsonl"
+        offset = 0
+    else:
+        # Resume from recorded cursor. ``source_path`` override is honoured
+        # (tests / file moves) but obs_path is always the recorded one.
+        source_path = Path(source_path or state["source_path"])
+        obs_path = Path(state["obs_path"])
+        offset = int(state["source_byte_offset"])
+
+    if not source_path.exists():
+        return {
+            "status": "no_source",
+            "turns": 0,
+            "new_entries": 0,
+            "by_type": {},
+            "source_byte_offset": offset,
+            "entry_count": int(state["entry_count"]) if state else 0,
+            "obs_path": str(obs_path),
+            "message": f"Source JSONL not found: {source_path}",
+        }
+
+    # --- Step 2: read new bytes -------------------------------------------
+    try:
+        file_size = source_path.stat().st_size
+    except OSError as e:
+        return {
+            "status": "failed",
+            "turns": 0,
+            "new_entries": 0,
+            "by_type": {},
+            "source_byte_offset": offset,
+            "entry_count": int(state["entry_count"]) if state else 0,
+            "obs_path": str(obs_path),
+            "error": f"stat {source_path}: {e}",
+            "message": f"Could not stat source JSONL: {e}",
+        }
+
+    # Truncation / rotation: re-read from byte 0. Observations already
+    # written stay — they're append-only per ADR-020 — but the cursor has
+    # to rewind since the old offset is past the new EOF.
+    if file_size < offset:
+        offset = 0
+
+    new_bytes, new_offset = _read_new_bytes(source_path, offset)
+    turns = _count_message_turns(new_bytes)
+
+    # Ensure the observations directory exists before we risk any writes.
+    db.OBS_DIR.mkdir(parents=True, exist_ok=True)
+
+    # --- Step 3: threshold check ------------------------------------------
+    if turns < batch_threshold:
+        # No state change: we want the next run to re-read the same bytes
+        # (plus whatever else has arrived) and try to clear the threshold.
+        existing_entries = (
+            int(state["entry_count"]) if state
+            else _count_obs_lines(obs_path)
+        )
+        return {
+            "status": "up_to_date" if turns == 0 else "below_threshold",
+            "turns": turns,
+            "new_entries": 0,
+            "by_type": {},
+            "source_byte_offset": offset,
+            "entry_count": existing_entries,
+            "obs_path": str(obs_path),
+            "message": (
+                "Already up to date." if turns == 0
+                else f"Only {turns} new turn(s) — need {batch_threshold}."
+            ),
+        }
+
+    # --- Step 4: assemble the prompt --------------------------------------
+    try:
+        prompt_template = prompt_path.read_text()
+    except OSError as e:
+        return {
+            "status": "failed",
+            "turns": turns,
+            "new_entries": 0,
+            "by_type": {},
+            "source_byte_offset": offset,
+            "entry_count": _count_obs_lines(obs_path),
+            "obs_path": str(obs_path),
+            "error": f"read prompt {prompt_path}: {e}",
+            "message": f"Could not read observer prompt: {e}",
+        }
+    prompt = _build_prompt(prompt_template, new_bytes, obs_path)
+
+    # --- Step 5: invoke claude -p -----------------------------------------
+    # ``shutil.which`` gives a precise error before we pay for the fork.
+    if shutil.which(claude_bin) is None and not Path(claude_bin).exists():
+        return {
+            "status": "failed",
+            "turns": turns,
+            "new_entries": 0,
+            "by_type": {},
+            "source_byte_offset": offset,
+            "entry_count": _count_obs_lines(obs_path),
+            "obs_path": str(obs_path),
+            "error": f"{claude_bin} not found on PATH",
+            "message": f"Could not find {claude_bin} on PATH.",
+        }
+
+    before_count = _count_obs_lines(obs_path)
+    try:
+        proc = subprocess.run(
+            [
+                claude_bin, "-p", prompt,
+                "--model", "haiku",
+                "--permission-mode", "acceptEdits",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "status": "failed",
+            "turns": turns,
+            "new_entries": 0,
+            "by_type": {},
+            "source_byte_offset": offset,
+            "entry_count": before_count,
+            "obs_path": str(obs_path),
+            "error": f"claude -p timed out after {timeout}s",
+            "message": f"claude -p timed out after {timeout}s.",
+        }
+    except OSError as e:
+        return {
+            "status": "failed",
+            "turns": turns,
+            "new_entries": 0,
+            "by_type": {},
+            "source_byte_offset": offset,
+            "entry_count": before_count,
+            "obs_path": str(obs_path),
+            "error": f"claude -p failed to start: {e}",
+            "message": f"Could not invoke {claude_bin}: {e}",
+        }
+
+    if proc.returncode != 0:
+        return {
+            "status": "failed",
+            "turns": turns,
+            "new_entries": 0,
+            "by_type": {},
+            "source_byte_offset": offset,
+            "entry_count": before_count,
+            "obs_path": str(obs_path),
+            "error": f"claude -p exited {proc.returncode}",
+            "stderr": (proc.stderr or "").strip(),
+            "message": (
+                f"claude -p exited {proc.returncode}. "
+                "State not advanced; next run will retry from same offset."
+            ),
+        }
+
+    # --- Step 6: diff observation file, advance state ---------------------
+    after_count = _count_obs_lines(obs_path)
+    new_entries = max(0, after_count - before_count)
+    by_type = (
+        _count_new_entries_by_type(obs_path, before_count)
+        if new_entries else {}
+    )
+
+    now = datetime.now().timestamp()
+    db.upsert_observation_state(
+        conn,
+        session_id,
+        str(source_path),
+        str(obs_path),
+        source_byte_offset=new_offset,
+        entry_count=after_count,
+        reflector_entry_offset=(
+            int(state["reflector_entry_offset"]) if state else 0
+        ),
+        last_observed_at=now,
+    )
+
+    # --- Step 7: summary --------------------------------------------------
+    return {
+        "status": "extracted",
+        "turns": turns,
+        "new_entries": new_entries,
+        "by_type": by_type,
+        "source_byte_offset": new_offset,
+        "entry_count": after_count,
+        "obs_path": str(obs_path),
+        "message": _summary_message(turns, by_type),
+    }

--- a/prompts/observer.md
+++ b/prompts/observer.md
@@ -1,8 +1,8 @@
 # ThreadHop Observer Prompt
 
 You are an observation extractor for Claude Code session transcripts. Your job
-is to read a chunk of conversation (JSONL transcript lines) and extract
-structured observations from what was **explicitly discussed**.
+is to read a cleaned conversation chunk and extract structured observations
+from what was **explicitly discussed**.
 
 ## Output rules
 
@@ -39,25 +39,40 @@ from this list:
 - **observation**: The catch-all for valuable knowledge that isn't a decision
   or task. Use sparingly — not every conversation remark is an observation.
 
-## What to read
+## Input shape
 
-The conversation chunk is JSONL — one JSON object per line. Each line has:
+The conversation chunk is a role-labelled transcript inside
+`<session_chunk>` tags. Each turn looks like:
 
-- `type`: `"human"` (user message) or `"assistant"` (Claude response)
-- `message.content`: Array of content blocks. Text blocks have `type: "text"`.
-  Tool-use blocks have `type: "tool_use"` with `name` and `input`.
-- `message.id`: Groups streaming chunks — multiple lines may share the same
-  `message.id`. Read them as one logical message.
+```
+### user · 2026-04-17T10:30:00Z
+What about rate limiting?
 
-**Focus on the human/assistant dialogue.** Tool calls (file reads, edits, bash
-commands) provide context but are not observations themselves. Extract
-observations from what was discussed *about* the tool results, not the raw
-tool output.
+### assistant · 2026-04-17T10:30:05Z
+Two options: leaky bucket vs token bucket. I'd go token bucket because
+the burst behaviour matches our traffic shape.
+[Editing ratelimit.go]
+Done — 60 rpm default, per-IP keyed.
+```
 
-**Skip entirely:**
-- `<system-reminder>` blocks — these are framework noise, not conversation
-- Lines with `type: "system"` — configuration, not discussion
-- Tool result content — raw output, not observations
+Key properties of this input:
+
+- **Tool outputs are already removed.** You will never see file contents,
+  `Bash` stdout, `Read` results, or other raw tool output — those are
+  filtered before you see them. Do not ask to see them.
+- **`tool_use` blocks are abbreviated in-line.** They appear as single
+  bracketed lines like `[Editing foo.py]`, `[Running npm]`,
+  `[Searching for pattern]`. Treat them as *context* for the surrounding
+  prose — evidence of what was done, not observations themselves.
+- **Streaming chunks are already merged.** One `### assistant · <ts>` block
+  is one logical response, even if Claude streamed it as multiple internal
+  chunks.
+- **`<system-reminder>` blocks are already stripped.** Internal reasoning
+  (`thinking`) blocks are also absent.
+
+Extract observations from what the **human and assistant said** — the
+prose around the tool calls. Tool abbreviations tell you *what was done*,
+but they are not observations on their own.
 
 ## JSON line format
 
@@ -74,8 +89,8 @@ Field details:
 - `context`: Brief rationale or surrounding context (1 sentence). Why this
   decision was made, what prompted this todo, etc. Empty string if none.
 - `ts`: ISO 8601 timestamp of the message where this was discussed.
-  Use the timestamp from the JSONL line. If spanning multiple messages,
-  use the timestamp of the message where the item was concluded.
+  Use the timestamp from the transcript header of the message where the
+  item was concluded (for multi-turn items, the final turn).
 
 **Do NOT include** `session`, `project`, or `source_offset` in the JSON lines.
 The session is encoded in the filename (`observations/<session_id>.jsonl`).
@@ -84,10 +99,10 @@ database, not in observation entries. Keep each line minimal.
 
 ## Multi-turn items
 
-Decisions often span several messages (user proposes → Claude analyzes →
-user decides → Claude confirms). Extract the **final form** — the decision
-as concluded, not each intermediate step. The `ts` should be the message
-where the decision was finalized.
+Decisions often span several turns (user proposes → assistant analyzes →
+user decides → assistant confirms). Extract the **final form** — the
+decision as concluded, not each intermediate step. The `ts` should be the
+turn where the decision was finalized.
 
-Similarly, if a todo is discussed across messages and then refined, extract
+Similarly, if a todo is discussed across turns and then refined, extract
 the final refined version only.

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -1,0 +1,426 @@
+"""Tests for the observer core function (task #18, ADR-018/019/020).
+
+The real observer shells out to ``claude -p --model haiku``. These tests
+inject a fake ``claude`` binary that appends a canned observation JSONL
+line to the output file, then verify the orchestrator's behaviour:
+
+  * Threshold gating (< 3 turns → skip, no subprocess).
+  * State seeding from ``sessions`` on first run.
+  * Byte-offset advancement on success, not on skip, not on failure.
+  * Line-count diffing for the ``by_type`` summary.
+  * Truncation / rotation handling.
+
+Run from the repo root::
+
+    python -m pytest tests/test_observer.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+import db
+import observer
+
+
+# --- Fixtures --------------------------------------------------------------
+
+
+@pytest.fixture
+def obs_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``db.OBS_DIR`` into the test's tmp_path.
+
+    The observer writes observation files under ``db.OBS_DIR``. Without
+    this redirect, tests would scribble into ``~/.config/threadhop``.
+    """
+    d = tmp_path / "observations"
+    d.mkdir()
+    monkeypatch.setattr(db, "OBS_DIR", d)
+    return d
+
+
+@pytest.fixture
+def fake_claude(tmp_path: Path) -> Callable[[list[dict] | str], Path]:
+    """Build a shell-script stand-in for the ``claude`` CLI.
+
+    The observer passes ``-p <prompt>`` followed by ``--model`` and
+    ``--permission-mode`` flags. Our fake ignores the prompt and appends
+    whatever observation lines the test specified to the output file
+    extracted from the prompt.
+
+    ``script_body`` may be:
+      * a ``list[dict]`` — serialized to one JSON line each and appended
+        to the observation file the real prompt names.
+      * a ``str`` — used as the raw shell body (for exit-code / error
+        paths).
+    """
+    def _make(script_body):
+        path = tmp_path / "fake_claude"
+        if isinstance(script_body, list):
+            # Extract the obs path from the prompt argument, then append
+            # the canned entries. The prompt contains a marker line
+            # "Append observations to: <path>" — grep it out.
+            entries = "\n".join(json.dumps(e) for e in script_body) + "\n"
+            payload_file = tmp_path / "fake_claude_payload.jsonl"
+            payload_file.write_text(entries)
+            body = f"""#!/usr/bin/env bash
+set -euo pipefail
+# -p <prompt> --model haiku --permission-mode acceptEdits
+prompt="$2"
+obs_path=$(printf '%s\\n' "$prompt" | sed -n 's/^Append observations to: //p')
+cat "{payload_file}" >> "$obs_path"
+"""
+        else:
+            body = script_body
+        path.write_text(body)
+        path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        return path
+    return _make
+
+
+# --- JSONL builders (mirror test_incremental_index.py) --------------------
+
+
+def _user_line(uuid: str, text: str, sid: str = "sess-1") -> str:
+    return json.dumps({
+        "type": "user",
+        "uuid": uuid,
+        "sessionId": sid,
+        "timestamp": "2026-04-17T10:00:00Z",
+        "message": {"id": f"umsg_{uuid}", "content": [{"type": "text", "text": text}]},
+    })
+
+
+def _assistant_line(uuid: str, mid: str, text: str, sid: str = "sess-1") -> str:
+    return json.dumps({
+        "type": "assistant",
+        "uuid": uuid,
+        "sessionId": sid,
+        "timestamp": "2026-04-17T10:00:01Z",
+        "message": {"id": mid, "content": [{"type": "text", "text": text}]},
+    })
+
+
+def _tool_result_user_line(uuid: str, sid: str = "sess-1") -> str:
+    """type:user with toolUseResult — must NOT count as a turn."""
+    return json.dumps({
+        "type": "user",
+        "uuid": uuid,
+        "sessionId": sid,
+        "timestamp": "2026-04-17T10:00:02Z",
+        "toolUseResult": {"type": "tool_result", "content": "ok"},
+    })
+
+
+def _write_session(tmp_path: Path, name: str, lines: list[str]) -> Path:
+    jsonl = tmp_path / f"{name}.jsonl"
+    jsonl.write_text("\n".join(lines) + "\n")
+    return jsonl
+
+
+def _seed_session_row(conn, session_id: str, session_path: Path):
+    db.upsert_session(
+        conn, session_id, str(session_path),
+        project="test-project",
+    )
+
+
+# --- Pure-function tests ---------------------------------------------------
+
+
+class TestCountMessageTurns:
+    def test_users_and_assistants_each_count(self):
+        raw = (
+            _user_line("u1", "hi") + "\n" +
+            _assistant_line("a1", "m1", "hello") + "\n" +
+            _user_line("u2", "more") + "\n"
+        ).encode()
+        assert observer._count_message_turns(raw) == 3
+
+    def test_assistant_streaming_chunks_collapse_to_one_turn(self):
+        # Three assistant lines, same message.id → one turn.
+        raw = (
+            _user_line("u1", "q") + "\n" +
+            _assistant_line("a1", "m1", "part 1") + "\n" +
+            _assistant_line("a2", "m1", "part 2") + "\n" +
+            _assistant_line("a3", "m1", "part 3") + "\n"
+        ).encode()
+        assert observer._count_message_turns(raw) == 2
+
+    def test_tool_result_user_lines_are_not_turns(self):
+        raw = (
+            _user_line("u1", "do a thing") + "\n" +
+            _tool_result_user_line("tr1") + "\n" +
+            _assistant_line("a1", "m1", "done") + "\n"
+        ).encode()
+        assert observer._count_message_turns(raw) == 2
+
+    def test_malformed_lines_skipped(self):
+        raw = (
+            _user_line("u1", "hi") + "\n" +
+            "not json at all\n" +
+            _assistant_line("a1", "m1", "hey") + "\n"
+        ).encode()
+        assert observer._count_message_turns(raw) == 2
+
+
+class TestReadNewBytes:
+    def test_partial_line_at_eof_is_held_back(self, tmp_path: Path):
+        p = tmp_path / "s.jsonl"
+        p.write_bytes(b"first\nsecond\nthird-unfinished")
+        out, new_off = observer._read_new_bytes(p, 0)
+        assert out == b"first\nsecond\n"
+        assert new_off == len(b"first\nsecond\n")
+
+    def test_no_complete_line_returns_unchanged_offset(self, tmp_path: Path):
+        p = tmp_path / "s.jsonl"
+        p.write_bytes(b"just-partial")
+        out, new_off = observer._read_new_bytes(p, 0)
+        assert out == b""
+        assert new_off == 0
+
+
+# --- Orchestrator tests ---------------------------------------------------
+
+
+class TestObserveSession:
+    def test_below_threshold_skips_without_subprocess(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        # Only 2 turns — threshold is 3. Fake claude would succeed, but
+        # we want to prove it's not even invoked.
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "hi"),
+            _assistant_line("a1", "m1", "hello"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        # Script that would fail loudly if called — proves we skipped.
+        claude = fake_claude("#!/usr/bin/env bash\nexit 99\n")
+
+        result = observer.observe_session(
+            conn, "sess-1", claude_bin=str(claude),
+        )
+
+        assert result["status"] == "below_threshold"
+        assert result["turns"] == 2
+        assert result["new_entries"] == 0
+        # Cursor did NOT advance — next run will re-read same bytes.
+        state = db.get_observation_state(conn, "sess-1")
+        # Below-threshold on first run doesn't even create a state row —
+        # caller sees the offset in the return value.
+        if state is not None:
+            assert state["source_byte_offset"] == 0
+
+    def test_up_to_date_when_no_new_bytes(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "a"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+        # Pre-seed state at EOF — nothing left to read.
+        size = jsonl.stat().st_size
+        obs_path = obs_dir / "sess-1.jsonl"
+        db.upsert_observation_state(
+            conn, "sess-1", str(jsonl), str(obs_path),
+            source_byte_offset=size,
+            entry_count=0,
+        )
+
+        claude = fake_claude("#!/usr/bin/env bash\nexit 99\n")
+        result = observer.observe_session(
+            conn, "sess-1", claude_bin=str(claude),
+        )
+
+        assert result["status"] == "up_to_date"
+        assert result["turns"] == 0
+
+    def test_no_source_when_session_row_missing(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        result = observer.observe_session(
+            conn, "ghost-session", claude_bin=str(fake_claude([])),
+        )
+        assert result["status"] == "no_source"
+
+    def test_no_source_when_file_gone(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        missing = tmp_path / "gone.jsonl"
+        _seed_session_row(conn, "sess-1", missing)
+        result = observer.observe_session(
+            conn, "sess-1", claude_bin=str(fake_claude([])),
+        )
+        assert result["status"] == "no_source"
+
+    def test_extraction_appends_and_advances_state(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        # 3 turns → meets threshold.
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "Should we use SQLite?"),
+            _assistant_line("a1", "m1", "Yes, SQLite fits the use case."),
+            _user_line("u2", "Great, decided."),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        canned = [
+            {
+                "type": "decision",
+                "text": "Use SQLite for local state",
+                "context": "single-file deployment",
+                "ts": "2026-04-17T10:00:03Z",
+            },
+            {
+                "type": "todo",
+                "text": "Write the schema migration",
+                "context": "",
+                "ts": "2026-04-17T10:00:03Z",
+            },
+        ]
+        claude = fake_claude(canned)
+
+        result = observer.observe_session(
+            conn, "sess-1", claude_bin=str(claude),
+        )
+
+        assert result["status"] == "extracted"
+        assert result["turns"] == 3
+        assert result["new_entries"] == 2
+        assert result["by_type"] == {"decision": 1, "todo": 1}
+
+        # State row exists with cursor at EOF and matching entry count.
+        expected_offset = jsonl.stat().st_size
+        state = db.get_observation_state(conn, "sess-1")
+        assert state is not None
+        assert state["source_byte_offset"] == expected_offset
+        assert state["entry_count"] == 2
+        assert state["status"] == "idle"  # observer function itself
+                                         # doesn't flip to running — that
+                                         # belongs to the sidecar (#34)
+        assert state["last_observed_at"] is not None
+
+        # Observation file contains exactly our two lines.
+        obs_path = Path(result["obs_path"])
+        lines = obs_path.read_text().strip().splitlines()
+        assert len(lines) == 2
+        assert json.loads(lines[0])["type"] == "decision"
+
+    def test_resume_reads_only_appended_bytes(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        # First extraction.
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "q"),
+            _assistant_line("a1", "m1", "a"),
+            _user_line("u2", "q2"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        claude = fake_claude([
+            {"type": "decision", "text": "x", "context": "", "ts": "2026-04-17T10:00:00Z"},
+        ])
+        r1 = observer.observe_session(conn, "sess-1", claude_bin=str(claude))
+        assert r1["status"] == "extracted"
+
+        # Append more messages — meets threshold again.
+        with open(jsonl, "a") as f:
+            f.write(_assistant_line("a2", "m2", "b") + "\n")
+            f.write(_user_line("u3", "q3") + "\n")
+            f.write(_assistant_line("a3", "m3", "c") + "\n")
+
+        # Second run: verify the fake only sees the appended bytes.
+        # We do that by checking the turn count the observer computed.
+        claude2 = fake_claude([
+            {"type": "todo", "text": "y", "context": "", "ts": "2026-04-17T10:01:00Z"},
+        ])
+        r2 = observer.observe_session(conn, "sess-1", claude_bin=str(claude2))
+
+        assert r2["status"] == "extracted"
+        # Only the 3 new turns, not the original 3.
+        assert r2["turns"] == 3
+        assert r2["new_entries"] == 1
+
+        # Observation file now has 2 lines total.
+        obs_path = Path(r2["obs_path"])
+        assert len(obs_path.read_text().strip().splitlines()) == 2
+
+    def test_subprocess_failure_does_not_advance_state(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "x"),
+            _assistant_line("a1", "m1", "y"),
+            _user_line("u2", "z"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        claude = fake_claude(
+            "#!/usr/bin/env bash\necho oops >&2\nexit 2\n"
+        )
+        result = observer.observe_session(
+            conn, "sess-1", claude_bin=str(claude),
+        )
+
+        assert result["status"] == "failed"
+        assert "exited 2" in result["error"]
+        # State row either doesn't exist or is at offset 0 — we must NOT
+        # have advanced past the un-processed bytes.
+        state = db.get_observation_state(conn, "sess-1")
+        if state is not None:
+            assert state["source_byte_offset"] == 0
+
+    def test_claude_bin_missing_is_a_failure_not_a_crash(
+        self, tmp_path, conn, obs_dir
+    ):
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "a"),
+            _assistant_line("a1", "m1", "b"),
+            _user_line("u2", "c"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        result = observer.observe_session(
+            conn, "sess-1",
+            claude_bin="/does/not/exist/claude-ghost",
+        )
+        assert result["status"] == "failed"
+        assert "not found" in result["error"]
+
+    def test_truncation_rewinds_cursor(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        # Start with a session and pretend we've observed past its EOF
+        # (simulates a rotated-and-replaced file with fewer bytes).
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "new-a"),
+            _assistant_line("a1", "m1", "new-b"),
+            _user_line("u2", "new-c"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+        obs_path = obs_dir / "sess-1.jsonl"
+        # Pretend prior run recorded a huge offset from an earlier,
+        # now-discarded version of the file.
+        db.upsert_observation_state(
+            conn, "sess-1", str(jsonl), str(obs_path),
+            source_byte_offset=10**9,  # way past current EOF
+            entry_count=0,
+        )
+
+        claude = fake_claude([
+            {"type": "decision", "text": "x", "context": "", "ts": "2026-04-17T10:00:00Z"},
+        ])
+        result = observer.observe_session(
+            conn, "sess-1", claude_bin=str(claude),
+        )
+
+        assert result["status"] == "extracted"
+        # All 3 turns should be read (cursor rewound to 0).
+        assert result["turns"] == 3

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -134,40 +134,71 @@ def _seed_session_row(conn, session_id: str, session_path: Path):
 # --- Pure-function tests ---------------------------------------------------
 
 
-class TestCountMessageTurns:
-    def test_users_and_assistants_each_count(self):
+class TestTranscriptRendering:
+    """The observer now feeds Haiku the cleaned transcript produced by
+    indexer.parse_byte_range (tool outputs stripped, tool_use abbreviated,
+    streaming chunks merged). These tests cover the assembly step — both
+    turn counting (which is just ``len(message_turns)`` now) and the
+    transcript-format helper the prompt splices in.
+    """
+
+    def test_users_and_assistants_each_count_as_turns(self):
+        import indexer
         raw = (
             _user_line("u1", "hi") + "\n" +
             _assistant_line("a1", "m1", "hello") + "\n" +
             _user_line("u2", "more") + "\n"
         ).encode()
-        assert observer._count_message_turns(raw) == 3
+        assert len(indexer.parse_byte_range(raw)) == 3
 
     def test_assistant_streaming_chunks_collapse_to_one_turn(self):
-        # Three assistant lines, same message.id → one turn.
+        import indexer
         raw = (
             _user_line("u1", "q") + "\n" +
             _assistant_line("a1", "m1", "part 1") + "\n" +
             _assistant_line("a2", "m1", "part 2") + "\n" +
             _assistant_line("a3", "m1", "part 3") + "\n"
         ).encode()
-        assert observer._count_message_turns(raw) == 2
+        turns = indexer.parse_byte_range(raw)
+        assert len(turns) == 2
+        # The assistant turn is the *merged* text, not three separate ones.
+        assistant_turn = next(t for t in turns if t["role"] == "assistant")
+        assert "part 1" in assistant_turn["text"]
+        assert "part 2" in assistant_turn["text"]
+        assert "part 3" in assistant_turn["text"]
 
     def test_tool_result_user_lines_are_not_turns(self):
+        import indexer
         raw = (
             _user_line("u1", "do a thing") + "\n" +
             _tool_result_user_line("tr1") + "\n" +
             _assistant_line("a1", "m1", "done") + "\n"
         ).encode()
-        assert observer._count_message_turns(raw) == 2
+        turns = indexer.parse_byte_range(raw)
+        assert len(turns) == 2
+        assert [t["role"] for t in turns] == ["user", "assistant"]
 
-    def test_malformed_lines_skipped(self):
-        raw = (
-            _user_line("u1", "hi") + "\n" +
-            "not json at all\n" +
-            _assistant_line("a1", "m1", "hey") + "\n"
-        ).encode()
-        assert observer._count_message_turns(raw) == 2
+    def test_format_transcript_uses_role_and_timestamp_headers(self):
+        turns = [
+            {"role": "user", "timestamp": "2026-04-17T10:00:00Z",
+             "text": "Should we use SQLite?"},
+            {"role": "assistant", "timestamp": "2026-04-17T10:00:01Z",
+             "text": "Yes — single-file deployment wins."},
+        ]
+        out = observer._format_transcript(turns)
+        assert "### user · 2026-04-17T10:00:00Z" in out
+        assert "### assistant · 2026-04-17T10:00:01Z" in out
+        assert "Should we use SQLite?" in out
+        assert "single-file deployment wins" in out
+
+    def test_format_transcript_skips_empty_text(self):
+        turns = [
+            {"role": "user", "timestamp": "t1", "text": "hello"},
+            {"role": "assistant", "timestamp": "t2", "text": ""},
+        ]
+        out = observer._format_transcript(turns)
+        assert "### user" in out
+        assert "### assistant" not in out
 
 
 class TestReadNewBytes:
@@ -393,6 +424,65 @@ class TestObserveSession:
         )
         assert result["status"] == "failed"
         assert "not found" in result["error"]
+
+    def test_prompt_contains_cleaned_transcript_not_raw_jsonl(
+        self, tmp_path, conn, obs_dir
+    ):
+        """The observer must send Haiku the cleaned transcript — not raw
+        JSONL with message.content blocks, tool results, or system-reminders.
+        We capture the prompt arg via a fake claude that dumps it to a file.
+        """
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "Should we cache this?"),
+            _assistant_line("a1", "m1", "Yes <system-reminder>internal</system-reminder> definitely"),
+            _user_line("u2", "Great"),
+            # A tool_result user line that must NOT appear in the prompt.
+            _tool_result_user_line("tr1"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        # Fake claude that writes its prompt arg to a known file.
+        captured = tmp_path / "captured_prompt.txt"
+        script = tmp_path / "fake_claude"
+        script.write_text(
+            "#!/usr/bin/env bash\n"
+            f"printf '%s' \"$2\" > {captured}\n"
+        )
+        script.chmod(
+            script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH
+        )
+
+        result = observer.observe_session(
+            conn, "sess-1", claude_bin=str(script),
+        )
+        assert result["status"] == "extracted"
+
+        prompt_body = captured.read_text()
+
+        # Isolate the transcript section — the prompt template itself
+        # references `<session_chunk>` and `<system-reminder>` in its
+        # instructions, so we can only assert stripping happened inside
+        # the actual delimited chunk. The delimiter sits on its own line,
+        # which lets us skip the backticked mentions in the guidance.
+        start = (
+            prompt_body.index("<session_chunk>\n")
+            + len("<session_chunk>\n")
+        )
+        end = prompt_body.index("\n</session_chunk>")
+        chunk = prompt_body[start:end]
+
+        # Role-labelled transcript headers present.
+        assert "### user" in chunk
+        assert "### assistant" in chunk
+
+        # Raw JSONL artifacts MUST NOT appear in the transcript.
+        assert "\"sessionId\"" not in chunk
+        assert "\"toolUseResult\"" not in chunk
+        assert "<system-reminder>" not in chunk
+
+        # Cleaned text still makes it through.
+        assert "Should we cache this?" in chunk
+        assert "definitely" in chunk
 
     def test_truncation_rewinds_cursor(
         self, tmp_path, conn, obs_dir, fake_claude


### PR DESCRIPTION
## Summary
- Implements the observer core function (ADR-018, task #18) in a new `observer.py` — state-aware orchestrator that reads new JSONL bytes per session from the recorded `source_byte_offset`, threshold-gates at 3 message turns, invokes `claude -p --model haiku --permission-mode acceptEdits`, diffs the per-session observation file, and advances `observation_state` in SQLite via `db.upsert_observation_state`.
- Feeds Haiku the same cleaned transcript the FTS index and TUI use, not raw JSONL. Extracted `indexer.parse_byte_range` as a public helper; observer formats its output as a role-labelled `### user · <ts>` / `### assistant · <ts>` transcript. Tool outputs are already stripped, `tool_use` is abbreviated, streaming chunks are merged, `<system-reminder>` blocks are removed. Prompt template rewritten to describe the new input shape.
- Adds `threadhop observe [--session <id>]` — on-demand-only CLI wrapper so the feature is demo-able before the background sidecar (task #34) lands. Auto-detects session id from the caller's terminal, runs one extraction pass, prints the summary + obs-file path + cursor.

## Commits
1. `ee14d61` — Observer core + 15 tests using a fake `claude` shim.
2. `2d4eb24` — Extract `indexer.parse_byte_range`, observer uses cleaned transcript, prompt rewritten, +2 tests.
3. `572d077` — `threadhop observe` CLI subcommand (partial task #34, on-demand mode only).

## Base branch
Branched off `docs/adr` (depends on migration 004 + ADR-018/019/020 + `prompts/observer.md`). Merge `docs/adr` → `main` first, or re-target this PR once that lands.

## Demo path
```bash
./threadhop observe                              # auto-detects current terminal's session
./threadhop observe --session <id>               # explicit
./threadhop observe --session <id> --batch-threshold 1   # demos on short sessions
```
Observations land at `~/.config/threadhop/observations/<session_id>.jsonl`; cursor + entry count in SQLite `observation_state`.

## Testing rules observed
- **No network calls, no real `claude` subprocess in tests.** Tests inject a fake `claude` binary (shell script) via the `claude_bin=` parameter. The shim parses `Append observations to: <path>` out of the prompt and appends canned JSONL — deterministic, full suite runs in < 2 seconds.
- **No writes outside `tmp_path`.** `db.OBS_DIR` is monkey-patched to a per-test temp directory so no test touches `~/.config/threadhop/observations/`. Same convention the existing `conftest.py` fixtures enforce for `db_path` and `config_path`.
- **State invariants under failure.** Every failure path (missing source, missing binary, non-zero exit, subprocess timeout, file rotation) returns a structured summary dict and does NOT advance `source_byte_offset` — the next run retries the same byte range.
- **No raw JSONL in Haiku's input.** One test captures the prompt arg sent to the fake `claude` and asserts the `<session_chunk>` delimited section contains neither `"sessionId"` nor `"toolUseResult"` nor `<system-reminder>` — only the cleaned role-labelled transcript.
- **Deliberately out of scope** (task #34 proper): watch mode, fsevents / polling, PID tracking, SIGTERM handling, stop/resume, stale-PID detection. Those land with the full background sidecar.

## Test plan
- [x] `python3 -m pytest tests/` — **70 passed** locally (53 pre-existing + 17 new)
- [x] Threshold gating: < 3 turns returns `status: "below_threshold"` with no subprocess call and no cursor advance
- [x] `status: "up_to_date"` when file size matches recorded offset
- [x] First-run state seeding: `session_path` resolved from `sessions` row when `observation_state` row is absent
- [x] Cursor advances to new EOF only on successful extraction; held on skip/failure/truncation
- [x] Streaming-chunk collapse: 3 assistant JSONL lines sharing `message.id` count as 1 turn, texts merged
- [x] Tool-result user lines (`toolUseResult` set) filtered by `parse_byte_range`, never reach Haiku
- [x] Truncation (`file_size < last_offset`) rewinds cursor to 0 and re-reads from start
- [x] Missing `claude` binary surfaces as `status: "failed"` with a clear error — no traceback
- [x] Prompt-capture test: `<session_chunk>` block contains cleaned transcript, no JSONL artifacts
- [x] `./threadhop observe --help` + bad-session error path smoke-checked locally
- [ ] Reviewer: manual smoke test with a real `claude` binary against a real session JSONL — `./threadhop observe --session <real-id> --batch-threshold 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)