### PR TITLE
Add context-aware help overlay + command registry (task #42)

### DIFF
--- a/db.py
+++ b/db.py
@@ -32,7 +32,7 @@ DB_PATH = DB_DIR / "sessions.db"
 # --- Schema version ---
 # Each migration N in MIGRATIONS moves the DB from version N to N+1.
 # The DB's current version lives in PRAGMA user_version.
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 
 # --- Migrations -----------------------------------------------------------
@@ -189,11 +189,50 @@ def _migration_003_index_state(conn: sqlite3.Connection) -> None:
         )
 
 
+def _migration_004_observation_state(conn: sqlite3.Connection) -> None:
+    """Phase 3: observer + reflector state tracking (ADR-019, ADR-022).
+
+    Tracks per-session observation state: where the observer left off in
+    the source JSONL (``source_byte_offset``), how many observation entries
+    have been written (``entry_count``), what the reflector has already
+    compared (``reflector_entry_offset``), and whether the observer is
+    currently running (``observer_pid``).
+
+    This table is the single source of truth for "has this session been
+    observed?" and "where did we leave off?" — queried by the TUI for the
+    observation indicator, by the observer for incremental processing, and
+    by the reflector for its own cadence tracking.
+    """
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS observation_state (
+            session_id              TEXT PRIMARY KEY,
+            source_path             TEXT NOT NULL,
+            obs_path                TEXT NOT NULL,
+            source_byte_offset      INTEGER NOT NULL DEFAULT 0,
+            entry_count             INTEGER NOT NULL DEFAULT 0,
+            reflector_entry_offset  INTEGER NOT NULL DEFAULT 0,
+            observer_pid            INTEGER,
+            status                  TEXT NOT NULL DEFAULT 'idle',
+                -- idle | running | stopped
+            started_at              REAL,
+            last_observed_at        REAL,
+            FOREIGN KEY (session_id) REFERENCES sessions(session_id)
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_obs_state_status "
+        "ON observation_state(status)"
+    )
+
+
 # Ordered list; MIGRATIONS[i] moves schema from version i to i+1.
 MIGRATIONS: list = [
     _migration_001_initial,
     _migration_002_messages,
     _migration_003_index_state,
+    _migration_004_observation_state,
 ]
 
 assert len(MIGRATIONS) == SCHEMA_VERSION, (
@@ -872,3 +911,169 @@ def migrate_config_json_to_sqlite(
             }
 
     return {"action": "migrated", "migrated": migrated, "skipped": skipped}
+
+
+# --- Observation state helpers (ADR-019, ADR-022) --------------------------
+
+# Directory where per-session observation JSONL files live.
+OBS_DIR = DB_DIR / "observations"
+
+
+def get_observation_state(
+    conn: sqlite3.Connection,
+    session_id: str,
+) -> dict | None:
+    """Return the observation state for a session, or None if never observed."""
+    return query_one(
+        conn,
+        "SELECT * FROM observation_state WHERE session_id = ?",
+        (session_id,),
+    )
+
+
+def upsert_observation_state(
+    conn: sqlite3.Connection,
+    session_id: str,
+    source_path: str,
+    obs_path: str,
+    *,
+    source_byte_offset: int = 0,
+    entry_count: int = 0,
+    reflector_entry_offset: int = 0,
+    observer_pid: int | None = None,
+    status: str = "idle",
+    started_at: float | None = None,
+    last_observed_at: float | None = None,
+) -> None:
+    """Insert or update the observation state for a session.
+
+    On conflict, updates all mutable fields. The caller controls which
+    fields to advance — typically ``source_byte_offset`` and ``entry_count``
+    after an observer run, or ``observer_pid`` and ``status`` on start/stop.
+    """
+    conn.execute(
+        """
+        INSERT INTO observation_state (
+            session_id, source_path, obs_path,
+            source_byte_offset, entry_count, reflector_entry_offset,
+            observer_pid, status, started_at, last_observed_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(session_id) DO UPDATE SET
+            source_path            = excluded.source_path,
+            obs_path               = excluded.obs_path,
+            source_byte_offset     = excluded.source_byte_offset,
+            entry_count            = excluded.entry_count,
+            reflector_entry_offset = excluded.reflector_entry_offset,
+            observer_pid           = excluded.observer_pid,
+            status                 = excluded.status,
+            started_at             = COALESCE(excluded.started_at, observation_state.started_at),
+            last_observed_at       = COALESCE(excluded.last_observed_at, observation_state.last_observed_at)
+        """,
+        (
+            session_id, source_path, obs_path,
+            source_byte_offset, entry_count, reflector_entry_offset,
+            observer_pid, status, started_at, last_observed_at,
+        ),
+    )
+
+
+def update_observer_offset(
+    conn: sqlite3.Connection,
+    session_id: str,
+    source_byte_offset: int,
+    entry_count: int,
+    last_observed_at: float,
+) -> None:
+    """Advance the observer's position after processing a chunk.
+
+    Called after each observer extraction. Updates the byte offset (where
+    to resume reading source JSONL) and entry count (how many observations
+    have been written so far).
+    """
+    conn.execute(
+        """
+        UPDATE observation_state
+        SET source_byte_offset = ?,
+            entry_count        = ?,
+            last_observed_at   = ?
+        WHERE session_id = ?
+        """,
+        (source_byte_offset, entry_count, last_observed_at, session_id),
+    )
+
+
+def update_reflector_offset(
+    conn: sqlite3.Connection,
+    session_id: str,
+    reflector_entry_offset: int,
+) -> None:
+    """Advance the reflector's position after a comparison pass.
+
+    The reflector processes observation entries (not source bytes), so its
+    offset is an entry index, not a byte offset.
+    """
+    conn.execute(
+        """
+        UPDATE observation_state
+        SET reflector_entry_offset = ?
+        WHERE session_id = ?
+        """,
+        (reflector_entry_offset, session_id),
+    )
+
+
+def set_observer_running(
+    conn: sqlite3.Connection,
+    session_id: str,
+    pid: int,
+    started_at: float,
+) -> None:
+    """Record that the observer is now running for this session."""
+    conn.execute(
+        """
+        UPDATE observation_state
+        SET observer_pid = ?, status = 'running', started_at = ?
+        WHERE session_id = ?
+        """,
+        (pid, started_at, session_id),
+    )
+
+
+def set_observer_stopped(
+    conn: sqlite3.Connection,
+    session_id: str,
+) -> None:
+    """Record that the observer has stopped (graceful or detected stale)."""
+    conn.execute(
+        """
+        UPDATE observation_state
+        SET observer_pid = NULL, status = 'stopped'
+        WHERE session_id = ?
+        """,
+        (session_id,),
+    )
+
+
+def get_observed_sessions(
+    conn: sqlite3.Connection,
+) -> list[dict]:
+    """Return all sessions that have observations (entry_count > 0).
+
+    Used by the TUI to show the observation indicator (ADR-021).
+    """
+    return query_all(
+        conn,
+        "SELECT session_id, entry_count, status, observer_pid "
+        "FROM observation_state WHERE entry_count > 0",
+    )
+
+
+def get_running_observers(
+    conn: sqlite3.Connection,
+) -> list[dict]:
+    """Return all sessions with a running observer (for --stop-all)."""
+    return query_all(
+        conn,
+        "SELECT session_id, observer_pid "
+        "FROM observation_state WHERE status = 'running' AND observer_pid IS NOT NULL",
+    )

--- a/docs/DESIGN-DECISIONS.md
+++ b/docs/DESIGN-DECISIONS.md
@@ -389,6 +389,363 @@ drag-to-resize.
 
 ---
 
+### ADR-015: Background observer-reflector as sidecar process
+
+**Context:** ADR-010 established the observer-first architecture with on-demand
+triggering (CLI query or TUI launch). But during active Claude Code sessions,
+observations only happen after the fact — never while you're working. We want
+the observer running continuously in the background, extracting observations
+in real-time, with a reflector identifying contradictory decisions across
+sessions. This should be a flag you enable — like Claude Code's remote control
+mode — and then forget about while you continue working.
+
+**Attribution:** The Observer/Reflector architecture is inspired by
+[Mastra's Observational Memory](https://mastra.ai/docs/memory/observational-memory)
+(`@mastra/memory@1.1.0`) — a three-tier system where Observer and Reflector
+agents run alongside the primary agent, compressing context and maintaining
+long-term memory. Credit to the Mastra team for the foundational pattern.
+See `docs/observational-memory.md` for the full reference.
+
+**The inherent problem with Mastra's approach:** Mastra's Observer and Reflector
+are *inline agents* — they run within the same process, share memory with the
+primary agent, and can directly modify its context window (removing old messages,
+injecting compressed observations, managing token budgets). In Claude Code, we
+have no access to the agent's context window. Claude Code is a black box that
+writes JSONL transcripts to disk. We can *read* those transcripts but cannot
+*modify* the running agent's context. This makes inline observation impossible.
+
+This constraint means ThreadHop's observer-reflector serves a fundamentally
+different purpose than Mastra's:
+
+| | Mastra OM | ThreadHop Observer-Reflector |
+|---|---|---|
+| Architecture | Inline (same process) | Sidecar (separate process) |
+| Access | Reads + writes agent context | Read-only transcript watcher |
+| Observer goal | Context compression | Knowledge extraction |
+| Reflector goal | Condense observations | Detect contradictory decisions |
+| Lifecycle | Coupled to agent | Independent of agent |
+| Value for | The agent (stays effective) | The human (understands what happened) |
+
+Mastra optimizes the agent's *ability to continue working* (context management).
+ThreadHop optimizes the human's *ability to understand what happened* across
+sessions (knowledge extraction + contradiction detection). Complementary goals,
+but architecturally distinct — which is why the inline approach was taken out
+of the design.
+
+**Decision:** Observer and Reflector run as background sidecar processes, enabled
+via a flag. The Claude Code terminal does NOT pause.
+
+**Architecture:**
+
+```
+Claude Code session (primary agent)
+    ↓ writes JSONL
+~/.claude/projects/.../<session>.jsonl
+    ↑ watches (fsevents / polling)
+Observer process (background, Haiku)
+    ↓ appends typed observations
+~/.config/threadhop/observations.jsonl
+    ↑ reads periodically
+Reflector process (background, Haiku)
+    ↓ writes conflict reports
+~/.config/threadhop/conflicts.jsonl
+```
+
+**Enabling from Claude Code — per-session opt-in (primary, see ADR-016):**
+
+```
+/threadhop:observe
+→ Spawns observer for THIS session only. Retroactive catch-up + watch mode.
+```
+
+**Alternative entry points (power users):**
+
+```bash
+# CLI: observe a specific session from another terminal
+threadhop observe --session <id> &
+
+# Auto-observe all sessions (NOT default, opt-in via config)
+threadhop config set observe.auto true
+```
+
+The primary model is per-session opt-in via the skill. Most conversations
+don't warrant observation. The user chooses which ones are valuable.
+See ADR-016 for the full trigger and injection design.
+
+**Observer behaviour (background mode):**
+
+1. Targets a specific session's JSONL (not all sessions)
+2. Retroactive catch-up: reads from byte 0, processes all existing messages
+3. Sets byte offset, switches to watch mode (fsevents on macOS, polling fallback)
+4. When new messages accumulate (configurable batch size, default ~10 messages):
+   - Reads new bytes from JSONL (byte offset tracking, same as ADR-010)
+   - Sends conversation chunk to Haiku
+   - Prompt: extract only explicitly discussed items across these five types:
+     `todo | decision | done | adr | observation`
+   - Appends typed JSONL observations to `observations.jsonl`
+5. Runs until the Claude Code session exits or manually stopped
+
+**Reflector behaviour — conflict detection:**
+
+The reflector's purpose is NOT condensation (Mastra's approach). It is
+specifically to **detect contradictory decisions** across sessions.
+
+Example conflict:
+```jsonl
+{"type":"decision","text":"REST over gRPC for client API","project":"atlas","session":"abc","ts":"..."}
+{"type":"decision","text":"gRPC for all service-to-service comms","project":"atlas","session":"def","ts":"..."}
+→ CONFLICT: REST vs gRPC scope overlap — both cover service communication
+```
+
+The Reflector:
+1. Runs at lower frequency (every N new observations, or every M minutes)
+2. Groups decisions by project and semantic topic
+3. Uses Haiku to identify contradictions between decisions
+4. Writes conflict reports to `conflicts.jsonl` for human review
+5. Surfaces conflicts via TUI notification or CLI query (`threadhop conflicts`)
+
+**Why NOT a daemon:**
+
+The observer is a background *process*, not a system daemon. It lives for the
+duration of a Claude Code session and exits when the session ends. No launchd
+plist, no systemd service, no process manager. Start it with `&` or a hook,
+kill it when done.
+
+**Rationale:**
+- Background process means zero friction — enable a flag and forget
+- File-watching is the only interface available (Claude Code is a black box)
+- Conflict detection is unique to ThreadHop — Mastra doesn't attempt this
+- Sidecar architecture means the observer works with any AI coding tool
+- On-demand mode (ADR-010) still works — background mode is additive
+- **Supersedes Q3** (was resolved as "no background process") — background
+  mode is now opt-in alongside the original on-demand trigger
+
+---
+
+### ADR-016: Per-session opt-in trigger and pull-based context injection
+
+**Context:** ADR-015 designed the observer-reflector as a background sidecar.
+But it assumed a global flag (auto-start hook, permanent config). In practice,
+most conversations don't warrant observation — routine debugging, quick fixes,
+file edits. The user needs to *choose* which conversations are valuable enough
+to observe. And once observations exist, they need a way to pull them back
+into the conversation.
+
+**Decision:** Observation is per-session opt-in, triggered by a skill
+(`/threadhop:observe`). Context injection is pull-based, triggered by a
+second skill (`/threadhop:insights`). Neither requires the TUI.
+
+**Why per-session, not global:**
+- Most Claude Code sessions are short or routine — observing them wastes
+  Haiku calls and pollutes `observations.jsonl` with noise
+- The user knows which conversations matter — architectural discussions,
+  design decisions, complex debugging sessions
+- Per-session opt-in means zero cost for throwaway sessions
+- A global auto-observe flag remains available as a power-user option
+  (`threadhop config set observe.auto true`) but is NOT the default
+
+**Trigger point 1 — beginning of conversation:**
+
+The user knows from the start this will be important:
+
+```
+User: /threadhop:observe
+
+1. Skill detects current session ID via ps/lsof
+2. JSONL is nearly empty (just started) — minimal retroactive work
+3. Observer starts watching in background
+4. Confirms: "Observing this session. Watching for new messages."
+5. User continues working normally
+```
+
+**Trigger point 2 — mid-conversation:**
+
+The user realizes mid-conversation that this discussion is worth capturing:
+
+```
+User: /threadhop:observe
+
+1. Skill detects current session ID
+2. Observer reads ENTIRE JSONL from byte 0 (retroactive catch-up)
+3. Processes all existing messages through Haiku — extracts observations
+4. Sets byte offset to current position
+5. Switches to watch mode for new messages
+6. Confirms: "Observing this session. 47 messages processed retroactively
+   — found 5 decisions, 3 TODOs, 1 ADR. Watching for new messages."
+7. User continues working — observer runs silently in background
+```
+
+The retroactive catch-up is identical to on-demand mode (ADR-010) — same
+incremental processing logic, same byte offset tracking. The only difference
+is that after catch-up, the observer stays resident instead of exiting.
+
+**Pull-based context injection — same session:**
+
+Claude Code is a black box — we can read its transcripts but cannot push
+into its context window. So injection is always **pull-based**: the user
+invokes a skill that reads from `observations.jsonl` / `conflicts.jsonl`
+and formats the findings into the conversation.
+
+```
+User: /threadhop:insights
+
+1. Skill reads observations.jsonl filtered by current session
+2. Reads conflicts.jsonl filtered by current project
+3. Formats and presents:
+
+   ┌─ ThreadHop Observations — this session ───────────────┐
+   │ DECISIONS:                                             │
+   │  • REST for client API (rationale: SDK constraints)    │
+   │  • Token bucket for rate limiting                      │
+   │ TODOs:                                                 │
+   │  • Implement /workflows endpoint                       │
+   │  • Write integration tests for auth flow               │
+   │ ADRs:                                                  │
+   │  • ADR-003: Chunk merging for assistant messages        │
+   │ CONFLICTS:                                             │
+   │  ⚠ Session "infra-design" decided "gRPC for all        │
+   │    services" — contradicts "REST for client API" above  │
+   └────────────────────────────────────────────────────────┘
+
+4. The model now has this context and can work with it
+```
+
+This is the same pattern as `/threadhop:context` (read data, format, inject)
+but reads from the observer's output instead of the clipboard.
+
+**Pull-based context injection — new session (enhanced handoff):**
+
+When the source session was observed, `/threadhop:handoff` is enhanced:
+
+```
+User (new session): /threadhop:handoff abc123
+
+Without observations (current behaviour):
+  1. Read entire JSONL (~thousands of lines)
+  2. Parse, strip, abbreviate
+  3. Send full transcript to Haiku sub-agent
+  4. Sub-agent compresses from scratch → ~30-50 line brief
+
+With observations (enhanced):
+  1. Read observations.jsonl filtered by session abc123
+  2. Observations already typed, structured, compressed
+  3. Send observations + conflicts to Haiku sub-agent
+  4. Sub-agent generates brief from structured input
+  5. Brief includes: decisions with rationale, open TODOs,
+     unresolved conflicts, current state
+  → Faster (less input), higher quality (structured input)
+```
+
+The handoff doesn't *replace* reading the raw transcript — it uses
+observations as primary input and can optionally pull raw messages for
+context where the observation is too compressed.
+
+**The complete feedback loop:**
+
+```
+Session A (architectural discussion):
+  1. Working on feature...
+  2. User realizes this is important
+  3. /threadhop:observe → retroactive catch-up + watch mode
+  4. Continue working... observer silently extracts observations
+  5. /threadhop:insights → "Here's what I've captured: 5 decisions, 3 TODOs"
+  6. User reviews, continues. Observer captures more.
+  7. Session gets long, user wants to continue elsewhere
+
+Session B (continuation):
+  1. /threadhop:handoff A → brief built from pre-extracted observations
+  2. /threadhop:conflicts → "1 conflict: Session A vs Session C on REST/gRPC"
+  3. User resolves conflict in this conversation
+  4. /threadhop:observe → now observing Session B, captures the resolution
+  5. Resolution appears in observations.jsonl as a new decision
+```
+
+The loop closes: **observe → extract → surface → resolve → observe the
+resolution**. Each session can opt in independently. Observations accumulate
+across sessions. Conflicts are detected cross-session and surfaced on demand.
+
+**Updated skill count — five skills:**
+
+| Skill | What it does | LLM? | New? |
+|---|---|---|---|
+| `/threadhop:tag` | Tag session status | No | Existing (ADR-012) |
+| `/threadhop:context` | Inject clipboard content | No | Existing (ADR-012) |
+| `/threadhop:handoff` | Generate handoff brief | Yes | Enhanced (ADR-016) |
+| `/threadhop:observe` | Start background observer for this session | No | New (ADR-016) |
+| `/threadhop:insights` | Pull observations + conflicts into conversation | No | New (ADR-016) |
+
+The observe skill itself is instant (spawns a process). The background
+observer uses Haiku. The insights skill is instant (reads files, formats).
+
+**Rationale:**
+- Per-session opt-in respects the user's attention — only important
+  conversations get the Haiku cost
+- Mid-conversation trigger with retroactive catch-up means you never miss
+  context, even if you decide to observe 30 minutes into a discussion
+- Pull-based injection is the only model that works with Claude Code's
+  black-box architecture
+- Enhanced handoff with observations is strictly better — faster (less
+  input to process) and higher quality (structured vs raw)
+- Five skills is still manageable — each does exactly one thing
+
+---
+
+### ADR-017: Context-aware discoverability via modal help and shared command metadata
+
+**Context:** ThreadHop already has multiple interaction surfaces with
+different affordances: the global search modal, the persistent in-transcript
+find bar, the stock footer, and transcript-local selection mode. The current
+footer only exposes a small subset of bindings, while other commands live in
+widget-local `on_key` handlers or transient notifications. That was fine when
+the app was smaller, but it does not scale now that bindings are focus-aware,
+mode-specific, and sometimes conflicting.
+
+An always-on footer that tries to show every key all the time would turn into
+noise and still be incomplete. The app needs one discoverability surface that
+answers "what can I do from here?" without flattening all contexts together.
+
+**Decision:** Add a context-aware help overlay, using the same full-app modal
+pattern as search, and back it with a shared command metadata registry.
+
+**UI model:**
+- Keep the footer minimal and contextual. It remains a compact reminder of the
+  highest-value actions currently available, not the source of truth for every
+  binding.
+- Add a global help overlay that takes over the app like search does and
+  groups commands by scope: global app, session list, transcript, selection
+  mode, reply input, and search/find.
+- The help overlay may optionally expose executable actions later, but v1 is
+  discoverability-first rather than a general command palette.
+- The help trigger must remain separate from handoff naming. Do not hardcode
+  `H` as the permanent key for help.
+
+**Architecture model:**
+- Define command metadata in one shared registry rather than duplicating key
+  descriptions across `Footer`, modal help text, README tables, and ad hoc
+  notifications.
+- The registry must support context predicates so commands can be shown only
+  when relevant (for example: transcript focused, selection mode active, find
+  bar open).
+- Widget-local commands still own their behaviour, but they also register
+  discoverability metadata so they stop being invisible to the rest of the UI.
+- Footer rendering and help-overlay rendering should both read from this same
+  metadata source.
+
+**Rationale:**
+- Search already established the right interaction precedent for a full-app
+  overlay in this TUI.
+- Context-aware discoverability matches the app's actual behaviour; a flat
+  list of bindings does not.
+- A shared registry prevents docs and UI surfaces from drifting apart as more
+  commands are added.
+- Leaving the help key unresolved avoids creating unnecessary coupling with the
+  future handoff shortcut work.
+
+**Rejected:** Expanding the footer into a permanent wall of bindings.
+**Rejected:** Maintaining help text separately in code, docs, and notifications.
+
+---
+
 ## Implementation Plan
 
 ### Phase 1: SQLite Foundation + Session Tags + Archive
@@ -419,31 +776,47 @@ _Enables instant search and cross-session context sharing. All TUI features._
    - `j`/`k` to navigate results, `Enter` to jump to source transcript
    - Filter syntax: `project:atlas`, `user:`, `assistant:`
 10. Future: trigram-based fuzzy search for typo tolerance
+11. Context-aware help overlay + shared command metadata registry:
+   - Full-app discoverability overlay, modeled on the search modal
+   - Footer stays minimal/contextual instead of listing every keybinding
+   - One registry feeds footer hints, help content, and future docs sync
+   - Trigger key intentionally left open; do not assume `H`
 
-### Phase 3: CLI Subcommands + Observer
-_Observer-first architecture. CLI access to observations without the TUI._
+### Phase 3: CLI Subcommands + Observer (on-demand + background)
+_Observer-first architecture. CLI access to observations without the TUI.
+Background mode for continuous observation during active sessions._
 
 1. Add argparse subcommand routing: no subcommand = TUI, with subcommand = CLI
 2. Implement `threadhop tag <status> [--session <id>]`
    - Auto-detect session from current terminal when `--session` omitted
-3. Implement Haiku observer:
+3. Implement Haiku observer (on-demand mode, ADR-010):
    - Process unindexed conversation chunks through Haiku
-   - Extract typed observations (todo, decision, done, adr, question, blocker)
+   - Extract typed observations: `todo | decision | done | adr | observation`
    - Append to `~/.config/threadhop/observations.jsonl`
    - Track byte offsets for incremental processing
-4. Implement CLI queries:
+4. Implement background observer mode (ADR-015):
+   - `threadhop observe` — runs as background sidecar process
+   - File-watching via fsevents (macOS), fallback to polling
+   - Auto-detects active session JSONL via ps/lsof
+   - Batched extraction (configurable, default ~10 messages)
+   - Exits when Claude Code session ends
+5. Implement CLI queries:
    - `threadhop todos [--project <name>]`
    - `threadhop decisions [--project <name>]`
    - `threadhop observations [--project <name>]`
    - All trigger observer for unprocessed messages before displaying results
 
 ### Phase 4: Skill Plugin
-_Three skills for in-session use._
+_Five skills for in-session use (ADR-012, ADR-016)._
 
 1. Research Claude Code skill plugin packaging/distribution
 2. `/threadhop:tag <status>` — detect session ID, call `threadhop tag` CLI
 3. `/threadhop:context` — read clipboard, format with source labels, inject
 4. `/threadhop:handoff <id> [--full]` — sub-agent compresses transcript
+   (enhanced: uses pre-extracted observations when available)
+5. `/threadhop:observe` — per-session opt-in, spawns background observer
+   (retroactive catch-up + watch mode)
+6. `/threadhop:insights` — pull observations + conflicts into conversation
 
 ### Phase 5: Project Memory + Bookmarks
 _Cross-session knowledge persistence._
@@ -455,13 +828,21 @@ _Cross-session knowledge persistence._
    in conversations and auto-append to observations
 5. Memory rendering: generate project memory markdown from observations for injection
 
-### Phase 6: Reflector
-_Condensation of accumulated observations._
+### Phase 6: Reflector — Conflict Detection
+_Contradiction detection across sessions. Runs as background sidecar alongside
+the observer (ADR-015), or on-demand via CLI._
 
-1. When observations.jsonl exceeds threshold, run Haiku reflector
-2. Merge related decisions, archive completed TODOs
-3. Produce condensed observation summaries
-4. Keep source links to original observations
+1. Build conflict detection reflector (Haiku):
+   - Group decisions by project and semantic topic
+   - Identify contradictory decisions across sessions
+   - Write conflict reports to `~/.config/threadhop/conflicts.jsonl`
+2. Background reflector mode:
+   - Runs at lower frequency than observer (every N observations or M minutes)
+   - Triggered automatically when observer appends new decisions
+3. CLI query: `threadhop conflicts [--project <name>]`
+4. TUI notification: surface unreviewed conflicts in sidebar or status bar
+5. Condensation (secondary goal): merge related decisions, archive completed
+   TODOs, produce condensed summaries with source links
 
 ---
 
@@ -549,11 +930,11 @@ CREATE TABLE memory (
 
 ## Skill Plugin Architecture
 
-### Principle: Three skills, clear boundaries
+### Principle: Five skills, clear boundaries
 
 Skills are for operations invoked mid-conversation from Claude Code. The TUI
 handles everything visual and instantaneous. The CLI handles queries and tagging
-from the terminal.
+from the terminal. See ADR-012 (original three) and ADR-016 (observe + insights).
 
 ### Plugin: `threadhop`
 
@@ -563,6 +944,8 @@ threadhop/
     tag.md              # /threadhop:tag <status>
     context.md          # /threadhop:context
     handoff.md          # /threadhop:handoff <session_id>
+    observe.md          # /threadhop:observe
+    insights.md         # /threadhop:insights
 ```
 
 ### What lives where
@@ -575,8 +958,10 @@ threadhop/
 | Bookmark | TUI | Visual selection, one-key action |
 | Tag session | TUI + Skill + CLI | All three entry points, one DB |
 | Observation queries | CLI | `threadhop todos`, `threadhop decisions` |
+| Start observation | Skill | Per-session opt-in, spawns background process |
+| Pull observations/conflicts | Skill | Read observer output, format for injection |
 | Context injection | Skill | Formats clipboard content with source labels |
-| Handoff | Skill | Needs LLM sub-agent for compression |
+| Handoff | Skill | LLM sub-agent, enhanced with pre-extracted observations |
 
 ### Skill 1: `/threadhop:tag <status>` (instant, no LLM)
 
@@ -637,6 +1022,84 @@ With --full flag:
 The raw transcript lives only in the sub-agent's context.
 The main session sees only the compressed brief.
 
+**Enhanced mode (when source session was observed, ADR-016):**
+
+```
+User (in Claude Code): /threadhop:handoff abc123
+
+1. Skill checks observations.jsonl for session abc123
+2. Observations exist → use structured input instead of raw JSONL
+3. Spawns sub-agent with:
+   - Pre-extracted observations (typed, structured)
+   - Any detected conflicts involving this session's decisions
+   - Prompt: "Generate a handoff brief from these structured observations.
+     Include: decisions with rationale, open TODOs, unresolved conflicts,
+     and what the next session needs to know."
+4. Sub-agent returns brief (~30-50 lines)
+5. Brief injected into current conversation
+
+Fallback: if no observations exist, reverts to full JSONL mode above.
+```
+
+### Skill 4: `/threadhop:observe` (instant, spawns background process)
+
+Per-session opt-in for background observation (ADR-016). The user decides
+which conversations are worth observing. Can be invoked at any point —
+beginning or mid-conversation.
+
+```
+User (in Claude Code): /threadhop:observe
+
+1. Skill detects current session ID from process context
+2. Checks if observer is already running for this session
+   - If yes: "Already observing this session."
+3. Spawns observer as background process:
+   threadhop observe --session <session_id> &
+4. Observer performs retroactive catch-up:
+   - Reads entire JSONL from byte 0
+   - Processes all existing messages through Haiku
+   - Extracts typed observations (todo | decision | done | adr | observation)
+5. Observer switches to watch mode (fsevents / polling)
+6. Confirms: "Observing this session. 47 messages processed retroactively
+   — found 5 decisions, 3 TODOs, 1 ADR. Watching for new messages."
+7. User continues working — observer runs silently
+```
+
+### Skill 5: `/threadhop:insights` (instant, no LLM)
+
+Pull-based context injection for observations and conflicts (ADR-016).
+Reads from the observer's output files and formats findings into the
+current conversation.
+
+```
+User (in Claude Code): /threadhop:insights
+
+1. Skill detects current session ID
+2. Reads observations.jsonl filtered by current session
+3. Reads conflicts.jsonl filtered by current project
+4. Formats and presents:
+
+   ┌─ ThreadHop Observations — this session ───────────────┐
+   │ DECISIONS:                                             │
+   │  • REST for client API (rationale: SDK constraints)    │
+   │  • Token bucket for rate limiting                      │
+   │ TODOs:                                                 │
+   │  • Implement /workflows endpoint                       │
+   │  • Write integration tests for auth flow               │
+   │ ADRs:                                                  │
+   │  • ADR-003: Chunk merging for assistant messages        │
+   │ CONFLICTS:                                             │
+   │  ⚠ Session "infra-design" decided "gRPC for all        │
+   │    services" — contradicts "REST for client API" above  │
+   └────────────────────────────────────────────────────────┘
+
+5. The model now has this context and can work with it
+```
+
+`/threadhop:insights` without an observed session shows nothing useful.
+It reads from files that only exist because `/threadhop:observe` was
+invoked. This coupling is intentional — no observation, no insights.
+
 ### Context injection flow (TUI → clipboard → skill)
 
 The full workflow for carrying context between sessions:
@@ -681,29 +1144,43 @@ For larger exports:
 - [ ] Per-keystroke result updates in search
 - [ ] Jump-to-source from search results (`Enter`)
 - [ ] Search filter syntax: `project:`, `user:`, `assistant:`
+- [ ] Context-aware help overlay + shared command metadata registry
 
-### Phase 3: CLI + Observer
+### Phase 3: CLI + Observer (on-demand + background)
 - [ ] Add argparse subcommand routing (no subcommand = TUI)
 - [ ] Implement `threadhop tag <status> [--session <id>]`
 - [ ] Session auto-detection from current terminal (ps/lsof)
 - [ ] Haiku observer: process conversation chunks, extract typed observations
 - [ ] Observations JSONL output at `~/.config/threadhop/observations.jsonl`
 - [ ] Incremental processing (byte offset tracking per session)
+- [ ] Background observer mode: `threadhop observe` sidecar process (ADR-015)
+- [ ] File-watching via fsevents (macOS) with polling fallback
+- [ ] Auto-detect active session JSONL, exit when session ends
 - [ ] `threadhop todos [--project]` CLI query
 - [ ] `threadhop decisions [--project]` CLI query
 - [ ] `threadhop observations [--project]` CLI query
 
-### Phase 4: Skills
+### Phase 4: Skills (ADR-012, ADR-016)
 - [ ] Research Claude Code skill plugin packaging
 - [ ] `/threadhop:tag <status>` skill (calls CLI)
 - [ ] `/threadhop:context` skill (clipboard formatting + injection)
-- [ ] `/threadhop:handoff <id> [--full]` skill (sub-agent compression)
+- [ ] `/threadhop:handoff <id> [--full]` skill (sub-agent, enhanced with observations)
+- [ ] `/threadhop:observe` skill (per-session opt-in, spawns background observer)
+- [ ] `/threadhop:insights` skill (pull observations + conflicts into conversation)
 
-### Phase 5-6: Memory + Reflector
+### Phase 5: Memory + Bookmarks
 - [ ] Build bookmark system (TUI feature)
 - [ ] Explicit annotation detection (ADR:, DECISION:, TODO: markers)
 - [ ] Project memory markdown rendering from observations
-- [ ] Reflector: condense old observations via Haiku
+
+### Phase 6: Reflector — Conflict Detection (ADR-015)
+- [ ] Build conflict detection reflector (Haiku)
+- [ ] Group decisions by project/topic, identify contradictions across sessions
+- [ ] Conflict reports at `~/.config/threadhop/conflicts.jsonl`
+- [ ] Background reflector mode (runs alongside observer sidecar)
+- [ ] `threadhop conflicts [--project]` CLI query
+- [ ] TUI notification for unreviewed conflicts
+- [ ] Condensation: merge related decisions, archive completed TODOs
 - [ ] Trigram-based fuzzy search for typo tolerance
 
 ---
@@ -725,9 +1202,14 @@ metadata). Per-feature requires explicit tagging of sessions to features.
 is essentially a tag that groups sessions and memory entries across projects.
 
 ### Q3: Observer trigger — when does auto-observation run?
-**Resolved:** On CLI query or TUI launch. When you run `threadhop todos`,
-it processes any unindexed messages first, then filters. No daemon, no hook,
-no background process. The TUI does the same on launch. See ADR-010.
+**Revised (ADR-015 supersedes original resolution):** Two modes:
+- **On-demand (ADR-010):** CLI query or TUI launch triggers observation of
+  unprocessed messages. `threadhop todos` processes first, then displays.
+- **Background (ADR-015):** `threadhop observe` runs as a sidecar process,
+  watching the active session's JSONL via fsevents. Enabled as a flag,
+  similar to Claude Code's remote control mode. The Claude Code terminal
+  does NOT pause — the observer is a background process, not a daemon.
+Both modes coexist. Background mode is additive — on-demand still works.
 
 ### Q4: Skill plugin packaging
 How are Claude Code skill plugins distributed? As a directory of .md files in

--- a/docs/DESIGN-DECISIONS.md
+++ b/docs/DESIGN-DECISIONS.md
@@ -232,7 +232,153 @@ Two transport mechanisms, both instantaneous (no LLM).
 
 ---
 
-### ADR-010: Sidebar resize via keybindings
+### ADR-010: Observer-first architecture
+
+**Context:** Initial design was TUI-first — observations only happened when the
+TUI was running. But the real value is in the observations themselves, not the
+TUI. Users want to query observations from the CLI without launching the TUI.
+
+**Decision:** The observer is the core. The TUI and CLI are both consumers.
+
+```
+Chats happen → observer processes them → observations.jsonl accumulates
+                                              ↓
+                             ThreadHop TUI reads them (browsing)
+                             threadhop todos (CLI query)
+                             grep/jq reads them (raw)
+```
+
+**Observer uses Haiku** for extraction:
+- ~200ms response time, ~$0.25/MTok input — fast and cheap
+- Processes conversation chunks and outputs typed JSONL observations
+- Types: `todo | decision | done | adr | question | blocker`
+- Prompt: extract only explicitly discussed items, do not infer
+
+**Observations stored as JSONL** at `~/.config/threadhop/observations.jsonl`:
+```jsonl
+{"type":"decision","text":"REST over gRPC","context":"Client SDK constraints","project":"agent-atlas","session":"abc123","ts":"2026-04-14T10:30:00Z"}
+{"type":"todo","text":"Implement /workflows endpoint","project":"agent-atlas","session":"abc123","ts":"2026-04-14T11:15:00Z"}
+```
+
+JSONL format means observations are queryable without any app — `grep`, `jq`,
+or the ThreadHop CLI all work.
+
+**Observer triggers on CLI query or TUI launch** — not a daemon, not a hook.
+When you run `threadhop todos`, it:
+1. Checks for unprocessed messages (byte offset tracking)
+2. Runs Haiku on new batches
+3. Appends observations
+4. Filters and displays
+
+**Rationale:**
+- The value is in the data, not the UI
+- JSONL is universally queryable — no vendor lock-in to our app
+- Haiku is fast/cheap enough to run on-demand without perceptible delay
+- No daemon or background process to manage
+
+---
+
+### ADR-011: Dual-mode CLI (TUI + subcommands)
+
+**Context:** ThreadHop was initially TUI-only. With the observer-first
+architecture, users need CLI access to observations, tagging, and handoffs
+without launching the TUI.
+
+**Decision:** Single executable, two modes:
+
+```bash
+# No subcommand = TUI mode
+threadhop
+threadhop --project atlas --days 7
+
+# With subcommand = CLI mode
+threadhop todos                        # list all open TODOs
+threadhop todos --project atlas        # filtered by project
+threadhop decisions                    # all decisions
+threadhop observations                 # everything
+threadhop tag backlog                  # tag current session
+threadhop tag in_review --session abc  # tag specific session
+threadhop handoff abc123               # generate handoff brief
+```
+
+**Session detection for `threadhop tag`:** When called without `--session`,
+detects the current session by scanning `ps` for claude processes in the
+current terminal. Same detection logic the TUI already uses.
+
+**Rationale:**
+- One executable, no separate CLI tool to install
+- Subcommand pattern is familiar (git, docker, etc.)
+- CLI queries trigger the observer, so observations are always fresh
+- Tags can be set from any terminal tab without switching to the TUI
+
+---
+
+### ADR-012: Three skills — tag, context, handoff
+
+**Context:** Need to interact with ThreadHop from within a Claude Code session
+without switching to the TUI or a terminal. Earlier design had two skills.
+Expanded to three with clearer separation.
+
+**Decision:** Three Claude Code skills with distinct roles:
+
+| Skill | What it does | Uses LLM? |
+|---|---|---|
+| `/threadhop:tag <status>` | Tags current session | No — calls `threadhop tag` CLI |
+| `/threadhop:context` | Formats clipboard content as sourced context | No — reads `pbpaste`, formats |
+| `/threadhop:handoff <id>` | Compresses a full session into a brief | Yes — sub-agent with Haiku |
+
+**`/threadhop:tag <status>`** — instant, no LLM:
+1. Detects current session ID from process context
+2. Calls `threadhop tag <status>`
+3. Confirms: "Tagged this session as backlog"
+
+**`/threadhop:context`** — instant, no LLM:
+1. Reads clipboard (`pbpaste`) containing messages copied from TUI
+2. Detects ThreadHop source labels in the content
+3. Presents as a clearly bounded context block in the conversation
+4. The model can now work with the injected context
+
+**`/threadhop:handoff <id> [--full]`** — LLM call:
+1. Reads the JSONL transcript for the given session
+2. Default: sub-agent generates a structured brief (~30-50 lines)
+3. `--full`: sub-agent produces comprehensive handoff with rationale and excerpts
+4. Injects the brief into the current conversation
+
+**Rationale:**
+- Tag: must work mid-conversation without context switching
+- Context: bridges TUI (visual selection) to Claude Code (injection)
+- Handoff: the only one that needs an LLM, clearly separated
+- Three skills is still minimal — each does one thing
+
+**Rejected:** Merging context and handoff into one skill (different mechanisms,
+different cost profiles).
+
+---
+
+### ADR-013: Session tagging from three entry points
+
+**Context:** Session tags (backlog, in_progress, in_review, done, archived)
+need to be settable from multiple places depending on the user's context.
+
+**Decision:** Three entry points, one database:
+
+| Entry point | How | When you'd use it |
+|---|---|---|
+| ThreadHop TUI | Press `s` to cycle status | Triaging multiple sessions |
+| Claude Code skill | `/threadhop:tag backlog` | Mid-conversation, without leaving |
+| Terminal CLI | `threadhop tag backlog` | Quick tag from another tab |
+
+All three write to the same SQLite `sessions` table. The TUI reflects
+changes from CLI/skill on the next 5s refresh.
+
+**Rationale:**
+- Different moments call for different interfaces
+- Shared database means no sync issues
+- The skill is the lightest possible — shells out to the CLI
+
+---
+
+### ADR-014: Sidebar resize via keybindings
 
 **Context:** Session list is hardcoded at 36 characters (`grid-columns: 36 1fr`).
 No way to resize from the UI.
@@ -274,41 +420,48 @@ _Enables instant search and cross-session context sharing. All TUI features._
    - Filter syntax: `project:atlas`, `user:`, `assistant:`
 10. Future: trigram-based fuzzy search for typo tolerance
 
-### Phase 3: Skill Plugin (lean — only LLM-powered operations)
-_Only skills that genuinely need an LLM or benefit from mid-conversation invocation._
+### Phase 3: CLI Subcommands + Observer
+_Observer-first architecture. CLI access to observations without the TUI._
+
+1. Add argparse subcommand routing: no subcommand = TUI, with subcommand = CLI
+2. Implement `threadhop tag <status> [--session <id>]`
+   - Auto-detect session from current terminal when `--session` omitted
+3. Implement Haiku observer:
+   - Process unindexed conversation chunks through Haiku
+   - Extract typed observations (todo, decision, done, adr, question, blocker)
+   - Append to `~/.config/threadhop/observations.jsonl`
+   - Track byte offsets for incremental processing
+4. Implement CLI queries:
+   - `threadhop todos [--project <name>]`
+   - `threadhop decisions [--project <name>]`
+   - `threadhop observations [--project <name>]`
+   - All trigger observer for unprocessed messages before displaying results
+
+### Phase 4: Skill Plugin
+_Three skills for in-session use._
 
 1. Research Claude Code skill plugin packaging/distribution
-2. `/threadhop:handoff <session_id>` — read JSONL, delegate to sub-agent
-   for compression, inject brief into current session
-3. `/threadhop:memory <project>` — read project memory, inject as context
-   (no LLM needed, just formatted file read)
+2. `/threadhop:tag <status>` — detect session ID, call `threadhop tag` CLI
+3. `/threadhop:context` — read clipboard, format with source labels, inject
+4. `/threadhop:handoff <id> [--full]` — sub-agent compresses transcript
 
-**Explicitly NOT skills (these are TUI features):**
-- Search (instantaneous, per-keystroke)
-- Message selection + copy (visual, clipboard)
-- Message export (visual, temp file)
-- Bookmarks (one-key action)
-- Session tagging (one-key action)
-
-### Phase 4: Project Memory + Bookmarks
+### Phase 5: Project Memory + Bookmarks
 _Cross-session knowledge persistence._
 
-1. Add memory table + bookmarks table to schema
+1. Add bookmarks table to schema
 2. Bookmark action from message selection mode (`space` to toggle)
 3. Bookmark browser panel in TUI
-4. Memory ledger: manual entry from TUI (type + text)
-5. `/threadhop:memory <project>` skill to inject project memory
-6. Explicit annotation detection: recognize "ADR:", "DECISION:", "TODO:" markers
-   in conversations and offer to append to ledger
+4. Explicit annotation detection: recognize "ADR:", "DECISION:", "TODO:" markers
+   in conversations and auto-append to observations
+5. Memory rendering: generate project memory markdown from observations for injection
 
-### Phase 5: Auto-Observer + Reflector
-_Automatic knowledge extraction._
+### Phase 6: Reflector
+_Condensation of accumulated observations._
 
-1. Background observer: detect new messages in active sessions during refresh
-2. Auto-extract observations (pattern matching first, `claude -p` later)
-3. Append to memory ledger with `source: "auto"`
-4. Reflector: periodic condensation of old observations
-5. Archive completed TODOs, merge related decisions
+1. When observations.jsonl exceeds threshold, run Haiku reflector
+2. Merge related decisions, archive completed TODOs
+3. Produce condensed observation summaries
+4. Keep source links to original observations
 
 ---
 
@@ -396,22 +549,21 @@ CREATE TABLE memory (
 
 ## Skill Plugin Architecture
 
-### Principle: Only skills that need LLM or can't be done visually
+### Principle: Three skills, clear boundaries
 
-The TUI handles everything that should be instantaneous or visual (search,
-selection, copy, export, tag, bookmark). Skills handle only what benefits
-from being invoked mid-conversation without context-switching to the TUI.
+Skills are for operations invoked mid-conversation from Claude Code. The TUI
+handles everything visual and instantaneous. The CLI handles queries and tagging
+from the terminal.
 
 ### Plugin: `threadhop`
 
 ```
 threadhop/
   skills/
+    tag.md              # /threadhop:tag <status>
+    context.md          # /threadhop:context
     handoff.md          # /threadhop:handoff <session_id>
-    memory.md           # /threadhop:memory <project>
 ```
-
-**Only two skills.** Everything else is a TUI feature.
 
 ### What lives where
 
@@ -421,11 +573,47 @@ threadhop/
 | Message select + copy | TUI | Visual selection, clipboard transport |
 | Message export to .md | TUI | Visual selection, writes to /tmp |
 | Bookmark | TUI | Visual selection, one-key action |
-| Tag session | TUI | One-key action on session list |
+| Tag session | TUI + Skill + CLI | All three entry points, one DB |
+| Observation queries | CLI | `threadhop todos`, `threadhop decisions` |
+| Context injection | Skill | Formats clipboard content with source labels |
 | Handoff | Skill | Needs LLM sub-agent for compression |
-| Memory inject | Skill | Reads project memory file, no LLM needed |
 
-### Handoff flow (the only LLM skill)
+### Skill 1: `/threadhop:tag <status>` (instant, no LLM)
+
+```
+User (in Claude Code): /threadhop:tag backlog
+
+1. Skill detects current session ID from process context
+2. Calls: threadhop tag backlog --session <session_id>
+3. ThreadHop CLI writes tag to SQLite
+4. Confirms: "Tagged this session as backlog"
+```
+
+### Skill 2: `/threadhop:context` (instant, no LLM)
+
+Bridges the TUI (visual selection) to Claude Code (context injection).
+User copies messages from the TUI, then invokes this skill to present
+them cleanly in the current conversation.
+
+```
+User (in Claude Code): /threadhop:context
+
+1. Skill reads clipboard (pbpaste)
+2. Detects ThreadHop source labels in the content
+3. Presents as a clearly bounded context block:
+
+   ┌─ From "API contracts" — ~/agent-atlas — 2026-04-12 ─┐
+   │ User: What about rate limiting?                       │
+   │ Claude: Two options: leaky bucket vs token bucket...  │
+   └───────────────────────────────────────────────────────┘
+
+4. The model now has this context and can work with it
+```
+
+### Skill 3: `/threadhop:handoff <id> [--full]` (LLM call)
+
+The only skill that uses an LLM. Compresses an entire session transcript
+into a brief for starting a fresh session.
 
 ```
 User (in Claude Code): /threadhop:handoff abc123
@@ -433,48 +621,41 @@ User (in Claude Code): /threadhop:handoff abc123
 1. Skill locates ~/.claude/projects/**/abc123.jsonl
 2. Parses JSONL → clean (role, text) pairs
 3. Strips system-reminders, abbreviates tool calls
-4. Spawns sub-agent with:
-   - Parsed transcript (full conversation)
+4. Spawns sub-agent (Haiku for speed, configurable) with:
+   - Parsed transcript
    - Prompt: "Generate a handoff brief. Focus on: decisions made (with
      rationale), current implementation state, open questions, and what
-     the next session needs to know. Format as structured markdown."
-5. Sub-agent returns handoff brief (~30-50 lines)
-6. Skill injects brief into current conversation:
-   "[Handoff from session 'API contracts' (abc123, 2026-04-12)]
-    ## Decisions made..."
+     the next session needs to know."
+5. Sub-agent returns brief (~30-50 lines)
+6. Brief injected into current conversation
+
+With --full flag:
+   Sub-agent produces comprehensive handoff with rationale,
+   code references, and conversation excerpts.
 ```
 
 The raw transcript lives only in the sub-agent's context.
 The main session sees only the compressed brief.
 
-### Memory inject flow (file read, no LLM)
+### Context injection flow (TUI → clipboard → skill)
+
+The full workflow for carrying context between sessions:
 
 ```
-User (in Claude Code): /threadhop:memory agent-atlas
-
-1. Skill reads project memory from SQLite (or rendered .md cache)
-2. Formats as structured context with section headers
-3. Injects directly — no sub-agent, no compression
+1. Open ThreadHop TUI
+2. Navigate to source session, view transcript
+3. Enter message select mode (m)
+4. Select messages visually (j/k to move, v for range)
+5. Press y → copied to clipboard with source labels
+6. Switch to Claude Code session
+7. Type /threadhop:context → clipboard content formatted and injected
 ```
 
-### Context injection flow (TUI → clipboard/file → other session)
-
-This is NOT a skill. It's a TUI workflow:
-
+For larger exports:
 ```
-1. User opens ThreadHop TUI
-2. Navigates to source session, views transcript
-3. Enters message select mode (m)
-4. Selects messages visually (j/k to move, v for range)
-5. Either:
-   a. Press y → copied to clipboard with source labels
-      → paste into any Claude Code / T3 session
-   b. Press e → exported to /tmp/threadhop/<id>-<ts>.md
-      → reference from any session: "Read /tmp/threadhop/..."
-6. The TUI shows confirmation: "3 messages copied" or "Exported to /tmp/..."
+5. Press e → exported to /tmp/threadhop/<id>-<ts>.md
+6. In Claude Code: "Read /tmp/threadhop/..."
 ```
-
-No message numbers. No opaque ranges. Visual selection, instant transport.
 
 ---
 
@@ -501,15 +682,28 @@ No message numbers. No opaque ranges. Visual selection, instant transport.
 - [ ] Jump-to-source from search results (`Enter`)
 - [ ] Search filter syntax: `project:`, `user:`, `assistant:`
 
-### Later (Phase 3-5)
+### Phase 3: CLI + Observer
+- [ ] Add argparse subcommand routing (no subcommand = TUI)
+- [ ] Implement `threadhop tag <status> [--session <id>]`
+- [ ] Session auto-detection from current terminal (ps/lsof)
+- [ ] Haiku observer: process conversation chunks, extract typed observations
+- [ ] Observations JSONL output at `~/.config/threadhop/observations.jsonl`
+- [ ] Incremental processing (byte offset tracking per session)
+- [ ] `threadhop todos [--project]` CLI query
+- [ ] `threadhop decisions [--project]` CLI query
+- [ ] `threadhop observations [--project]` CLI query
+
+### Phase 4: Skills
 - [ ] Research Claude Code skill plugin packaging
-- [ ] Implement handoff skill with sub-agent delegation
-- [ ] Implement memory injection skill (file read, no LLM)
-- [ ] Build bookmark system (TUI feature, not skill)
-- [ ] Build project memory ledger
-- [ ] Add explicit annotation detection
-- [ ] Build auto-observer
-- [ ] Build reflector
+- [ ] `/threadhop:tag <status>` skill (calls CLI)
+- [ ] `/threadhop:context` skill (clipboard formatting + injection)
+- [ ] `/threadhop:handoff <id> [--full]` skill (sub-agent compression)
+
+### Phase 5-6: Memory + Reflector
+- [ ] Build bookmark system (TUI feature)
+- [ ] Explicit annotation detection (ADR:, DECISION:, TODO: markers)
+- [ ] Project memory markdown rendering from observations
+- [ ] Reflector: condense old observations via Haiku
 - [ ] Trigram-based fuzzy search for typo tolerance
 
 ---
@@ -531,11 +725,9 @@ metadata). Per-feature requires explicit tagging of sessions to features.
 is essentially a tag that groups sessions and memory entries across projects.
 
 ### Q3: Observer trigger — when does auto-observation run?
-Options:
-- On the TUI's 5s refresh cycle (piggyback, always-on)
-- On session close/inactivity detection (event-driven)
-- On-demand only (manual trigger)
-**Leaning:** On-demand for v1 (via skill or TUI action). Piggyback for v2.
+**Resolved:** On CLI query or TUI launch. When you run `threadhop todos`,
+it processes any unindexed messages first, then filters. No daemon, no hook,
+no background process. The TUI does the same on launch. See ADR-010.
 
 ### Q4: Skill plugin packaging
 How are Claude Code skill plugins distributed? As a directory of .md files in
@@ -549,9 +741,9 @@ contents, command output) and would dominate search with noise.
 find themselves wanting to search "what was the output of that command."
 
 ### Q6: Handoff sub-agent model
-The handoff skill delegates transcript compression to a sub-agent. Which model?
-Haiku for speed/cost? Sonnet for quality? Configurable?
-**Leaning:** Default to the same model as the parent session. Allow override.
+**Resolved:** Haiku for the observer (fast, cheap, structured extraction).
+Handoff skill defaults to Haiku for speed (~200ms, ~$0.25/MTok). `--full` flag
+can use a stronger model. Configurable via CLI flag or config. See ADR-010.
 
 ---
 

--- a/docs/DESIGN-DECISIONS.md
+++ b/docs/DESIGN-DECISIONS.md
@@ -248,20 +248,30 @@ Chats happen → observer processes them → observations.jsonl accumulates
                              grep/jq reads them (raw)
 ```
 
-**Observer uses Haiku** for extraction:
-- ~200ms response time, ~$0.25/MTok input — fast and cheap
+**Observer uses Haiku via `claude -p`** (amended 2026-04-17, see ADR-018):
+- Invoked as `claude -p --model haiku --permission-mode acceptEdits`
+- NOT the Anthropic API — uses the same Claude subscription, same binary
+- ~200ms response time — fast and cheap under one subscription
 - Processes conversation chunks and outputs typed JSONL observations
-- Types: `todo | decision | done | adr | question | blocker`
+- Types: `todo | decision | done | adr | observation | conflict`
 - Prompt: extract only explicitly discussed items, do not infer
+- Reusable prompt lives at `~/.config/threadhop/prompts/observer.md`
 
-**Observations stored as JSONL** at `~/.config/threadhop/observations.jsonl`:
+**Observations stored as per-session JSONL** (amended 2026-04-17, see ADR-019)
+at `~/.config/threadhop/observations/<session_id>.jsonl`:
 ```jsonl
-{"type":"decision","text":"REST over gRPC","context":"Client SDK constraints","project":"agent-atlas","session":"abc123","ts":"2026-04-14T10:30:00Z"}
-{"type":"todo","text":"Implement /workflows endpoint","project":"agent-atlas","session":"abc123","ts":"2026-04-14T11:15:00Z"}
+{"type":"decision","text":"REST over gRPC","context":"Client SDK constraints","ts":"2026-04-14T10:30:00Z"}
+{"type":"todo","text":"Implement /workflows endpoint","context":"","ts":"2026-04-14T11:15:00Z"}
 ```
 
+One file per session — the session ID is in the filename, not duplicated in
+every line. Project is looked up from the `sessions` table. Byte offsets are
+tracked in the `observation_state` table, not in observation entries. Each
+line stays minimal: type + text + context + timestamp.
+
 JSONL format means observations are queryable without any app — `grep`, `jq`,
-or the ThreadHop CLI all work.
+or the ThreadHop CLI all work. Per-session scoping means single-session
+queries read one file, not grep through a global log.
 
 **Observer triggers on CLI query or TUI launch** — not a daemon, not a hook.
 When you run `threadhop todos`, it:
@@ -442,13 +452,13 @@ Claude Code session (primary agent)
     ↓ writes JSONL
 ~/.claude/projects/.../<session>.jsonl
     ↑ watches (fsevents / polling)
-Observer process (background, Haiku)
+Observer process (claude -p --model haiku --permission-mode acceptEdits)
     ↓ appends typed observations
-~/.config/threadhop/observations.jsonl
-    ↑ reads periodically
-Reflector process (background, Haiku)
-    ↓ writes conflict reports
-~/.config/threadhop/conflicts.jsonl
+~/.config/threadhop/observations/<session_id>.jsonl    ← per-session file (ADR-019)
+    ↑ reads periodically (every 5-6 new entries)
+Reflector process (claude -p --model haiku, companion to observer)
+    ↓ appends type:"conflict" entries to SAME file     ← unified output (ADR-020)
+~/.config/threadhop/observations/<session_id>.jsonl
 ```
 
 **Enabling from Claude Code — per-session opt-in (primary, see ADR-016):**
@@ -485,7 +495,7 @@ See ADR-016 for the full trigger and injection design.
    - Appends typed JSONL observations to `observations.jsonl`
 5. Runs until the Claude Code session exits or manually stopped
 
-**Reflector behaviour — conflict detection:**
+**Reflector behaviour — conflict detection (amended 2026-04-17, see ADR-020):**
 
 The reflector's purpose is NOT condensation (Mastra's approach). It is
 specifically to **detect contradictory decisions** across sessions.
@@ -494,15 +504,18 @@ Example conflict:
 ```jsonl
 {"type":"decision","text":"REST over gRPC for client API","project":"atlas","session":"abc","ts":"..."}
 {"type":"decision","text":"gRPC for all service-to-service comms","project":"atlas","session":"def","ts":"..."}
-→ CONFLICT: REST vs gRPC scope overlap — both cover service communication
+→ Reflector appends: {"type":"conflict","text":"REST vs gRPC scope overlap","refs":["abc","def"],...}
 ```
 
 The Reflector:
-1. Runs at lower frequency (every N new observations, or every M minutes)
-2. Groups decisions by project and semantic topic
-3. Uses Haiku to identify contradictions between decisions
-4. Writes conflict reports to `conflicts.jsonl` for human review
-5. Surfaces conflicts via TUI notification or CLI query (`threadhop conflicts`)
+1. Runs as a companion to the observer, NOT independently triggered
+2. Accumulates like the observer — processes every 5-6 new messages, not per-decision
+3. Groups decisions by project and semantic topic
+4. Uses Haiku to identify contradictions between decisions
+5. **Appends conflict entries to the SAME per-session observation JSONL** (ADR-020) —
+   no separate `conflicts.jsonl`. Conflicts are `type: "conflict"` entries alongside
+   decisions, TODOs, etc. Forward-only, append-only — same constraints as observer.
+6. Surfaces conflicts via TUI notification or CLI query (`threadhop conflicts`)
 
 **Why NOT a daemon:**
 
@@ -613,32 +626,34 @@ User: /threadhop:insights
 This is the same pattern as `/threadhop:context` (read data, format, inject)
 but reads from the observer's output instead of the clipboard.
 
-**Pull-based context injection — new session (enhanced handoff):**
+**Pull-based context injection — new session (handoff, amended 2026-04-17):**
 
-When the source session was observed, `/threadhop:handoff` is enhanced:
+The handoff skill always uses the observer as its underlying function.
+There is no separate "compress from raw JSONL" path. See ADR-018 for
+the observer-as-core-function principle.
 
 ```
 User (new session): /threadhop:handoff abc123
 
-Without observations (current behaviour):
-  1. Read entire JSONL (~thousands of lines)
-  2. Parse, strip, abbreviate
-  3. Send full transcript to Haiku sub-agent
-  4. Sub-agent compresses from scratch → ~30-50 line brief
-
-With observations (enhanced):
-  1. Read observations.jsonl filtered by session abc123
+If observations exist for abc123:
+  1. Read observations/<session_id>.jsonl
   2. Observations already typed, structured, compressed
-  3. Send observations + conflicts to Haiku sub-agent
-  4. Sub-agent generates brief from structured input
-  5. Brief includes: decisions with rationale, open TODOs,
+  3. Format into handoff brief (may use Haiku for final polish)
+  4. Brief includes: decisions with rationale, open TODOs,
      unresolved conflicts, current state
-  → Faster (less input), higher quality (structured input)
+
+If NO observations exist for abc123:
+  1. Run the observer on the full session (from byte 0)
+  2. Observer processes entire JSONL, writes observations/<session_id>.jsonl
+  3. Read the freshly-written observations
+  4. Format into handoff brief
+  → Same result as if the session had been observed all along
 ```
 
-The handoff doesn't *replace* reading the raw transcript — it uses
-observations as primary input and can optionally pull raw messages for
-context where the observation is too compressed.
+The observer is the core function — handoff is an entry point that
+runs the observer first (if needed), then formats. No separate
+compression path exists. This guarantees identical results whether
+a session was observed incrementally or in one shot at handoff time.
 
 **The complete feedback loop:**
 
@@ -653,11 +668,11 @@ Session A (architectural discussion):
   7. Session gets long, user wants to continue elsewhere
 
 Session B (continuation):
-  1. /threadhop:handoff A → brief built from pre-extracted observations
-  2. /threadhop:conflicts → "1 conflict: Session A vs Session C on REST/gRPC"
+  1. /threadhop:handoff A → runs observer if needed, formats from observations
+  2. /threadhop:insights → includes conflict entries from the same observation file
   3. User resolves conflict in this conversation
   4. /threadhop:observe → now observing Session B, captures the resolution
-  5. Resolution appears in observations.jsonl as a new decision
+  5. Resolution appears in observations/<session_B_id>.jsonl as a new decision
 ```
 
 The loop closes: **observe → extract → surface → resolve → observe the
@@ -746,6 +761,510 @@ pattern as search, and back it with a shared command metadata registry.
 
 ---
 
+### ADR-018: Observer as core function — `claude -p` invocation, not API
+
+**Context:** ADR-010 and ADR-015 described the observer using "Haiku" without
+specifying the invocation mechanism. There was ambiguity about whether this
+meant an Anthropic API call (requiring an API key and separate billing) or
+something else. The intent was always to use the same Claude subscription.
+
+**Decision:** The observer invokes `claude -p --model haiku --permission-mode
+acceptEdits` — headless Claude Code, not the Anthropic API.
+
+**Invocation:**
+
+```bash
+claude -p "$(cat ~/.config/threadhop/prompts/observer.md)
+
+<session_chunk>
+$(tail -c +$BYTE_OFFSET <source_jsonl_path>)
+</session_chunk>
+
+Append observations to: $OBS_FILE_PATH" \
+  --model haiku \
+  --permission-mode acceptEdits
+```
+
+**The observer prompt** lives at `~/.config/threadhop/prompts/observer.md`
+(or bundled with the app). It is a reusable, static prompt that constrains:
+
+1. **Append-only**: You may only append to the observation file. Never delete
+   or modify existing lines.
+2. **One JSON line per observation**: If you identify 3 decisions, write 3
+   separate JSON lines. Each line is a complete, self-contained JSON object.
+3. **No permission to delete**: The `acceptEdits` mode allows file writes
+   but the prompt explicitly forbids deletion or modification of existing
+   content.
+4. **Typed extraction only**: Extract items that were explicitly discussed.
+   Do not infer, speculate, or synthesize. Types:
+   `todo | decision | done | adr | observation | conflict`
+
+**Observation JSONL line format (minimal — metadata lives elsewhere):**
+
+```jsonl
+{"type":"decision","text":"REST over gRPC","context":"Client SDK constraints","ts":"2026-04-14T10:30:00Z"}
+{"type":"todo","text":"Implement /workflows endpoint","context":"","ts":"2026-04-14T11:15:00Z"}
+```
+
+Each line has only four fields: `type`, `text`, `context`, `ts`. No session ID
+(encoded in filename: `observations/<session_id>.jsonl`), no project (looked
+up from `sessions` table), no byte offset (tracked in `observation_state`
+table). This keeps every line minimal and avoids duplicating metadata that
+the caller already knows.
+
+**Why `claude -p` and not the Anthropic API:**
+- No API key management — uses the same Claude subscription
+- No separate billing — all under one account
+- Uses the same `claude` binary already installed
+- `--permission-mode acceptEdits` provides just enough filesystem access
+  to append to the observation file, nothing more
+- The observer process is just another `claude -p` invocation with a
+  crafted prompt — same as how the user uses Claude Code
+
+**The observer is the core function:**
+
+Every feature that needs observations uses the same observer logic:
+
+| Entry point | Calls observer? | Then what? |
+|---|---|---|
+| `threadhop observe --session X` (CLI) | Yes, in watch mode | Keeps running, appends as messages arrive |
+| `/threadhop:observe` (skill) | Yes, spawns background | Same as CLI but auto-detects session |
+| `/threadhop:handoff X` (skill) | Yes, if no observations exist | Runs observer on full session, then formats |
+| `threadhop todos` (CLI query) | Yes, on-demand for unprocessed | Then filters and displays |
+| TUI re-observe trigger | Yes, resumes from last offset | Same observer, picks up where it left off |
+
+All entry points produce identical observations. A session observed
+incrementally over 2 hours produces the same JSONL as one observed
+in a single shot at handoff time. The observer function is deterministic
+given the same input — entry point doesn't affect output.
+
+**Rationale:**
+- Single function, multiple entry points — no code duplication
+- Reusable prompt file means the extraction logic is testable and
+  versionable independently of the app code
+- `acceptEdits` is the minimum permission — can't read arbitrary files,
+  can't execute commands, can only write to the specified output path
+- Headless mode means the observer process is invisible to the user
+
+---
+
+### ADR-019: Per-session observation files with SQLite state tracking
+
+**Context:** ADR-010 stored all observations in a single global
+`observations.jsonl`. With per-session opt-in (ADR-016) and the observer
+as a core function (ADR-018), observations need to be scoped to individual
+sessions. The observer also needs state persistence — byte offsets, PID
+tracking, observation counts — to support stop/resume, TUI indicators,
+and handoff lookups.
+
+**Decision:** One observation file per session, state tracked in SQLite.
+
+**File layout:**
+
+```
+~/.config/threadhop/observations/
+  abc123.jsonl          ← observations for session abc123
+  def456.jsonl          ← observations for session def456
+```
+
+Per-session files make:
+- Session-scoped queries instant (read one file, not grep through global)
+- The "has observations" indicator trivial (file exists + entry count > 0)
+- Handoff a single file read
+- Cleanup straightforward (delete when session archived)
+
+**SQLite state table (`observation_state`, updated with reflector offset per ADR-022):**
+
+```sql
+CREATE TABLE observation_state (
+    session_id              TEXT PRIMARY KEY,
+    source_path             TEXT NOT NULL,       -- path to source session JSONL
+    obs_path                TEXT NOT NULL,       -- path to observations JSONL
+    source_byte_offset      INTEGER NOT NULL DEFAULT 0,  -- where observer last read
+    entry_count             INTEGER NOT NULL DEFAULT 0,   -- total observations written
+    reflector_entry_offset  INTEGER NOT NULL DEFAULT 0,   -- last entry reflector processed
+    observer_pid            INTEGER,             -- PID if running, NULL otherwise
+    status                  TEXT NOT NULL DEFAULT 'idle',
+        -- idle | running | stopped
+    started_at              REAL,                -- when observation first started
+    last_observed_at        REAL,                -- when last observation appended
+    FOREIGN KEY (session_id) REFERENCES sessions(session_id)
+);
+```
+
+**State lifecycle:**
+
+```
+idle → running (observer starts, PID recorded)
+  ↓
+running → stopped (observer exits or user stops it)
+  ↓
+stopped → running (user re-observes, resumes from source_byte_offset)
+```
+
+**Re-observation from any entry point:**
+
+When the user triggers observation on a session that was previously
+observed (and stopped), the observer checks `source_byte_offset`:
+- If the source JSONL has grown since last observation → process only
+  new bytes (from offset to EOF)
+- If no new bytes → "Already up to date. N observations on file."
+- Then switches to watch mode (if background) or exits (if on-demand)
+
+This is the same incremental logic regardless of entry point. The state
+table is the single source of truth for "where did we leave off."
+
+**PID tracking for lifecycle management:**
+
+The `observer_pid` column enables:
+- TUI detection of "is this session currently being observed?"
+- `threadhop observe --stop` sends SIGTERM to the recorded PID
+- Stale PID detection: if the PID is recorded but the process is dead
+  (checked via `kill -0 $PID`), status is corrected to `stopped`
+- `threadhop observe --stop-all` queries all rows with non-null PIDs
+
+**Stop mechanisms:**
+
+```bash
+threadhop observe --stop                    # stops current session's observer
+threadhop observe --stop --session abc123   # stops specific observer
+threadhop observe --stop-all                # stops all running observers
+```
+
+All use SIGTERM to the recorded PID. Observer handles SIGTERM gracefully:
+flushes any pending observations, updates `source_byte_offset` in SQLite,
+sets `status = 'stopped'`, exits cleanly.
+
+**Rationale:**
+- Per-session files eliminate grep/filter overhead for single-session queries
+- SQLite state tracking enables stop/resume, indicator queries, stale
+  PID detection — all the lifecycle management the TUI and CLI need
+- `entry_count` is maintained alongside byte offset so the TUI indicator
+  can check "has observations" without reading the file
+- The state table bridges all entry points — CLI, skill, TUI all read
+  and write the same state
+
+---
+
+### ADR-020: Unified observation JSONL — observer and reflector share one file
+
+**Context:** ADR-015 originally specified separate files: `observations.jsonl`
+for the observer and `conflicts.jsonl` for the reflector. With per-session
+files (ADR-019), a separate conflicts file per session adds storage overhead
+and query complexity. The reflector's output (conflict entries) is semantically
+an observation — it's an insight extracted from the conversation, just at a
+higher level of abstraction.
+
+**Decision:** Observer and reflector both append to the same per-session
+observation JSONL. No separate `conflicts.jsonl`. Conflicts are entries
+with `type: "conflict"` alongside all other observation types.
+
+**Unified entry types:**
+
+```jsonl
+{"type":"decision","text":"REST over gRPC","context":"SDK constraints","ts":"..."}
+{"type":"todo","text":"Implement /workflows endpoint","context":"","ts":"..."}
+{"type":"conflict","text":"REST vs gRPC scope overlap","refs":["abc123","def456"],"topic":"api-protocol","ts":"..."}
+{"type":"done","text":"Auth flow tests passing","context":"","ts":"..."}
+```
+
+Lines are minimal — session and project are NOT stored per line. Session is
+encoded in the filename. Conflict entries add `refs` and `topic` for
+cross-session linking and dedup.
+
+**Write rules (same for observer and reflector):**
+1. **Forward-only**: Append new lines. Never delete or modify existing lines.
+2. **One JSON line per entry**: Self-contained, independently parseable.
+3. **No edit permission**: Even if a TODO is marked done later, a new
+   `type: "done"` entry is appended — the original TODO line remains.
+
+**Reflector cadence:**
+
+The reflector does NOT wake on every new decision. It accumulates like
+the observer — every 5-6 new messages worth of observations, it scans
+for contradictions across the project's sessions. It is a companion
+process to the observer, not an independent daemon.
+
+```
+Observer appends observations → reflector notices growth
+  → after 5-6 new entries, reflector reads recent decisions
+  → compares with decisions from other sessions in same project
+  → appends type:"conflict" entries if contradictions found
+```
+
+**Why not a separate conflicts file:**
+- One file per session is simpler to manage, query, and clean up
+- Conflicts are semantically observations — higher-level ones
+- The insights skill reads one file, not two
+- The handoff skill reads one file, not two
+- `grep "conflict" observations/abc123.jsonl` works for quick conflict checks
+- Append-only, forward-only means no write contention between observer and
+  reflector — they can both safely append to the same file
+
+**Rejected:** Separate `conflicts.jsonl` per session (extra file overhead,
+split queries, two files to manage per session).
+**Rejected:** Global `conflicts.jsonl` (requires filtering, defeats
+per-session scoping).
+
+---
+
+### ADR-022: Reflector implementation — prompt, invocation, and state tracking
+
+**Context:** ADR-015 and ADR-020 established that the reflector detects
+contradictory decisions across sessions and appends `type: "conflict"`
+entries to the same per-session observation JSONL. But the design never
+specified how the reflector is actually invoked, what input it receives,
+what its prompt looks like, or how it tracks its own state. Unlike the
+observer (which reads raw JSONL transcripts), the reflector works at the
+**observation layer** — it reads decisions from observation files, not
+source transcripts. This makes its input shape fundamentally different.
+
+**Decision:** The reflector is a second `claude -p` call, triggered by
+the observer process, with its own prompt and its own offset tracking.
+
+**Input shape — observer vs reflector:**
+
+```
+Observer reads:        Source JSONL (raw transcript) → extracts observations
+Reflector reads:       Observation JSONLs (extracted decisions) → finds contradictions
+```
+
+The reflector never touches the source transcripts. It operates entirely
+on the already-extracted observation layer. Its input is:
+
+1. **Recent decisions from the current session** — new `type: "decision"`
+   entries since the reflector last ran (tracked by `reflector_entry_offset`)
+2. **All decisions from other sessions in the same project** — gathered by
+   scanning `observations/<other_session>.jsonl` files that share the same
+   `project` value
+
+Both sets are piped into the prompt as structured input.
+
+**Invocation:**
+
+```bash
+claude -p "$(cat ~/.config/threadhop/prompts/reflector.md)
+
+<current_session_decisions>
+# Recent decisions from session abc123 (since reflector last ran)
+$(jq -c 'select(.type==\"decision\")' observations/abc123.jsonl | tail -n +$REFLECTOR_OFFSET)
+</current_session_decisions>
+
+<project_decisions>
+# All decisions from other sessions in project 'atlas'
+$(for f in observations/*.jsonl; do
+    jq -c 'select(.type==\"decision\" and .project==\"atlas\")' "$f"
+  done | grep -v '\"session\":\"abc123\"')
+</project_decisions>
+
+If you find contradictions, append conflict entries to: observations/abc123.jsonl" \
+  --model haiku \
+  --permission-mode acceptEdits
+```
+
+**The reflector prompt** lives at `~/.config/threadhop/prompts/reflector.md`
+(alongside `observer.md`). It constrains:
+
+1. **Append-only**: Same rules as observer — forward-only, no deletions.
+2. **One JSON line per conflict**: Each conflict is a self-contained entry.
+3. **Conflict deduplication**: Before appending, check if the same pair of
+   sessions + same topic already has a conflict entry. If yes, skip.
+   (The prompt includes existing conflict entries for this check.)
+4. **Structured conflict format**: Each conflict entry must reference both
+   sessions and explain the contradiction clearly.
+
+**Conflict entry format:**
+
+```jsonl
+{"type":"conflict","text":"REST vs gRPC scope overlap — session abc decided REST for client API, session def decided gRPC for all services","refs":["abc123","def456"],"topic":"api-protocol","session":"abc123","project":"atlas","ts":"2026-04-14T12:00:00Z"}
+```
+
+Fields:
+- `refs`: array of session IDs involved in the contradiction
+- `topic`: semantic grouping key (helps dedup and display)
+- `session`: the session this entry lives in (where the reflector was triggered)
+- Other fields same as observer entries
+
+**Trigger mechanism — observer spawns reflector:**
+
+The reflector is NOT an independent process. The observer triggers it:
+
+```
+Observer loop:
+  1. Watch source JSONL for new messages
+  2. When ~3-4 new messages: run observer extraction (claude -p)
+  3. Observer appends observations, increments entry_count
+  4. Check: has entry_count grown by ≥5 since reflector_entry_offset?
+     → YES: spawn reflector (claude -p with reflector prompt)
+     → NO: continue watching
+  5. Reflector appends any conflicts, updates reflector_entry_offset
+```
+
+The observer process owns the reflector's lifecycle. There is no separate
+reflector daemon, PID, or stop mechanism. When the observer stops, the
+reflector stops. When the observer resumes, the reflector resumes from
+its own offset.
+
+**On-demand reflector (for handoff and CLI queries):**
+
+When the observer core function runs on-demand (e.g., `threadhop handoff`
+or `threadhop conflicts`), the reflector runs as a follow-up step:
+
+```
+threadhop conflicts --project atlas:
+  1. For each session in project: run observer if unprocessed messages exist
+  2. Run reflector for each session with new decisions
+  3. Display all type:"conflict" entries across project
+```
+
+Same function, different trigger — just like the observer.
+
+**State tracking — reflector offset in observation_state:**
+
+The `observation_state` table gains one column for the reflector:
+
+```sql
+ALTER TABLE observation_state ADD COLUMN
+    reflector_entry_offset  INTEGER NOT NULL DEFAULT 0;
+    -- last entry index the reflector has processed
+```
+
+This means:
+- `entry_count = 15, reflector_entry_offset = 10` → 5 unprocessed entries,
+  reflector should run
+- `entry_count = 15, reflector_entry_offset = 15` → up to date, skip
+- After reflector runs: `reflector_entry_offset = entry_count`
+
+The offset tracks entries (line count in observation JSONL), not bytes —
+because the reflector reads structured observations, not raw transcript.
+
+**Where conflicts are written — single-session scoping:**
+
+When session A said "REST" and session B said "gRPC", the conflict is
+written to **the session currently being observed** (the one whose observer
+triggered the reflector). The `refs` array links both sessions.
+
+If the other session is later observed, the reflector will discover the
+same contradiction from the other side and write its own conflict entry
+there. This is intentional — each session's observation file tells its
+own complete story, including conflicts it's involved in.
+
+**Deduplication prevents noise:** The reflector prompt includes existing
+`type: "conflict"` entries from the current session. Before writing a new
+conflict, it checks: "is there already a conflict entry with the same
+`refs` pair and `topic`?" If yes, skip. This means re-running the
+reflector is idempotent.
+
+**Prompt file layout:**
+
+```
+~/.config/threadhop/prompts/
+  observer.md           ← extraction prompt (ADR-018)
+  reflector.md          ← conflict detection prompt (this ADR)
+```
+
+**Rationale:**
+- Observer triggers reflector → no extra daemon, no extra PID management
+- Reflector operates on observation layer, not transcript layer — smaller
+  input, faster processing, and it doesn't need to understand raw JSONL
+- Entry-count offset tracking is simpler than byte offsets (observations
+  are structured, line-per-entry)
+- Single-session scoping with `refs` links means each session file is
+  self-contained while still enabling cross-session conflict queries
+- Dedup in the prompt means reflector is idempotent — safe to re-run
+- Same `claude -p --model haiku --permission-mode acceptEdits` invocation
+  as observer — no new execution model to build
+
+---
+
+### ADR-021: Observation indicator in TUI session list + transcript header
+
+**Context:** When a session has been observed (observations exist), the
+user needs a way to know this from the TUI without opening the transcript
+or running a CLI command. The existing session status circles (◐ ● ○)
+indicate process state and should not be overloaded with observation state —
+remembering what each circle variant means is already enough cognitive load.
+
+**Decision:** Add a small notepad-style icon next to the session name for
+observed sessions. Add a subtle header line in the transcript view showing
+the observation file path and entry count.
+
+**Session list indicator:**
+
+```
+● my-session 🗒             ← observed (has observations)
+○ another-session            ← not observed
+◐ active-work                ← working, no observations
+◐ active-work 🗒             ← working AND observed
+```
+
+The `🗒` (or a terminal-safe fallback like `≡` or `[O]`) appears after the
+session name when `observation_state.entry_count > 0` for that session.
+This is checked during the existing 5s refresh cycle — no extra DB queries.
+
+If emoji rendering is unreliable across terminals, fall back to a Rich
+markup colored marker: `[dim]≡[/dim]` or `[dim cyan]obs[/dim cyan]`.
+
+**Transcript header (Option B — subtle, non-interfering):**
+
+When viewing a transcript that has observations, show a one-line header
+above the first message:
+
+```
+─── 🗒 12 observations · ~/.config/threadhop/observations/abc123.jsonl ───
+```
+
+This header:
+- Is positioned above the transcript content, below the session title area
+- Does NOT interfere with the persistent search bar (which is at the bottom)
+- Is static (not a focusable widget) — purely informational
+- Shows the entry count and file path for quick reference
+- Can be selected/copied for use in another terminal
+
+**TUI action for observation path:**
+
+When an observed session is highlighted in the session list, pressing `o`
+(for "observations") copies the file path to clipboard:
+
+```
+~/.config/threadhop/observations/abc123.jsonl
+```
+
+Notification: "Observation path copied — view in terminal or IDE"
+
+This gives the user a fast path to `cat`, `jq`, or IDE-open the
+observation file without remembering the path structure.
+
+**TUI re-observe trigger:**
+
+When pressing `o` on a session that has NO observations yet, instead of
+copying a non-existent path, offer to start observation:
+
+```
+Press o on unobserved session → "No observations yet. Start observing? (y/n)"
+  y → spawns observer, same as `threadhop observe --session <id>`
+  n → dismiss
+```
+
+When pressing `o` on a session that has observations but the observer is
+stopped, offer to resume:
+
+```
+Press o on observed+stopped session → copies path (observations exist)
+Press O (shift) → "Resume observing? (y/n)"
+  y → resumes from last byte offset
+```
+
+**Rationale:**
+- The notepad icon is additive — doesn't change the meaning of existing circles
+- The transcript header is passive (no interaction needed) and positioned
+  to avoid conflicting with search or footer
+- Copying the file path is the lowest-overhead way to bridge TUI → terminal/IDE
+- Re-observe from TUI closes the loop: discover observations exist → re-observe
+  if session has grown → observations update
+
+---
+
 ## Implementation Plan
 
 ### Phase 1: SQLite Foundation + Session Tags + Archive
@@ -784,39 +1303,58 @@ _Enables instant search and cross-session context sharing. All TUI features._
 
 ### Phase 3: CLI Subcommands + Observer (on-demand + background)
 _Observer-first architecture. CLI access to observations without the TUI.
-Background mode for continuous observation during active sessions._
+Observer uses `claude -p --model haiku --permission-mode acceptEdits` (ADR-018).
+Per-session observation files with SQLite state tracking (ADR-019)._
 
 1. Add argparse subcommand routing: no subcommand = TUI, with subcommand = CLI
 2. Implement `threadhop tag <status> [--session <id>]`
    - Auto-detect session from current terminal when `--session` omitted
-3. Implement Haiku observer (on-demand mode, ADR-010):
-   - Process unindexed conversation chunks through Haiku
-   - Extract typed observations: `todo | decision | done | adr | observation`
-   - Append to `~/.config/threadhop/observations.jsonl`
-   - Track byte offsets for incremental processing
-4. Implement background observer mode (ADR-015):
-   - `threadhop observe` — runs as background sidecar process
+3. Create reusable observer prompt at `~/.config/threadhop/prompts/observer.md`
+   - Append-only, one JSON line per observation, typed extraction only
+   - Types: `todo | decision | done | adr | observation | conflict`
+4. Add `observation_state` table to SQLite schema (ADR-019)
+5. Implement observer core function (ADR-018):
+   - Reads source JSONL from `source_byte_offset` (or byte 0 for new sessions)
+   - Invokes `claude -p --model haiku --permission-mode acceptEdits`
+   - Appends typed observations to `~/.config/threadhop/observations/<session_id>.jsonl`
+   - Updates `source_byte_offset` and `entry_count` in SQLite
+   - Same function used by all entry points (CLI, skill, handoff, TUI)
+6. Implement background observer mode (ADR-015):
+   - `threadhop observe --session <id>` — runs as background sidecar
    - File-watching via fsevents (macOS), fallback to polling
-   - Auto-detects active session JSONL via ps/lsof
-   - Batched extraction (configurable, default ~10 messages)
-   - Exits when Claude Code session ends
-5. Implement CLI queries:
+   - Batched extraction (configurable, default ~3-4 new messages trigger)
+   - Records PID in `observation_state.observer_pid`
+   - Exits when Claude Code session ends or `--stop` is sent
+7. Implement stop/resume lifecycle (ADR-019):
+   - `threadhop observe --stop [--session <id>]` — SIGTERM to recorded PID
+   - `threadhop observe --stop-all` — stops all running observers
+   - Resume: reads `source_byte_offset`, processes only new bytes
+   - Stale PID detection via `kill -0 $PID`
+8. Implement CLI queries:
    - `threadhop todos [--project <name>]`
    - `threadhop decisions [--project <name>]`
    - `threadhop observations [--project <name>]`
+   - `threadhop conflicts [--project <name>]` (reads `type: "conflict"` entries)
    - All trigger observer for unprocessed messages before displaying results
 
-### Phase 4: Skill Plugin
-_Five skills for in-session use (ADR-012, ADR-016)._
+### Phase 4: Skill Plugin + TUI Observation Indicator
+_Five skills for in-session use (ADR-012, ADR-016). TUI observation
+indicator and transcript header (ADR-021)._
 
 1. Research Claude Code skill plugin packaging/distribution
 2. `/threadhop:tag <status>` — detect session ID, call `threadhop tag` CLI
 3. `/threadhop:context` — read clipboard, format with source labels, inject
-4. `/threadhop:handoff <id> [--full]` — sub-agent compresses transcript
-   (enhanced: uses pre-extracted observations when available)
+4. `/threadhop:handoff <id> [--full]` — runs observer first if no observations
+   exist (ADR-018), then formats from observations. No separate JSONL compression path.
 5. `/threadhop:observe` — per-session opt-in, spawns background observer
    (retroactive catch-up + watch mode)
-6. `/threadhop:insights` — pull observations + conflicts into conversation
+6. `/threadhop:insights` — reads per-session observation file (includes conflict
+   entries from reflector), formats and injects into conversation
+7. TUI observation indicator (ADR-021):
+   - 🗒 icon next to session name when `observation_state.entry_count > 0`
+   - Subtle transcript header: entry count + file path
+   - `o` key: copy observation path to clipboard (or start observing if none)
+   - `O` key: resume observation on a stopped session
 
 ### Phase 5: Project Memory + Bookmarks
 _Cross-session knowledge persistence._
@@ -829,19 +1367,27 @@ _Cross-session knowledge persistence._
 5. Memory rendering: generate project memory markdown from observations for injection
 
 ### Phase 6: Reflector — Conflict Detection
-_Contradiction detection across sessions. Runs as background sidecar alongside
-the observer (ADR-015), or on-demand via CLI._
+_Contradiction detection across sessions. Second `claude -p` call triggered
+by the observer process (ADR-022). Writes `type: "conflict"` entries to the
+SAME per-session observation JSONL (ADR-020). Uses `reflector_entry_offset`
+for incremental processing._
 
-1. Build conflict detection reflector (Haiku):
-   - Group decisions by project and semantic topic
-   - Identify contradictory decisions across sessions
-   - Write conflict reports to `~/.config/threadhop/conflicts.jsonl`
-2. Background reflector mode:
-   - Runs at lower frequency than observer (every N observations or M minutes)
-   - Triggered automatically when observer appends new decisions
-3. CLI query: `threadhop conflicts [--project <name>]`
-4. TUI notification: surface unreviewed conflicts in sidebar or status bar
-5. Condensation (secondary goal): merge related decisions, archive completed
+1. Create reflector prompt (`~/.config/threadhop/prompts/reflector.md`):
+   - Input: recent decisions from current session + all decisions from
+     other sessions in same project
+   - Constrains: append-only, dedup by `refs` pair + `topic`
+   - Output: `type: "conflict"` entries with `refs`, `topic`, `text`
+2. Build reflector core function (Haiku via `claude -p`):
+   - Reads decisions from observation files (NOT raw transcripts)
+   - Gathers cross-session decisions by scanning `observations/*.jsonl`
+   - Appends conflicts to current session's observation JSONL
+   - Updates `reflector_entry_offset` in `observation_state`
+3. Observer-triggered background mode:
+   - Observer checks: `entry_count - reflector_entry_offset >= 5`
+   - If yes: spawns reflector `claude -p` call
+   - No separate PID — observer owns reflector lifecycle
+3. TUI notification: surface unreviewed conflicts in sidebar or status bar
+4. Condensation (secondary goal): merge related decisions, archive completed
    TODOs, produce condensed summaries with source links
 
 ---
@@ -924,6 +1470,22 @@ CREATE TABLE memory (
     resolved      INTEGER DEFAULT 0,        -- for TODOs: 0=open, 1=done
     created_at    REAL NOT NULL
 );
+
+-- Observer + reflector state tracking (ADR-019, ADR-022)
+CREATE TABLE observation_state (
+    session_id              TEXT PRIMARY KEY,
+    source_path             TEXT NOT NULL,       -- path to source session JSONL
+    obs_path                TEXT NOT NULL,       -- path to per-session observations JSONL
+    source_byte_offset      INTEGER NOT NULL DEFAULT 0,  -- where observer last read in source
+    entry_count             INTEGER NOT NULL DEFAULT 0,   -- total observation entries written
+    reflector_entry_offset  INTEGER NOT NULL DEFAULT 0,   -- last entry index reflector processed
+    observer_pid            INTEGER,             -- PID if running, NULL otherwise
+    status                  TEXT NOT NULL DEFAULT 'idle',
+        -- idle | running | stopped
+    started_at              REAL,                -- when observation first started
+    last_observed_at        REAL,                -- when last observation appended
+    FOREIGN KEY (session_id) REFERENCES sessions(session_id)
+);
 ```
 
 ---
@@ -958,10 +1520,11 @@ threadhop/
 | Bookmark | TUI | Visual selection, one-key action |
 | Tag session | TUI + Skill + CLI | All three entry points, one DB |
 | Observation queries | CLI | `threadhop todos`, `threadhop decisions` |
-| Start observation | Skill | Per-session opt-in, spawns background process |
-| Pull observations/conflicts | Skill | Read observer output, format for injection |
+| Start observation | Skill + TUI | Per-session opt-in, spawns background process |
+| Pull observations/conflicts | Skill | Read per-session observation file, format for injection |
 | Context injection | Skill | Formats clipboard content with source labels |
-| Handoff | Skill | LLM sub-agent, enhanced with pre-extracted observations |
+| Handoff | Skill | Runs observer first if needed, formats from observations |
+| Observation indicator | TUI | 🗒 icon + transcript header for observed sessions |
 
 ### Skill 1: `/threadhop:tag <status>` (instant, no LLM)
 
@@ -995,51 +1558,37 @@ User (in Claude Code): /threadhop:context
 4. The model now has this context and can work with it
 ```
 
-### Skill 3: `/threadhop:handoff <id> [--full]` (LLM call)
+### Skill 3: `/threadhop:handoff <id> [--full]` (observer + format)
 
-The only skill that uses an LLM. Compresses an entire session transcript
-into a brief for starting a fresh session.
+Uses the observer as its underlying function (ADR-018). There is no
+separate "compress raw JSONL" path — the handoff always works from
+observations, running the observer first if needed.
 
 ```
 User (in Claude Code): /threadhop:handoff abc123
 
-1. Skill locates ~/.claude/projects/**/abc123.jsonl
-2. Parses JSONL → clean (role, text) pairs
-3. Strips system-reminders, abbreviates tool calls
-4. Spawns sub-agent (Haiku for speed, configurable) with:
-   - Parsed transcript
-   - Prompt: "Generate a handoff brief. Focus on: decisions made (with
-     rationale), current implementation state, open questions, and what
-     the next session needs to know."
-5. Sub-agent returns brief (~30-50 lines)
-6. Brief injected into current conversation
+1. Skill checks observation_state for session abc123
+2. If observations exist (entry_count > 0):
+   a. Check if source JSONL has grown since last observation
+   b. If yes: run observer on new bytes (incremental catch-up)
+   c. Read observations/abc123.jsonl
+3. If NO observations exist:
+   a. Run observer on full session (from byte 0)
+   b. Observer writes observations/abc123.jsonl
+   c. Read the freshly-written observations
+4. Format observations into handoff brief:
+   - Short sets: format directly without another LLM call
+   - Large sets: spawns Haiku sub-agent for final polish/compression
+5. Brief injected into current conversation (~30-50 lines)
 
 With --full flag:
    Sub-agent produces comprehensive handoff with rationale,
    code references, and conversation excerpts.
 ```
 
-The raw transcript lives only in the sub-agent's context.
-The main session sees only the compressed brief.
-
-**Enhanced mode (when source session was observed, ADR-016):**
-
-```
-User (in Claude Code): /threadhop:handoff abc123
-
-1. Skill checks observations.jsonl for session abc123
-2. Observations exist → use structured input instead of raw JSONL
-3. Spawns sub-agent with:
-   - Pre-extracted observations (typed, structured)
-   - Any detected conflicts involving this session's decisions
-   - Prompt: "Generate a handoff brief from these structured observations.
-     Include: decisions with rationale, open TODOs, unresolved conflicts,
-     and what the next session needs to know."
-4. Sub-agent returns brief (~30-50 lines)
-5. Brief injected into current conversation
-
-Fallback: if no observations exist, reverts to full JSONL mode above.
-```
+The observer function is the same regardless of entry point.
+A session observed incrementally over 2 hours produces identical
+observations to one observed in a single shot at handoff time.
 
 ### Skill 4: `/threadhop:observe` (instant, spawns background process)
 
@@ -1075,9 +1624,9 @@ current conversation.
 User (in Claude Code): /threadhop:insights
 
 1. Skill detects current session ID
-2. Reads observations.jsonl filtered by current session
-3. Reads conflicts.jsonl filtered by current project
-4. Formats and presents:
+2. Reads observations/<session_id>.jsonl (single file contains all
+   observation types including conflicts appended by the reflector)
+3. Formats and presents:
 
    ┌─ ThreadHop Observations — this session ───────────────┐
    │ DECISIONS:                                             │
@@ -1097,8 +1646,11 @@ User (in Claude Code): /threadhop:insights
 ```
 
 `/threadhop:insights` without an observed session shows nothing useful.
-It reads from files that only exist because `/threadhop:observe` was
-invoked. This coupling is intentional — no observation, no insights.
+It reads from per-session observation files that only exist because
+the observer ran (via `/threadhop:observe`, handoff, or CLI). Conflict
+entries from the reflector appear inline as `type: "conflict"` — no
+separate file to read. This coupling is intentional — no observation,
+no insights.
 
 ### Context injection flow (TUI → clipboard → skill)
 
@@ -1150,36 +1702,44 @@ For larger exports:
 - [ ] Add argparse subcommand routing (no subcommand = TUI)
 - [ ] Implement `threadhop tag <status> [--session <id>]`
 - [ ] Session auto-detection from current terminal (ps/lsof)
-- [ ] Haiku observer: process conversation chunks, extract typed observations
-- [ ] Observations JSONL output at `~/.config/threadhop/observations.jsonl`
-- [ ] Incremental processing (byte offset tracking per session)
-- [ ] Background observer mode: `threadhop observe` sidecar process (ADR-015)
+- [ ] Create reusable observer prompt (`~/.config/threadhop/prompts/observer.md`)
+- [ ] Add `observation_state` table to SQLite schema (ADR-019)
+- [ ] Observer core function: `claude -p --model haiku --permission-mode acceptEdits` (ADR-018)
+- [ ] Per-session observation files at `~/.config/threadhop/observations/<session_id>.jsonl` (ADR-019)
+- [ ] Incremental processing (byte offset tracking in `observation_state` table)
+- [ ] Background observer mode: `threadhop observe --session <id>` sidecar (ADR-015)
 - [ ] File-watching via fsevents (macOS) with polling fallback
-- [ ] Auto-detect active session JSONL, exit when session ends
+- [ ] Batched extraction: trigger on ~3-4 new messages
+- [ ] Observer stop/resume lifecycle: `--stop`, `--stop-all`, PID tracking (ADR-019)
+- [ ] Stale PID detection via `kill -0 $PID`
 - [ ] `threadhop todos [--project]` CLI query
 - [ ] `threadhop decisions [--project]` CLI query
 - [ ] `threadhop observations [--project]` CLI query
+- [ ] `threadhop conflicts [--project]` CLI query (reads `type: "conflict"` entries)
 
-### Phase 4: Skills (ADR-012, ADR-016)
+### Phase 4: Skills + TUI Observation Indicator (ADR-012, ADR-016, ADR-021)
 - [ ] Research Claude Code skill plugin packaging
 - [ ] `/threadhop:tag <status>` skill (calls CLI)
 - [ ] `/threadhop:context` skill (clipboard formatting + injection)
-- [ ] `/threadhop:handoff <id> [--full]` skill (sub-agent, enhanced with observations)
+- [ ] `/threadhop:handoff <id> [--full]` skill (runs observer first if needed, formats from observations)
 - [ ] `/threadhop:observe` skill (per-session opt-in, spawns background observer)
-- [ ] `/threadhop:insights` skill (pull observations + conflicts into conversation)
+- [ ] `/threadhop:insights` skill (reads unified per-session observation file)
+- [ ] TUI observation indicator: 🗒 icon next to observed sessions (ADR-021)
+- [ ] Transcript header: entry count + observation file path (ADR-021)
+- [ ] `o` key: copy observation path / start observing (ADR-021)
+- [ ] `O` key: resume observation on stopped session (ADR-021)
 
 ### Phase 5: Memory + Bookmarks
 - [ ] Build bookmark system (TUI feature)
 - [ ] Explicit annotation detection (ADR:, DECISION:, TODO: markers)
 - [ ] Project memory markdown rendering from observations
 
-### Phase 6: Reflector — Conflict Detection (ADR-015)
-- [ ] Build conflict detection reflector (Haiku)
-- [ ] Group decisions by project/topic, identify contradictions across sessions
-- [ ] Conflict reports at `~/.config/threadhop/conflicts.jsonl`
-- [ ] Background reflector mode (runs alongside observer sidecar)
-- [ ] `threadhop conflicts [--project]` CLI query
-- [ ] TUI notification for unreviewed conflicts
+### Phase 6: Reflector — Conflict Detection (ADR-015, ADR-020, ADR-022)
+- [ ] Create reflector prompt (`prompts/reflector.md`) — dedup, structured conflict format
+- [ ] Build reflector core function — second `claude -p` call, reads observation layer
+- [ ] Observer-triggered reflector — spawns when `entry_count - reflector_entry_offset >= 5`
+- [ ] On-demand reflector — runs as follow-up after observer in CLI queries and handoff
+- [ ] TUI notification for unreviewed `type: "conflict"` entries
 - [ ] Condensation: merge related decisions, archive completed TODOs
 - [ ] Trigram-based fuzzy search for typo tolerance
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,6 +1,6 @@
 # ThreadHop — Implementation Task List
 
-Extracted from [DESIGN-DECISIONS.md](DESIGN-DECISIONS.md) on 2026-04-14.
+Extracted from [DESIGN-DECISIONS.md](DESIGN-DECISIONS.md). Last reconciled 2026-04-15.
 
 ---
 
@@ -14,16 +14,16 @@ _Immediate value, enables all future features._
   One-time migration on first run: move session names, session order, last-viewed timestamps from config.json into the sessions table. Keep config.json only for app-level settings (theme, sidebar_width). _(ADR-001)_
 
 - [ ] **3. Add session status field + grouped display** *(blocked by: #1)*
-  Add `status` field to session model with values: `active | in_progress | in_review | done | archived`. Render sessions grouped by status in the TUI sidebar. _(ADR-004)_
+  Add `status` field to session model with values: `active | in_progress | in_review | done | archived`. Render sessions grouped by status in the TUI sidebar. _(ADR-004, ADR-013)_
 
 - [ ] **4. Implement status cycling keybinds (s/S)** *(blocked by: #3)*
-  `s` cycles status forward (active → in_progress → in_review → done), `S` cycles backward. Manual reorder works within each status group.
+  `s` cycles status forward (active → in_progress → in_review → done), `S` cycles backward. Manual reorder works within each status group. First of three tag entry points. _(ADR-013)_
 
 - [ ] **5. Implement archive (a) + archive toggle (A)** *(blocked by: #3)*
   `a` sets session status to archived. `A` toggles visibility of archived sessions. Archived sessions hidden by default. _(ADR-004)_
 
 - [ ] **6. Implement sidebar resize ([/])**
-  Add `[` and `]` keybindings to shrink/grow sidebar. Min 20, max 60, step 4. Persist width in config. Update `grid-columns` CSS dynamically via `self.styles.grid.columns`. _(ADR-010)_
+  Add `[` and `]` keybindings to shrink/grow sidebar. Min 20, max 60, step 4. Persist width in config. Update `grid-columns` CSS dynamically via `self.styles.grid.columns`. _(ADR-014)_
 
 - [ ] **7. Write tests for DB migration** *(blocked by: #1, #2)*
   Test that config.json values are correctly migrated to SQLite. Test idempotency (running migration twice doesn't duplicate data). Test that config.json is preserved for app-level settings.
@@ -46,7 +46,7 @@ _Enables instant search and cross-session context sharing. All TUI features._
   In message selection mode, press `v` to start range selection. Move with `j`/`k` to extend the range. Visual highlight on all selected messages.
 
 - [ ] **12. Clipboard copy with source labels (y)** *(blocked by: #10)*
-  Press `y` on selected messages to copy to clipboard. Format includes source labels: `[From "session name" — ~/cwd — timestamp]`. _(ADR-008)_
+  Press `y` on selected messages to copy to clipboard. Format includes source labels: `[From "session name" — ~/cwd — timestamp]`. Source labels are what `/threadhop:context` later parses. _(ADR-008)_
 
 - [ ] **13. Temp file export (e) → /tmp/threadhop/** *(blocked by: #10)*
   Press `e` to export selected messages to `/tmp/threadhop/<session_id>-<timestamp>.md`. Display full path in TUI after export. Auto-cleaned on OS reboot. _(ADR-008)_
@@ -54,49 +54,81 @@ _Enables instant search and cross-session context sharing. All TUI features._
 - [ ] **14. Real-time search panel (/) with FTS5 prefix matching** *(blocked by: #8, #9)*
   Press `/` to open search input. FTS5 prefix matching per keystroke (e.g., `rate* lim*`). Results show message snippet, session name, project, timestamp. Navigate with `j`/`k`, `Enter` to jump to source. Filter syntax: `project:`, `user:`, `assistant:`. _(ADR-002, ADR-007)_
 
-- [ ] **24. Data model hardening: CHECK constraints + Pydantic schemas** *(blocked by: #1; prereq for: #8)*
+- [ ] **33. Data model hardening: CHECK constraints + Pydantic schemas** *(blocked by: #1; prereq for: #8)*
   Add a migration introducing `CHECK (status IN ('active','in_progress','in_review','done','archived'))` on the `sessions` table so the enum is enforced at the DB layer, not just the app. Design Pydantic models as the validation boundary for JSONL transcript parsing — user/assistant messages, `tool_use` blocks, `tool_result` blocks — so the indexer in #8 folds over typed instances instead of raw dicts and malformed lines fail loudly. Use `Literal` types for enums (session status, message role, memory `type`). Define `Session`, `Message`, `Bookmark`, `MemoryEntry` shapes alongside their table migrations so the Python types and SQL schemas evolve together. Add `pydantic` to the script's PEP 723 dependency block. _(ADR-001, ADR-003, ADR-004)_
 
 ---
 
-## Phase 3: Skill Plugin
-_Only skills that genuinely need an LLM or benefit from mid-conversation invocation._
+## Phase 3: CLI Subcommands + Observer
+_Observer-first architecture. CLI access to observations without launching the TUI._
 
-- [ ] **15. Research Claude Code skill plugin packaging**
-  Determine how Claude Code skill plugins are distributed — directory of .md files in `~/.claude/skills/`? npm/pip package? Verify the plugin contract before implementing skills. _(Open Question Q4)_
+- [ ] **15. Add argparse subcommand routing**
+  No subcommand → TUI mode (preserve existing behaviour, including `--project` / `--days` flags). With subcommand → CLI mode. Shared arg parsing for `--project`, `--session`. _(ADR-011)_
 
-- [ ] **16. Implement handoff skill (/threadhop:handoff)** *(blocked by: #15)*
-  Read JSONL for given session_id, parse to clean (role, text) pairs, strip system-reminders, abbreviate tool calls. Spawn sub-agent for transcript compression. Inject compressed brief (~30-50 lines) into current session. _(ADR-006)_
+- [ ] **16. Implement `threadhop tag <status> [--session <id>]` CLI** *(blocked by: #1, #3, #15)*
+  Writes status to the same SQLite `sessions` table the TUI reads. Second of three tag entry points. _(ADR-011, ADR-013)_
 
-- [ ] **17. Implement memory injection skill (/threadhop:memory)** *(blocked by: #15, #19)*
-  Read project memory from SQLite (or rendered .md cache), format as structured context with section headers, inject directly. No sub-agent, no LLM needed. _(ADR-006)_
+- [ ] **17. Session auto-detection from current terminal** *(blocked by: #16)*
+  When `threadhop tag` is called without `--session`, detect the current session ID by scanning `ps` for `claude` processes in the current terminal's process tree. Reuse the detection logic the TUI already runs in `_get_active_claude_sessions()`.
+
+- [ ] **18. Build Haiku observer** *(blocked by: #8)*
+  Process unindexed conversation chunks through Haiku. Extract typed observations (`todo | decision | done | adr | question | blocker`). Prompt: extract only explicitly discussed items, do not infer. Append to `~/.config/threadhop/observations.jsonl`. _(ADR-010)_
+
+- [ ] **19. Incremental observer processing (byte offset per session)** *(blocked by: #18)*
+  Track per-session byte offsets so the observer only re-processes new conversation. Observer triggers on CLI query or TUI launch — not a daemon, not a hook. _(ADR-010)_
+
+- [ ] **20. Implement `threadhop todos [--project]` CLI query** *(blocked by: #18, #19)*
+  Runs observer for unprocessed messages, then prints open TODOs from `observations.jsonl`. Filterable by `--project`. _(ADR-010, ADR-011)_
+
+- [ ] **21. Implement `threadhop decisions [--project]` CLI query** *(blocked by: #18, #19)*
+  Same pattern as `todos` but filters for `type: decision`. _(ADR-010, ADR-011)_
+
+- [ ] **22. Implement `threadhop observations [--project]` CLI query** *(blocked by: #18, #19)*
+  Unfiltered dump of all observations, newest first. Output format should stay grep/jq-friendly. _(ADR-010, ADR-011)_
 
 ---
 
-## Phase 4: Project Memory + Bookmarks
-_Cross-session knowledge persistence._
+## Phase 4: Skill Plugin
+_Three skills for in-session use — tag, context, handoff._
 
-- [ ] **18. Build bookmark system**
-  Add bookmarks table to schema. Toggle bookmark from message selection mode with `space`. Support labels and tags (JSON array). Build bookmark browser panel in TUI.
+- [ ] **23. Research Claude Code skill plugin packaging**
+  Determine how Claude Code skill plugins are distributed — directory of `.md` files in `~/.claude/skills/`? npm/pip package? Verify the plugin contract before implementing skills. _(Open Question Q4)_
 
-- [ ] **19. Build project memory ledger**
-  Add memory table to schema. Support typed entries: `decision | todo | done | adr | observation`. Append-only, filterable by project/type/date. Manual entry from TUI (type + text). Rendered as markdown for injection. _(ADR-005)_
+- [ ] **24. Implement `/threadhop:tag <status>` skill** *(blocked by: #16, #23)*
+  Instant, no LLM. Detects current session ID from process context, shells out to `threadhop tag <status>`, confirms: "Tagged this session as <status>". Third of three tag entry points. _(ADR-012, ADR-013)_
 
-- [ ] **20. Add explicit annotation detection** *(blocked by: #19)*
-  Recognize `ADR:`, `DECISION:`, `TODO:` markers in conversations and offer to append them to the project memory ledger automatically.
+- [ ] **25. Implement `/threadhop:context` skill** *(blocked by: #12, #23)*
+  Instant, no LLM. Reads clipboard via `pbpaste`, detects ThreadHop source labels, presents the content as a clearly bounded context block in the current conversation. Bridges TUI visual selection → Claude Code injection. _(ADR-012)_
+
+- [ ] **26. Implement `/threadhop:handoff <id> [--full]` skill** *(blocked by: #23)*
+  The only LLM-powered skill. Reads JSONL for given session, parses to clean (role, text) pairs, strips system-reminders, abbreviates tool calls. Spawns sub-agent (Haiku default) to compress into a ~30-50 line brief. `--full` flag uses a stronger model for comprehensive handoff with rationale and excerpts. _(ADR-006, ADR-012)_
 
 ---
 
-## Phase 5: Auto-Observer + Reflector
-_Automatic knowledge extraction._
+## Phase 5: Project Memory + Bookmarks
+_Cross-session knowledge persistence (beyond the raw observations log)._
 
-- [ ] **21. Build auto-observer**
-  Background observer that detects new messages in active sessions during refresh cycle. Auto-extract observations (pattern matching first, `claude -p` later). Append to memory ledger with `source: "auto"`.
+- [ ] **27. Build bookmark system** *(blocked by: #1, #10)*
+  Add `bookmarks` table to schema. Toggle bookmark from message selection mode with `space`. Support labels and tags (JSON array). Build bookmark browser panel in TUI.
 
-- [ ] **22. Build reflector** *(blocked by: #21)*
-  Periodic condensation of old observations. Archive completed TODOs, merge related decisions. Keeps the memory ledger manageable over time.
+- [ ] **28. Build project memory ledger** *(blocked by: #1)*
+  Add `memory` table to schema. Support typed entries: `decision | todo | done | adr | observation`. Append-only, filterable by project/type/date. Manual entry from TUI (type + text). Distinct from observations.jsonl: this is for curated/explicit entries with `source: 'explicit'`. _(ADR-005)_
 
-- [ ] **23. Trigram-based fuzzy search for typo tolerance** *(blocked by: #14)*
+- [ ] **29. Add explicit annotation detection** *(blocked by: #18, #28)*
+  Recognize `ADR:`, `DECISION:`, `TODO:` markers in conversations and offer to append them to the memory ledger automatically with `source: 'auto'`.
+
+- [ ] **30. Project memory markdown rendering** *(blocked by: #18, #28)*
+  Render project memory (observations + explicit ledger entries) as markdown for injection into new sessions. Used when a future skill/CLI wants to hand the current project's accumulated context to a fresh session.
+
+---
+
+## Phase 6: Reflector + Fuzzy Search
+_Condensation and search resilience — add only when volume demands it._
+
+- [ ] **31. Build reflector** *(blocked by: #18)*
+  Periodic condensation of old observations via Haiku. Archive completed TODOs, merge related decisions, produce condensed summaries. Keep source links back to original observations. Keeps the memory ledger manageable over time.
+
+- [ ] **32. Trigram-based fuzzy search for typo tolerance** *(blocked by: #14)*
   Add trigram tokenizer as a secondary FTS table. Fall back to trigram search when FTS5 prefix returns zero results. Handles spelling mistakes (e.g., "retr" matches "retry"). _(ADR-007)_
 
 ---
@@ -105,19 +137,33 @@ _Automatic knowledge extraction._
 
 ```
 #1 SQLite DB ──┬──> #2 Migration ──> #7 Tests
-               ├──> #3 Status ──┬──> #4 Keybinds (s/S)
-               │                └──> #5 Archive (a/A)
-               └──> #24 Data models ──> #8 Indexer ──> #9 Incremental ──> #14 Search ──> #23 Fuzzy
-                                                                      └──> #14 Search
+               ├──> #3 Status ──┬──> #4 Keybinds (s/S)  ─────────┐
+               │                └──> #5 Archive (a/A)            │
+               ├──> #33 Data models ──> #8 Indexer ──> #9 Incremental ──> #14 Search │ ──> #32 Fuzzy
+               │                                      └──> #18 Observer ──> #19 Incremental
+               │                                                            ├──> #20 todos
+               │                                                            ├──> #21 decisions
+               │                                                            ├──> #22 observations
+               │                                                            ├──> #29 Annotation detection
+               │                                                            ├──> #30 Memory rendering
+               │                                                            └──> #31 Reflector
+               ├──> #27 Bookmarks (also needs #10)
+               └──> #28 Memory ledger ──┬──> #29 Annotation detection
+                                        └──> #30 Memory rendering
+
 #6 Sidebar resize (independent)
 
 #10 Selection ──┬──> #11 Range select
-                ├──> #12 Clipboard copy
-                └──> #13 Temp export
+                ├──> #12 Clipboard copy ──> #25 /threadhop:context (also needs #23)
+                ├──> #13 Temp export
+                └──> #27 Bookmarks (also needs #1)
 
-#15 Skill research ──┬──> #16 Handoff skill
-                     └──> #17 Memory skill (also needs #19)
+#15 Subcommand routing ──> #16 tag CLI ──> #17 Auto-detect session
+                                        └──> #24 /threadhop:tag skill (also needs #23)
 
-#19 Memory ledger ──> #20 Annotation detection
-#21 Auto-observer ──> #22 Reflector
+#23 Skill packaging research ──┬──> #24 /threadhop:tag
+                                ├──> #25 /threadhop:context
+                                └──> #26 /threadhop:handoff
+
+Entry points for session tagging (ADR-013): #4 (TUI) · #16 (CLI) · #24 (skill) — all write to the same sessions table.
 ```

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,6 +1,6 @@
 # ThreadHop — Implementation Task List
 
-Extracted from [DESIGN-DECISIONS.md](DESIGN-DECISIONS.md). Last reconciled 2026-04-15.
+Extracted from [DESIGN-DECISIONS.md](DESIGN-DECISIONS.md). Last reconciled 2026-04-17.
 
 ---
 
@@ -54,13 +54,17 @@ _Enables instant search and cross-session context sharing. All TUI features._
 - [ ] **14. Real-time search panel (/) with FTS5 prefix matching** *(blocked by: #8, #9)*
   Press `/` to open search input. FTS5 prefix matching per keystroke (e.g., `rate* lim*`). Results show message snippet, session name, project, timestamp. Navigate with `j`/`k`, `Enter` to jump to source. Filter syntax: `project:`, `user:`, `assistant:`. _(ADR-002, ADR-007)_
 
+- [ ] **42. Context-aware help overlay + command metadata registry**
+  Add a full-app discoverability surface modeled on the search modal, but for commands instead of FTS results. Keep the footer minimal/contextual rather than trying to show every keybinding all the time. Define a shared command metadata registry that covers both app-level bindings and widget-local modes (session list, transcript, selection mode, reply input, search/find), and use it to drive the help overlay plus footer hints from one source of truth. The implementation should leave the final help trigger key open and must not assume `H`, since handoff shortcut work is still in flux. _(ADR-017)_
+
 - [ ] **33. Data model hardening: CHECK constraints + Pydantic schemas** *(blocked by: #1; prereq for: #8)*
   Add a migration introducing `CHECK (status IN ('active','in_progress','in_review','done','archived'))` on the `sessions` table so the enum is enforced at the DB layer, not just the app. Design Pydantic models as the validation boundary for JSONL transcript parsing — user/assistant messages, `tool_use` blocks, `tool_result` blocks — so the indexer in #8 folds over typed instances instead of raw dicts and malformed lines fail loudly. Use `Literal` types for enums (session status, message role, memory `type`). Define `Session`, `Message`, `Bookmark`, `MemoryEntry` shapes alongside their table migrations so the Python types and SQL schemas evolve together. Add `pydantic` to the script's PEP 723 dependency block. _(ADR-001, ADR-003, ADR-004)_
 
 ---
 
-## Phase 3: CLI Subcommands + Observer
-_Observer-first architecture. CLI access to observations without launching the TUI._
+## Phase 3: CLI Subcommands + Observer (on-demand + background)
+_Observer-first architecture. CLI access to observations without launching the TUI.
+Background sidecar mode for continuous observation during active sessions (ADR-015)._
 
 - [ ] **15. Add argparse subcommand routing**
   No subcommand → TUI mode (preserve existing behaviour, including `--project` / `--days` flags). With subcommand → CLI mode. Shared arg parsing for `--project`, `--session`. _(ADR-011)_
@@ -71,11 +75,17 @@ _Observer-first architecture. CLI access to observations without launching the T
 - [ ] **17. Session auto-detection from current terminal** *(blocked by: #16)*
   When `threadhop tag` is called without `--session`, detect the current session ID by scanning `ps` for `claude` processes in the current terminal's process tree. Reuse the detection logic the TUI already runs in `_get_active_claude_sessions()`.
 
-- [ ] **18. Build Haiku observer** *(blocked by: #8)*
-  Process unindexed conversation chunks through Haiku. Extract typed observations (`todo | decision | done | adr | question | blocker`). Prompt: extract only explicitly discussed items, do not infer. Append to `~/.config/threadhop/observations.jsonl`. _(ADR-010)_
+- [ ] **18. Build Haiku observer (on-demand mode)** *(blocked by: #8)*
+  Process unindexed conversation chunks through Haiku. Extract typed observations across five types: `todo | decision | done | adr | observation`. Prompt: extract only explicitly discussed items, do not infer. Append to `~/.config/threadhop/observations.jsonl`. _(ADR-010)_
 
 - [ ] **19. Incremental observer processing (byte offset per session)** *(blocked by: #18)*
-  Track per-session byte offsets so the observer only re-processes new conversation. Observer triggers on CLI query or TUI launch — not a daemon, not a hook. _(ADR-010)_
+  Track per-session byte offsets so the observer only re-processes new conversation. On-demand trigger: CLI query or TUI launch. _(ADR-010)_
+
+- [ ] **34. Build background observer sidecar (`threadhop observe`)** *(blocked by: #18, #19)*
+  Background process mode for the observer (ADR-015). Watches the active session's JSONL via fsevents (macOS) with polling fallback. Auto-detects active session via `ps`/`lsof`. Batches new messages (configurable, default ~10 messages) and runs Haiku extraction. Exits when the Claude Code session ends. Designed to be enabled as a flag — like Claude Code's remote control — so the user continues working without interruption. _(ADR-015)_
+
+- [ ] **35. Observer enable/disable configuration** *(blocked by: #34)*
+  Three entry points for enabling background observation: (1) `threadhop observe &` manual start, (2) Claude Code hook in `.claude/settings.json` for auto-start, (3) `threadhop config set observe.enabled true` for permanent flag. Add `threadhop observe --stop` to gracefully shut down a running observer. _(ADR-015)_
 
 - [ ] **20. Implement `threadhop todos [--project]` CLI query** *(blocked by: #18, #19)*
   Runs observer for unprocessed messages, then prints open TODOs from `observations.jsonl`. Filterable by `--project`. _(ADR-010, ADR-011)_
@@ -89,7 +99,7 @@ _Observer-first architecture. CLI access to observations without launching the T
 ---
 
 ## Phase 4: Skill Plugin
-_Three skills for in-session use — tag, context, handoff._
+_Five skills for in-session use — tag, context, handoff, observe, insights (ADR-012, ADR-016)._
 
 - [ ] **23. Research Claude Code skill plugin packaging**
   Determine how Claude Code skill plugins are distributed — directory of `.md` files in `~/.claude/skills/`? npm/pip package? Verify the plugin contract before implementing skills. _(Open Question Q4)_
@@ -101,7 +111,13 @@ _Three skills for in-session use — tag, context, handoff._
   Instant, no LLM. Reads clipboard via `pbpaste`, detects ThreadHop source labels, presents the content as a clearly bounded context block in the current conversation. Bridges TUI visual selection → Claude Code injection. _(ADR-012)_
 
 - [ ] **26. Implement `/threadhop:handoff <id> [--full]` skill** *(blocked by: #23)*
-  The only LLM-powered skill. Reads JSONL for given session, parses to clean (role, text) pairs, strips system-reminders, abbreviates tool calls. Spawns sub-agent (Haiku default) to compress into a ~30-50 line brief. `--full` flag uses a stronger model for comprehensive handoff with rationale and excerpts. _(ADR-006, ADR-012)_
+  LLM-powered skill. Reads JSONL for given session, parses to clean (role, text) pairs, strips system-reminders, abbreviates tool calls. Spawns sub-agent (Haiku default) to compress into a ~30-50 line brief. `--full` flag uses a stronger model for comprehensive handoff with rationale and excerpts. **Enhanced (ADR-016):** when the source session was observed, uses pre-extracted observations as structured input instead of raw JSONL — faster and higher quality. Falls back to full JSONL mode when no observations exist. _(ADR-006, ADR-012, ADR-016)_
+
+- [ ] **40. Implement `/threadhop:observe` skill** *(blocked by: #23, #34)*
+  Instant, no LLM (spawns background process). Per-session opt-in for observation (ADR-016). Detects current session ID, checks if observer already running, spawns `threadhop observe --session <id> &` in background. Observer performs retroactive catch-up (reads JSONL from byte 0, processes through Haiku), then switches to watch mode. Reports catch-up summary: "47 messages processed — 5 decisions, 3 TODOs, 1 ADR. Watching for new messages." _(ADR-015, ADR-016)_
+
+- [ ] **41. Implement `/threadhop:insights` skill** *(blocked by: #23, #40)*
+  Instant, no LLM. Pull-based context injection (ADR-016). Reads `observations.jsonl` filtered by current session and `conflicts.jsonl` filtered by current project. Formats observations grouped by type (decisions, TODOs, ADRs, observations) with any detected conflicts highlighted. Presents as a bounded context block in the conversation. Returns nothing useful if session was never observed. _(ADR-016)_
 
 ---
 
@@ -122,11 +138,24 @@ _Cross-session knowledge persistence (beyond the raw observations log)._
 
 ---
 
-## Phase 6: Reflector + Fuzzy Search
-_Condensation and search resilience — add only when volume demands it._
+## Phase 6: Reflector — Conflict Detection + Fuzzy Search
+_Contradiction detection across sessions. Background sidecar alongside observer (ADR-015).
+Condensation as secondary goal. Add only when observation volume demands it._
 
-- [ ] **31. Build reflector** *(blocked by: #18)*
-  Periodic condensation of old observations via Haiku. Archive completed TODOs, merge related decisions, produce condensed summaries. Keep source links back to original observations. Keeps the memory ledger manageable over time.
+- [ ] **31. Build conflict detection reflector** *(blocked by: #18)*
+  The reflector's primary mission is detecting contradictory decisions across sessions (ADR-015). Groups decisions by project and semantic topic. Uses Haiku to identify contradictions (e.g., "REST over gRPC" in session A vs "gRPC for all service comms" in session B). Writes conflict reports to `~/.config/threadhop/conflicts.jsonl`. _(ADR-015)_
+
+- [ ] **36. Background reflector mode** *(blocked by: #31, #34)*
+  Runs as a companion to the background observer sidecar. Lower frequency than the observer — triggers every N new decision-type observations or every M minutes. Automatically starts when `threadhop observe` is running and new decisions are appended. _(ADR-015)_
+
+- [ ] **37. `threadhop conflicts [--project]` CLI query** *(blocked by: #31)*
+  Displays unreviewed conflicts from `conflicts.jsonl`. Shows the two conflicting decisions, their sessions, timestamps, and the reflector's explanation of the contradiction. Supports `--resolved` flag to mark conflicts as reviewed. _(ADR-015)_
+
+- [ ] **38. TUI conflict notification** *(blocked by: #31)*
+  Surface unreviewed conflicts in the TUI sidebar or status bar. Badge count or indicator when new conflicts are detected. Press a key to open conflict detail view. _(ADR-015)_
+
+- [ ] **39. Observation condensation (secondary reflector goal)** *(blocked by: #31)*
+  When observations.jsonl exceeds a size threshold, merge related decisions, archive completed TODOs, produce condensed summaries. Keep source links back to original observations. This is Mastra's original reflector purpose — retained as a secondary goal behind conflict detection.
 
 - [ ] **32. Trigram-based fuzzy search for typo tolerance** *(blocked by: #14)*
   Add trigram tokenizer as a secondary FTS table. Fall back to trigram search when FTS5 prefix returns zero results. Handles spelling mistakes (e.g., "retr" matches "retry"). _(ADR-007)_
@@ -146,12 +175,19 @@ _Condensation and search resilience — add only when volume demands it._
                │                                                            ├──> #22 observations
                │                                                            ├──> #29 Annotation detection
                │                                                            ├──> #30 Memory rendering
-               │                                                            └──> #31 Reflector
+               │                                                            ├──> #34 Background observer ──> #35 Enable/disable config
+               │                                                            │                            └──> #36 Background reflector
+               │                                                            └──> #31 Conflict reflector ──> #37 conflicts CLI
+               │                                                                                         ├──> #38 TUI notification
+               │                                                                                         ├──> #39 Condensation
+               │                                                                                         └──> #36 Background reflector (also needs #34)
                ├──> #27 Bookmarks (also needs #10)
                └──> #28 Memory ledger ──┬──> #29 Annotation detection
                                         └──> #30 Memory rendering
 
 #6 Sidebar resize (independent)
+
+#42 Help overlay + command registry (independent)
 
 #10 Selection ──┬──> #11 Range select
                 ├──> #12 Clipboard copy ──> #25 /threadhop:context (also needs #23)
@@ -163,7 +199,13 @@ _Condensation and search resilience — add only when volume demands it._
 
 #23 Skill packaging research ──┬──> #24 /threadhop:tag
                                 ├──> #25 /threadhop:context
-                                └──> #26 /threadhop:handoff
+                                ├──> #26 /threadhop:handoff (enhanced with observations)
+                                ├──> #40 /threadhop:observe (also needs #34)
+                                └──> #41 /threadhop:insights (also needs #40)
 
 Entry points for session tagging (ADR-013): #4 (TUI) · #16 (CLI) · #24 (skill) — all write to the same sessions table.
+
+Observer-reflector sidecar chain (ADR-015): #18 → #19 → #34 → #35 (background observer) + #31 → #36 (background reflector)
+
+Observe-insights feedback loop (ADR-016): #34 → #40 (/observe skill) → #41 (/insights skill) → #26 (enhanced handoff)
 ```

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -63,8 +63,8 @@ _Enables instant search and cross-session context sharing. All TUI features._
 ---
 
 ## Phase 3: CLI Subcommands + Observer (on-demand + background)
-_Observer-first architecture. CLI access to observations without launching the TUI.
-Background sidecar mode for continuous observation during active sessions (ADR-015)._
+_Observer-first architecture. Observer uses `claude -p --model haiku --permission-mode acceptEdits`
+(ADR-018). Per-session observation files with SQLite state tracking (ADR-019)._
 
 - [ ] **15. Add argparse subcommand routing**
   No subcommand → TUI mode (preserve existing behaviour, including `--project` / `--days` flags). With subcommand → CLI mode. Shared arg parsing for `--project`, `--session`. _(ADR-011)_
@@ -75,31 +75,69 @@ Background sidecar mode for continuous observation during active sessions (ADR-0
 - [ ] **17. Session auto-detection from current terminal** *(blocked by: #16)*
   When `threadhop tag` is called without `--session`, detect the current session ID by scanning `ps` for `claude` processes in the current terminal's process tree. Reuse the detection logic the TUI already runs in `_get_active_claude_sessions()`.
 
-- [ ] **18. Build Haiku observer (on-demand mode)** *(blocked by: #8)*
-  Process unindexed conversation chunks through Haiku. Extract typed observations across five types: `todo | decision | done | adr | observation`. Prompt: extract only explicitly discussed items, do not infer. Append to `~/.config/threadhop/observations.jsonl`. _(ADR-010)_
+- [ ] **43. Create reusable observer prompt** *(prereq for: #18)*
+  Write `~/.config/threadhop/prompts/observer.md` (or bundle with app at `prompts/observer.md`). Constrains Haiku: append-only, one JSON line per observation, no deletions, typed extraction only. Types: `todo | decision | done | adr | observation`. Each line is minimal: `type`, `text`, `context`, `ts` — no session/project/offset (metadata lives in filename and DB). **DONE — prompt exists at `prompts/observer.md`.** _(ADR-018)_
+
+- [x] **44. Add `observation_state` table to SQLite schema** *(blocked by: #1; prereq for: #18)*
+  **DONE.** Migration 004 in `db.py`. Table: `session_id`, `source_path`, `obs_path`, `source_byte_offset`, `entry_count`, `reflector_entry_offset`, `observer_pid`, `status` (idle/running/stopped), `started_at`, `last_observed_at`. Helper functions: `get_observation_state`, `upsert_observation_state`, `update_observer_offset`, `update_reflector_offset`, `set_observer_running`, `set_observer_stopped`, `get_observed_sessions`, `get_running_observers`. _(ADR-019, ADR-022)_
+
+- [ ] **18. Build observer core function** *(blocked by: #8, #43, #44)*
+  The single observer function used by ALL entry points (CLI, skill, handoff, TUI). This is an **orchestrator**, not just a `claude -p` call. The full sequence:
+
+  **Step 1 — Check state:** Read `observation_state` row for the session from SQLite. If no row exists, create one with `source_byte_offset=0` (first observation). If row exists, read `source_byte_offset` for where the observer last left off.
+
+  **Step 2 — Read new messages:** Open the source JSONL at `source_path`, seek to `source_byte_offset`, read from there to EOF. Parse the new bytes into JSONL lines. Count how many new human/assistant message turns are in this chunk (not raw lines — group by `message.id` for assistant streaming chunks).
+
+  **Step 3 — Batch threshold check:** If fewer than 3 new message turns since last observation, skip (not enough context for meaningful extraction). Return early. In background mode, continue watching; in on-demand mode, report "up to date."
+
+  **Step 4 — Build the prompt:** Read `prompts/observer.md`. Append the new message chunk as the conversation input. Append the output file path: `~/.config/threadhop/observations/<session_id>.jsonl`. Ensure the `observations/` directory exists.
+
+  **Step 5 — Invoke `claude -p`:**
+  ```bash
+  claude -p "<prompt_with_chunk>" \
+    --model haiku \
+    --permission-mode acceptEdits
+  ```
+  The Haiku process reads the chunk, extracts observations, and appends JSON lines to the observation file. Each line has only: `type`, `text`, `context`, `ts`.
+
+  **Step 6 — Update state:** Count lines in the observation file (or diff before/after to get new entry count). Record new `source_byte_offset` (current EOF of source JSONL) and updated `entry_count` in `observation_state` via `db.update_observer_offset()`.
+
+  **Step 7 — Return summary:** Report what was extracted: "Processed N messages. Found X decisions, Y TODOs, Z observations." Used by the skill and CLI for user feedback.
+
+  **Existing infrastructure to use:**
+  - `db.py`: `observation_state` table + all helper functions (migration 004)
+  - `prompts/observer.md`: the prompt file
+  - `indexer.py`: `parse_messages()` for JSONL parsing / chunk merging logic (reuse or adapt)
+  - `db.OBS_DIR`: `~/.config/threadhop/observations/` path constant
+
+  _(ADR-010, ADR-018, ADR-019)_
 
 - [ ] **19. Incremental observer processing (byte offset per session)** *(blocked by: #18)*
-  Track per-session byte offsets so the observer only re-processes new conversation. On-demand trigger: CLI query or TUI launch. _(ADR-010)_
+  The incremental logic is built into task #18's Step 1-2 (read from `source_byte_offset`, not byte 0). This task covers the **watch mode** layer on top: after the initial extraction, continue monitoring the source JSONL for growth. When the file grows and the batch threshold is met again, re-run Steps 2-7. Uses `observation_state.source_byte_offset` as the cursor. On-demand mode: run once and exit. Background mode: loop with fsevents/polling. _(ADR-010, ADR-019)_
 
 - [ ] **34. Build background observer sidecar (`threadhop observe`)** *(blocked by: #18, #19)*
-  Background process mode for the observer (ADR-015). Watches the active session's JSONL via fsevents (macOS) with polling fallback. Auto-detects active session via `ps`/`lsof`. Batches new messages (configurable, default ~10 messages) and runs Haiku extraction. Exits when the Claude Code session ends. Designed to be enabled as a flag — like Claude Code's remote control — so the user continues working without interruption. _(ADR-015)_
+  Background process mode for the observer (ADR-015). `threadhop observe --session <id>` watches the session's JSONL via fsevents (macOS) with polling fallback. Batches new messages (~3-4 trigger extraction). Records PID in `observation_state.observer_pid`. Exits when Claude Code session ends or `--stop` is sent. _(ADR-015)_
 
-- [ ] **35. Observer enable/disable configuration** *(blocked by: #34)*
-  Three entry points for enabling background observation: (1) `threadhop observe &` manual start, (2) Claude Code hook in `.claude/settings.json` for auto-start, (3) `threadhop config set observe.enabled true` for permanent flag. Add `threadhop observe --stop` to gracefully shut down a running observer. _(ADR-015)_
+- [ ] **35. Observer stop/resume lifecycle** *(blocked by: #34, #44)*
+  Stop mechanisms: `threadhop observe --stop [--session <id>]` sends SIGTERM to recorded PID. `threadhop observe --stop-all` stops all running observers. Observer handles SIGTERM gracefully: flushes pending observations, updates byte offset, sets `status = 'stopped'`. Resume: reads `source_byte_offset`, processes only new bytes. Stale PID detection via `kill -0 $PID` — corrects status to 'stopped' if process dead. Entry points for enabling: (1) manual `threadhop observe --session <id> &`, (2) Claude Code hook in `.claude/settings.json`, (3) `threadhop config set observe.enabled true`. _(ADR-015, ADR-019)_
 
 - [ ] **20. Implement `threadhop todos [--project]` CLI query** *(blocked by: #18, #19)*
-  Runs observer for unprocessed messages, then prints open TODOs from `observations.jsonl`. Filterable by `--project`. _(ADR-010, ADR-011)_
+  Runs observer for unprocessed messages, then prints open TODOs from per-session observation files. Filterable by `--project`. _(ADR-010, ADR-011, ADR-019)_
 
 - [ ] **21. Implement `threadhop decisions [--project]` CLI query** *(blocked by: #18, #19)*
   Same pattern as `todos` but filters for `type: decision`. _(ADR-010, ADR-011)_
 
 - [ ] **22. Implement `threadhop observations [--project]` CLI query** *(blocked by: #18, #19)*
-  Unfiltered dump of all observations, newest first. Output format should stay grep/jq-friendly. _(ADR-010, ADR-011)_
+  Unfiltered dump of all observations, newest first. Reads from per-session files in `~/.config/threadhop/observations/`. Output format stays grep/jq-friendly. _(ADR-010, ADR-011, ADR-019)_
+
+- [ ] **45. Implement `threadhop conflicts [--project]` CLI query** *(blocked by: #18, #19)*
+  Reads `type: "conflict"` entries from per-session observation files. Shows conflicting decisions, their sessions, timestamps, and the reflector's explanation. Supports `--resolved` flag to mark conflicts as reviewed. _(ADR-020)_
 
 ---
 
-## Phase 4: Skill Plugin
-_Five skills for in-session use — tag, context, handoff, observe, insights (ADR-012, ADR-016)._
+## Phase 4: Skill Plugin + TUI Observation Indicator
+_Five skills for in-session use (ADR-012, ADR-016). TUI observation indicator
+and transcript header (ADR-021)._
 
 - [ ] **23. Research Claude Code skill plugin packaging**
   Determine how Claude Code skill plugins are distributed — directory of `.md` files in `~/.claude/skills/`? npm/pip package? Verify the plugin contract before implementing skills. _(Open Question Q4)_
@@ -110,14 +148,23 @@ _Five skills for in-session use — tag, context, handoff, observe, insights (AD
 - [ ] **25. Implement `/threadhop:context` skill** *(blocked by: #12, #23)*
   Instant, no LLM. Reads clipboard via `pbpaste`, detects ThreadHop source labels, presents the content as a clearly bounded context block in the current conversation. Bridges TUI visual selection → Claude Code injection. _(ADR-012)_
 
-- [ ] **26. Implement `/threadhop:handoff <id> [--full]` skill** *(blocked by: #23)*
-  LLM-powered skill. Reads JSONL for given session, parses to clean (role, text) pairs, strips system-reminders, abbreviates tool calls. Spawns sub-agent (Haiku default) to compress into a ~30-50 line brief. `--full` flag uses a stronger model for comprehensive handoff with rationale and excerpts. **Enhanced (ADR-016):** when the source session was observed, uses pre-extracted observations as structured input instead of raw JSONL — faster and higher quality. Falls back to full JSONL mode when no observations exist. _(ADR-006, ADR-012, ADR-016)_
+- [ ] **26. Implement `/threadhop:handoff <id> [--full]` skill** *(blocked by: #18, #23)*
+  Runs observer as underlying function (ADR-018). Checks `observation_state` for target session. If observations exist: reads per-session observation file, catches up on new bytes if source JSONL grew. If NO observations: runs observer on full session from byte 0 first. Then formats observations into handoff brief (~30-50 lines). Short observation sets format directly; large sets use Haiku sub-agent for polish. `--full` flag produces comprehensive handoff with rationale and excerpts. No separate "compress raw JSONL" path — observer is always the first step. _(ADR-012, ADR-016, ADR-018)_
 
 - [ ] **40. Implement `/threadhop:observe` skill** *(blocked by: #23, #34)*
-  Instant, no LLM (spawns background process). Per-session opt-in for observation (ADR-016). Detects current session ID, checks if observer already running, spawns `threadhop observe --session <id> &` in background. Observer performs retroactive catch-up (reads JSONL from byte 0, processes through Haiku), then switches to watch mode. Reports catch-up summary: "47 messages processed — 5 decisions, 3 TODOs, 1 ADR. Watching for new messages." _(ADR-015, ADR-016)_
+  Instant, no LLM (spawns background process). Per-session opt-in for observation (ADR-016). Detects current session ID, checks `observation_state.observer_pid` for existing observer. Spawns `threadhop observe --session <id> &` in background. Observer performs retroactive catch-up from `source_byte_offset` (or byte 0 for new), then switches to watch mode. Reports summary: "47 messages processed — 5 decisions, 3 TODOs, 1 ADR. Watching for new messages." _(ADR-015, ADR-016, ADR-019)_
 
 - [ ] **41. Implement `/threadhop:insights` skill** *(blocked by: #23, #40)*
-  Instant, no LLM. Pull-based context injection (ADR-016). Reads `observations.jsonl` filtered by current session and `conflicts.jsonl` filtered by current project. Formats observations grouped by type (decisions, TODOs, ADRs, observations) with any detected conflicts highlighted. Presents as a bounded context block in the conversation. Returns nothing useful if session was never observed. _(ADR-016)_
+  Instant, no LLM. Pull-based context injection (ADR-016). Reads per-session observation file `observations/<session_id>.jsonl` — single file contains all types including `type: "conflict"` entries from reflector (ADR-020). Formats grouped by type. Returns nothing useful if session was never observed. _(ADR-016, ADR-020)_
+
+- [ ] **46. TUI observation indicator — 🗒 icon in session list** *(blocked by: #44)*
+  Add notepad icon (🗒 or fallback `≡` / `[O]`) next to session name when `observation_state.entry_count > 0`. Checked during existing 5s refresh cycle. Icon is independent of process state circles (◐ ● ○) — additive, not replacement. _(ADR-021)_
+
+- [ ] **47. TUI transcript header for observed sessions** *(blocked by: #44)*
+  When viewing a transcript with observations, show one-line header above first message: `─── 🗒 12 observations · ~/.config/threadhop/observations/abc123.jsonl ───`. Positioned above transcript, below session title. Does NOT interfere with search bar (bottom). Static, informational, copyable. _(ADR-021)_
+
+- [ ] **48. TUI observation keybindings (o/O)** *(blocked by: #46, #34)*
+  `o` on observed session: copy observation file path to clipboard, show notification. `o` on unobserved session: offer to start observing (y/n). `O` on stopped+observed session: resume observation from last byte offset. _(ADR-021)_
 
 ---
 
@@ -128,7 +175,7 @@ _Cross-session knowledge persistence (beyond the raw observations log)._
   Add `bookmarks` table to schema. Toggle bookmark from message selection mode with `space`. Support labels and tags (JSON array). Build bookmark browser panel in TUI.
 
 - [ ] **28. Build project memory ledger** *(blocked by: #1)*
-  Add `memory` table to schema. Support typed entries: `decision | todo | done | adr | observation`. Append-only, filterable by project/type/date. Manual entry from TUI (type + text). Distinct from observations.jsonl: this is for curated/explicit entries with `source: 'explicit'`. _(ADR-005)_
+  Add `memory` table to schema. Support typed entries: `decision | todo | done | adr | observation`. Append-only, filterable by project/type/date. Manual entry from TUI (type + text). Distinct from per-session observation files: this is for curated/explicit entries with `source: 'explicit'`. _(ADR-005)_
 
 - [ ] **29. Add explicit annotation detection** *(blocked by: #18, #28)*
   Recognize `ADR:`, `DECISION:`, `TODO:` markers in conversations and offer to append them to the memory ledger automatically with `source: 'auto'`.
@@ -139,23 +186,24 @@ _Cross-session knowledge persistence (beyond the raw observations log)._
 ---
 
 ## Phase 6: Reflector — Conflict Detection + Fuzzy Search
-_Contradiction detection across sessions. Background sidecar alongside observer (ADR-015).
-Condensation as secondary goal. Add only when observation volume demands it._
+_Contradiction detection across sessions. Reflector writes `type: "conflict"` entries
+to the SAME per-session observation JSONL (ADR-020, ADR-022). Triggered by observer
+process — not independent. Uses `reflector_entry_offset` for incremental processing._
 
-- [ ] **31. Build conflict detection reflector** *(blocked by: #18)*
-  The reflector's primary mission is detecting contradictory decisions across sessions (ADR-015). Groups decisions by project and semantic topic. Uses Haiku to identify contradictions (e.g., "REST over gRPC" in session A vs "gRPC for all service comms" in session B). Writes conflict reports to `~/.config/threadhop/conflicts.jsonl`. _(ADR-015)_
+- [ ] **49. Create reflector prompt** *(prereq for: #31)*
+  Write `~/.config/threadhop/prompts/reflector.md`. Constrains Haiku: append-only, one JSON line per conflict, dedup check against existing conflicts (same `refs` pair + `topic` = skip). Input shape: recent decisions from current session + all decisions from other sessions in same project. Output: `type: "conflict"` entries with `refs`, `topic`, `text` fields. _(ADR-022)_
 
-- [ ] **36. Background reflector mode** *(blocked by: #31, #34)*
-  Runs as a companion to the background observer sidecar. Lower frequency than the observer — triggers every N new decision-type observations or every M minutes. Automatically starts when `threadhop observe` is running and new decisions are appended. _(ADR-015)_
+- [ ] **31. Build conflict detection reflector core function** *(blocked by: #18, #49)*
+  Second `claude -p --model haiku --permission-mode acceptEdits` call (ADR-022). Input: recent `type: "decision"` entries since `reflector_entry_offset` from current session + all decisions from other sessions in same project (gathered from `observations/*.jsonl`). Groups by semantic topic, identifies contradictions. Appends `type: "conflict"` entries to same per-session observation JSONL. Updates `reflector_entry_offset` in `observation_state`. Idempotent — dedup by `refs` pair + `topic`. _(ADR-015, ADR-020, ADR-022)_
 
-- [ ] **37. `threadhop conflicts [--project]` CLI query** *(blocked by: #31)*
-  Displays unreviewed conflicts from `conflicts.jsonl`. Shows the two conflicting decisions, their sessions, timestamps, and the reflector's explanation of the contradiction. Supports `--resolved` flag to mark conflicts as reviewed. _(ADR-015)_
+- [ ] **36. Observer-triggered reflector in background mode** *(blocked by: #31, #34)*
+  The observer process owns the reflector lifecycle (ADR-022). After each observer extraction, checks if `entry_count - reflector_entry_offset >= 5`. If yes, spawns reflector `claude -p` call. No separate PID, no separate daemon — when observer stops, reflector stops. When observer resumes, reflector resumes from its own `reflector_entry_offset`. _(ADR-015, ADR-020, ADR-022)_
 
 - [ ] **38. TUI conflict notification** *(blocked by: #31)*
-  Surface unreviewed conflicts in the TUI sidebar or status bar. Badge count or indicator when new conflicts are detected. Press a key to open conflict detail view. _(ADR-015)_
+  Surface unreviewed `type: "conflict"` entries in the TUI sidebar or status bar. Badge count or indicator when new conflicts are detected. Press a key to open conflict detail view. _(ADR-015, ADR-020)_
 
 - [ ] **39. Observation condensation (secondary reflector goal)** *(blocked by: #31)*
-  When observations.jsonl exceeds a size threshold, merge related decisions, archive completed TODOs, produce condensed summaries. Keep source links back to original observations. This is Mastra's original reflector purpose — retained as a secondary goal behind conflict detection.
+  When per-session observation files exceed a size threshold, merge related decisions, archive completed TODOs, produce condensed summaries. Keep source links back to original observations. Forward-only: condensation appends summary entries, does not delete originals.
 
 - [ ] **32. Trigram-based fuzzy search for typo tolerance** *(blocked by: #14)*
   Add trigram tokenizer as a secondary FTS table. Fall back to trigram search when FTS5 prefix returns zero results. Handles spelling mistakes (e.g., "retr" matches "retry"). _(ADR-007)_
@@ -169,18 +217,25 @@ Condensation as secondary goal. Add only when observation volume demands it._
                ├──> #3 Status ──┬──> #4 Keybinds (s/S)  ─────────┐
                │                └──> #5 Archive (a/A)            │
                ├──> #33 Data models ──> #8 Indexer ──> #9 Incremental ──> #14 Search │ ──> #32 Fuzzy
-               │                                      └──> #18 Observer ──> #19 Incremental
-               │                                                            ├──> #20 todos
-               │                                                            ├──> #21 decisions
-               │                                                            ├──> #22 observations
-               │                                                            ├──> #29 Annotation detection
-               │                                                            ├──> #30 Memory rendering
-               │                                                            ├──> #34 Background observer ──> #35 Enable/disable config
-               │                                                            │                            └──> #36 Background reflector
-               │                                                            └──> #31 Conflict reflector ──> #37 conflicts CLI
-               │                                                                                         ├──> #38 TUI notification
-               │                                                                                         ├──> #39 Condensation
-               │                                                                                         └──> #36 Background reflector (also needs #34)
+               ├──> #44 observation_state table ──┐
+               │                                   ├──> #46 TUI obs indicator
+               │                                   ├──> #47 Transcript header
+               │                                   └──> (prereq for #18, #35)
+               │
+               │  #43 Observer prompt (independent)
+               │         ↓
+               │  #8 Indexer + #43 + #44 ──> #18 Observer core ──> #19 Incremental
+               │                                                    ├──> #20 todos
+               │                                                    ├──> #21 decisions
+               │                                                    ├──> #22 observations
+               │                                                    ├──> #45 conflicts CLI
+               │                                                    ├──> #29 Annotation detection
+               │                                                    ├──> #30 Memory rendering
+               │                                                    ├──> #34 Background observer ──> #35 Stop/resume lifecycle
+               │                                                    │                            ├──> #48 TUI obs keybindings (o/O)
+               │                                                    │                            └──> #36 Observer-triggered reflector (also needs #31)
+               │                                                    └──> #49 Reflector prompt ──> #31 Reflector core ──> #38 TUI notification
+               │                                                                                                     └──> #39 Condensation
                ├──> #27 Bookmarks (also needs #10)
                └──> #28 Memory ledger ──┬──> #29 Annotation detection
                                         └──> #30 Memory rendering
@@ -199,13 +254,18 @@ Condensation as secondary goal. Add only when observation volume demands it._
 
 #23 Skill packaging research ──┬──> #24 /threadhop:tag
                                 ├──> #25 /threadhop:context
-                                ├──> #26 /threadhop:handoff (enhanced with observations)
+                                ├──> #26 /threadhop:handoff (runs observer first, then formats)
                                 ├──> #40 /threadhop:observe (also needs #34)
-                                └──> #41 /threadhop:insights (also needs #40)
+                                └──> #41 /threadhop:insights (reads unified per-session file)
 
 Entry points for session tagging (ADR-013): #4 (TUI) · #16 (CLI) · #24 (skill) — all write to the same sessions table.
 
-Observer-reflector sidecar chain (ADR-015): #18 → #19 → #34 → #35 (background observer) + #31 → #36 (background reflector)
+Observer as core function (ADR-018): #43 prompt + #44 state table → #18 core → used by #34 (background), #26 (handoff), #20-22,45 (CLI queries), #40 (skill)
 
-Observe-insights feedback loop (ADR-016): #34 → #40 (/observe skill) → #41 (/insights skill) → #26 (enhanced handoff)
+Reflector as observer companion (ADR-022): #49 prompt → #31 core → triggered by #34 observer (when entry_count - reflector_entry_offset ≥ 5)
+  Reflector input: decisions from observation files (not raw transcripts). Output: type:"conflict" entries in same JSONL.
+
+Observer-reflector unified output (ADR-020): #18 observer + #31 reflector both append to observations/<session_id>.jsonl
+
+TUI observation surface (ADR-021): #44 → #46 indicator + #47 header + #48 keybindings (o/O)
 ```

--- a/docs/general-learnings.md
+++ b/docs/general-learnings.md
@@ -22,6 +22,7 @@ original context carrying ~80% of signal. Generated on-demand, not in advance.
 ## 2. Mastra Observational Memory Pattern
 
 Reference: `observational-memory.mdx` (Mastra `@mastra/memory` docs)
+Credit: [Mastra team](https://mastra.ai) — `@mastra/memory@1.1.0`
 
 A three-tier memory system that applies beyond Mastra's framework:
 
@@ -43,6 +44,20 @@ Reflections (condensed patterns, merged items)
 **Applicable insight:** This tiered compression model works for any system where
 context accumulates over time. The Observer/Reflector split means you can start
 with just observation (cheap) and add reflection later (when volume demands it).
+
+**The inherent problem when applying to Claude Code:** Mastra's Observer/Reflector
+are *inline agents* — they share the same process and memory as the primary agent
+and can directly modify its context window (removing old messages, injecting
+compressed observations). Claude Code is a black box: we can read its JSONL
+transcript files but cannot modify the running agent's context. This makes the
+inline approach impossible.
+
+ThreadHop adapts the pattern as an *external sidecar* — the observer watches
+transcript files post-hoc, and the reflector focuses on *conflict detection*
+(finding contradictory decisions across sessions) rather than Mastra's original
+goal of context compression. The value shifts from helping the *agent* stay
+effective to helping the *human* understand what happened. See ADR-015 in
+`DESIGN-DECISIONS.md` for the full architecture.
 
 ## 3. Feature-Scoped Shared Memory
 

--- a/docs/general-learnings.md
+++ b/docs/general-learnings.md
@@ -1,0 +1,159 @@
+# General Learnings — Cross-Session Context & Memory Patterns
+
+Extracted from design discussion on 2026-04-14. These are not specific to the
+ThreadHop repo — they apply to any multi-session AI workflow.
+
+---
+
+## 1. The Context Portability Problem
+
+When working with AI coding assistants across multiple sessions, knowledge gets
+trapped. A session at 40-50% context usage has accumulated decisions, rationale,
+and working state that cannot be efficiently carried to a new session.
+
+**Three failed approaches:**
+- **Continue the bloated session** — quality degrades past ~40% context
+- **Dump full markdown** — recreates the bloat in the new session
+- **Manually summarize** — labor-intensive, lossy, breaks flow
+
+**The right approach:** Structured compression via handoff briefs — 5-10% of
+original context carrying ~80% of signal. Generated on-demand, not in advance.
+
+## 2. Mastra Observational Memory Pattern
+
+Reference: `observational-memory.mdx` (Mastra `@mastra/memory` docs)
+
+A three-tier memory system that applies beyond Mastra's framework:
+
+```
+Recent messages (full fidelity, current task)
+    ↓ Observer (threshold-triggered, e.g. 30k tokens)
+Observations (compressed, structured, append-only log)
+    ↓ Reflector (threshold-triggered, e.g. 40k tokens)
+Reflections (condensed patterns, merged items)
+```
+
+**Key design decisions in OM:**
+- Observer runs in background, non-blocking (async buffering)
+- Observations are append-only — never rewritten, only condensed by Reflector
+- Resource scope enables cross-thread memory (experimental, can cause task bleed)
+- Token-tiered model selection: cheaper models for small inputs, stronger for large
+- Retrieval mode keeps observation-to-source links for recall
+
+**Applicable insight:** This tiered compression model works for any system where
+context accumulates over time. The Observer/Reflector split means you can start
+with just observation (cheap) and add reflection later (when volume demands it).
+
+## 3. Feature-Scoped Shared Memory
+
+The right unit for cross-session context is neither the session nor the project —
+it's the **feature**. A feature spans multiple sessions (planning → implementation
+→ verification), possibly multiple projects, possibly multiple AI models.
+
+**Feature context contains:**
+- Decisions made (with rationale)
+- Current implementation state
+- Open questions / unresolved threads
+- Contributing sessions (with their roles: planning, implementation, review)
+
+**This differs from CLAUDE.md:**
+
+| CLAUDE.md | Feature Memory |
+|-----------|----------------|
+| Snapshot (declarative) | Timeline (sequential) |
+| Rewritten on update | Append-only |
+| "What are the rules?" | "What happened and when?" |
+| Project-scoped | Feature-scoped (cross-project) |
+
+## 4. The Verification Session Problem
+
+A common workflow: Plan (Session 1) → Implement (Session 2) → Verify (Session 3,
+often with a different model). Session 3 needs not just the plan artifact but the
+**reasoning** behind it — rejected alternatives, constraints, tradeoffs.
+
+That reasoning lives in Session 1's conversation and never makes it into the plan.
+The handoff brief solves this by explicitly capturing decisions and rationale, not
+just outcomes.
+
+## 5. SQLite FTS vs Embeddings for Personal Tools
+
+For personal-scale search across conversation transcripts (hundreds of sessions,
+thousands of messages):
+
+**SQLite FTS5 with porter stemming** is the right starting point:
+- Keyword search with stemming ("running" matches "run")
+- Zero infrastructure — SQLite is stdlib in Python
+- Deterministic results — you know why something matched
+- Sub-millisecond queries on personal-scale data
+- `porter unicode61` tokenizer handles English + Unicode
+
+**Embeddings become worth it only when:**
+- Keyword search fails on actual usage patterns
+- You need semantic similarity ("find discussions about error handling" matching
+  "exception management")
+- The dataset is large enough that keyword recall drops
+
+For most personal tools, keyword search covers 90%+ of queries because you
+remember *words* you used, not abstract concepts.
+
+## 6. Language Choice for TUI Tools
+
+For I/O-bound TUI applications (file reading, subprocess calls, widget rendering):
+
+**Python + Textual** is the right default:
+- Textual provides a complete widget system (layout, styling, events)
+- Bottlenecks are I/O and subprocess calls — language doesn't help
+- SQLite FTS queries run in C regardless of host language
+- `uv run --script` gives near-instant startup with no install step
+- Single-file deployment is a major UX advantage
+
+**Rust** only makes sense if:
+- Startup time matters at the <50ms level
+- You're processing millions of records in a tight loop
+- You want to distribute a single static binary
+
+**TypeScript** only makes sense if:
+- You plan to share code with a browser/Electron UI later
+- Your team knows TS better than Python
+
+## 7. Strict LLM vs Instantaneous Boundary in Tool Design
+
+When building tools that mix AI-powered and non-AI operations, draw a hard
+line between what needs an LLM call and what must be instantaneous:
+
+**Instantaneous (TUI / local app):**
+- Search — must update per-keystroke, FTS queries are sub-millisecond
+- Visual selection — users select messages by seeing them, not by typing indices
+- Copy/export — clipboard and file writes are instant
+- Tagging/bookmarking — single-key state changes
+
+**LLM-powered (skill/plugin):**
+- Transcript compression / handoff — genuinely needs summarization
+- Knowledge extraction — needs understanding, not just filtering
+
+**The failure mode:** Making search or context insertion into an LLM skill.
+Search needs per-keystroke feedback. Context insertion needs visual message
+selection — you can't type "messages 15-25" without seeing them first, making
+an opaque range parameter useless. These must be instant, visual, and local.
+
+**The architecture:** The TUI and the skill plugin share the same database
+but serve different moments. The TUI is for browsing, selecting, and instant
+operations. Skills are invoked mid-conversation for operations that benefit
+from LLM processing (handoff) or that inject pre-built context without
+switching windows (project memory).
+
+## 8. Context Transport: Clipboard vs Temp Files
+
+Two complementary mechanisms for carrying messages between sessions:
+
+- **Clipboard** for small grabs (1-5 messages): select, copy, paste into
+  the other session. Include source labels so the receiving session knows
+  where the context came from.
+
+- **Temp files** for larger context blocks (10+ messages): export to
+  `/tmp/<tool-name>/<id>.md`, display the full path, let the user
+  reference it via file read in the receiving session.
+
+Key: temp files go in `/tmp/`, NOT in the repo or config directory.
+They are ephemeral references, auto-cleaned on reboot. The absolute path
+makes them referenceable from any session on the machine.

--- a/indexer.py
+++ b/indexer.py
@@ -355,6 +355,132 @@ def index_all(
 # --- Incremental indexing (task #9) ----------------------------------------
 
 
+def parse_byte_range(
+    raw_bytes: bytes,
+    *,
+    fallback_session_id: str | None = None,
+) -> list[dict]:
+    """Parse a JSONL byte range into cleaned message groups.
+
+    Applies ADR-003 chunk-merging (consecutive assistant lines sharing
+    ``message.id`` collapse into one row), strips ``<system-reminder>``
+    blocks, skips tool-result user lines, and abbreviates ``tool_use``
+    blocks. Empty rows (a line that reduced to nothing after cleaning)
+    are dropped.
+
+    Callers are expected to trim any trailing partial line before
+    calling — see ``index_session_incremental`` for how to do that with
+    a byte offset. Malformed JSON lines are silently skipped.
+
+    Returns one dict per logical message with the same shape
+    ``index_session_incremental`` writes to ``messages``::
+
+        {"uuid", "session_id", "role", "text", "timestamp",
+         "cwd", "parent_uuid", "is_sidechain", "message_id"}
+
+    ``fallback_session_id`` is substituted when a line omits its own
+    ``sessionId`` (rare, but happens on older transcripts).
+
+    Extracted as a public helper so the observer (ADR-018) can reuse
+    the exact rendering the FTS index uses — "observer sees what the
+    user sees."
+    """
+    raw_lines = raw_bytes.decode("utf-8", errors="replace").split("\n")
+    # split() on "line1\nline2\n" → ["line1", "line2", ""] — drop trailing empty.
+    if raw_lines and raw_lines[-1] == "":
+        raw_lines.pop()
+
+    groups: list[dict] = []
+    current_chunk: dict | None = None
+    current_chunk_parts: list[str] = []
+
+    def _flush_chunk() -> None:
+        nonlocal current_chunk, current_chunk_parts
+        if current_chunk is not None:
+            current_chunk["text"] = "\n\n".join(
+                p for p in current_chunk_parts if p
+            ).strip()
+            if current_chunk["text"]:
+                groups.append(current_chunk)
+            current_chunk = None
+            current_chunk_parts = []
+
+    for raw_line in raw_lines:
+        if not raw_line.strip():
+            continue
+        try:
+            msg = json.loads(raw_line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+        mtype = msg.get("type")
+        if mtype not in ("user", "assistant"):
+            continue
+
+        if mtype == "user":
+            _flush_chunk()
+
+            text = _extract_user_text(msg)
+            if not text:
+                continue
+
+            uid = msg.get("uuid")
+            sid = msg.get("sessionId") or fallback_session_id
+            if not uid:
+                continue
+
+            groups.append({
+                "uuid": uid,
+                "session_id": sid,
+                "role": "user",
+                "text": text,
+                "timestamp": msg.get("timestamp"),
+                "cwd": msg.get("cwd"),
+                "parent_uuid": msg.get("parentUuid"),
+                "is_sidechain": 1 if msg.get("isSidechain") else 0,
+                "message_id": msg.get("message", {}).get("id"),
+            })
+            continue
+
+        # --- assistant line ---
+        mid = msg.get("message", {}).get("id")
+        parts = _extract_assistant_blocks(msg)
+
+        # Continuing the same logical message → accumulate.
+        if (
+            mid is not None
+            and current_chunk is not None
+            and current_chunk.get("message_id") == mid
+        ):
+            current_chunk_parts.extend(parts)
+            continue
+
+        # Different message.id → flush previous and start fresh.
+        _flush_chunk()
+
+        uid = msg.get("uuid")
+        sid = msg.get("sessionId") or fallback_session_id
+        if not uid:
+            continue
+
+        current_chunk = {
+            "uuid": uid,
+            "session_id": sid,
+            "role": "assistant",
+            "text": "",  # populated by _flush_chunk
+            "timestamp": msg.get("timestamp"),
+            "cwd": msg.get("cwd"),
+            "parent_uuid": msg.get("parentUuid"),
+            "is_sidechain": 1 if msg.get("isSidechain") else 0,
+            "message_id": mid,
+        }
+        current_chunk_parts = list(parts)
+
+    # Flush the last chunk.
+    _flush_chunk()
+    return groups
+
+
 def index_session_incremental(
     conn: sqlite3.Connection,
     session_id: str,
@@ -363,9 +489,9 @@ def index_session_incremental(
     """Incrementally index new JSONL content for a session.
 
     Called from the TUI's 5-second refresh cycle.  Reads only bytes
-    appended since the last index, parses new lines, applies the same
-    chunk-merging logic as ``parse_messages``, and upserts into the
-    ``messages`` + ``messages_fts`` tables.
+    appended since the last index, parses new lines via
+    ``parse_byte_range``, and upserts into the ``messages`` +
+    ``messages_fts`` tables.
 
     Edge cases:
 
@@ -418,111 +544,9 @@ def index_session_incremental(
     processable = new_bytes[: last_newline + 1]
     new_offset = last_offset + last_newline + 1
 
-    # --- Parse raw lines ---
-    raw_lines = processable.decode("utf-8", errors="replace").split("\n")
-    # split() on "line1\nline2\n" → ["line1", "line2", ""] — drop trailing empty
-    if raw_lines and raw_lines[-1] == "":
-        raw_lines.pop()
-
-    if not raw_lines:
-        db.upsert_index_state(
-            conn, session_id, str(file_path), new_offset,
-            _dt.now().timestamp(),
-        )
-        return
-
-    # --- Group messages with chunk merging (ADR-003) ---
-    # Reuses the same extraction helpers as parse_messages but reads from
-    # a byte range instead of the full file.
-
-    parsed_groups: list[dict] = []
-    current_chunk: dict | None = None
-    current_chunk_parts: list[str] = []
-
-    def _flush_chunk() -> None:
-        nonlocal current_chunk, current_chunk_parts
-        if current_chunk is not None:
-            current_chunk["text"] = "\n\n".join(
-                p for p in current_chunk_parts if p
-            ).strip()
-            if current_chunk["text"]:
-                parsed_groups.append(current_chunk)
-            current_chunk = None
-            current_chunk_parts = []
-
-    for raw_line in raw_lines:
-        if not raw_line.strip():
-            continue
-        try:
-            msg = json.loads(raw_line)
-        except (json.JSONDecodeError, ValueError):
-            continue
-
-        mtype = msg.get("type")
-        if mtype not in ("user", "assistant"):
-            continue
-
-        if mtype == "user":
-            _flush_chunk()
-
-            text = _extract_user_text(msg)
-            if not text:
-                continue
-
-            uid = msg.get("uuid")
-            sid = msg.get("sessionId") or session_id
-            if not uid:
-                continue
-
-            parsed_groups.append({
-                "uuid": uid,
-                "session_id": sid,
-                "role": "user",
-                "text": text,
-                "timestamp": msg.get("timestamp"),
-                "cwd": msg.get("cwd"),
-                "parent_uuid": msg.get("parentUuid"),
-                "is_sidechain": 1 if msg.get("isSidechain") else 0,
-                "message_id": msg.get("message", {}).get("id"),
-            })
-            continue
-
-        # --- assistant line ---
-        mid = msg.get("message", {}).get("id")
-        parts = _extract_assistant_blocks(msg)
-
-        # Continuing the same logical message → accumulate.
-        if (
-            mid is not None
-            and current_chunk is not None
-            and current_chunk.get("message_id") == mid
-        ):
-            current_chunk_parts.extend(parts)
-            continue
-
-        # Different message.id → flush previous and start fresh.
-        _flush_chunk()
-
-        uid = msg.get("uuid")
-        sid = msg.get("sessionId") or session_id
-        if not uid:
-            continue
-
-        current_chunk = {
-            "uuid": uid,
-            "session_id": sid,
-            "role": "assistant",
-            "text": "",  # populated by _flush_chunk
-            "timestamp": msg.get("timestamp"),
-            "cwd": msg.get("cwd"),
-            "parent_uuid": msg.get("parentUuid"),
-            "is_sidechain": 1 if msg.get("isSidechain") else 0,
-            "message_id": mid,
-        }
-        current_chunk_parts = list(parts)
-
-    # Flush the last chunk.
-    _flush_chunk()
+    parsed_groups = parse_byte_range(
+        processable, fallback_session_id=session_id,
+    )
 
     if not parsed_groups:
         db.upsert_index_state(

--- a/observer.py
+++ b/observer.py
@@ -8,12 +8,16 @@ indicator, and CLI query commands). It is an **orchestrator**, not just a
   1. Read the per-session ``observation_state`` row to find where the last
      run left off (``source_byte_offset``).
   2. Open the source JSONL, seek to that offset, read to EOF.
-  3. Count *message turns* in the new bytes (user lines + assistant
-     ``message.id`` groups — streaming chunks are one turn, not many).
+  3. Parse the new bytes via ``indexer.parse_byte_range`` — same pipeline
+     that feeds the FTS index and the TUI. Tool outputs are already
+     filtered out, ``<system-reminder>`` blocks stripped, ``tool_use``
+     blocks rendered as one-line abbreviations, streaming chunks merged.
+     The observer sees exactly what the user sees.
   4. If fewer than ``BATCH_THRESHOLD`` new turns accumulated, return early —
      Haiku with two turns of context tends to hallucinate or extract trivia.
-  5. Assemble the prompt: ``prompts/observer.md`` + the chunk + the output
-     file path (``~/.config/threadhop/observations/<session_id>.jsonl``).
+  5. Format the cleaned turns as a readable role-labelled transcript and
+     splice it into ``prompts/observer.md`` along with the output file
+     path (``~/.config/threadhop/observations/<session_id>.jsonl``).
   6. Invoke ``claude -p --model haiku --permission-mode acceptEdits`` — the
      Haiku process appends JSONL observations to the output file itself
      (``acceptEdits`` is the minimum permission required for file append).
@@ -41,6 +45,7 @@ from pathlib import Path
 from typing import Any
 
 import db
+import indexer
 
 
 # --- Configuration --------------------------------------------------------
@@ -67,44 +72,32 @@ _TYPE_ORDER = ("decision", "todo", "done", "adr", "observation", "conflict")
 # --- Helpers --------------------------------------------------------------
 
 
-def _count_message_turns(raw: bytes) -> int:
-    """Count distinct user/assistant turns in a JSONL byte range.
+def _format_transcript(turns: list[dict]) -> str:
+    """Render cleaned message turns as a role-labelled transcript.
 
-    Mirrors ADR-003 chunk-merging: consecutive assistant lines sharing the
-    same ``message.id`` are one logical turn. User lines carrying a
-    ``toolUseResult`` are tool output (not user speech) and don't count.
-    Malformed JSON lines are skipped silently — the observer shouldn't
-    refuse to run just because one line is corrupt.
+    Each turn becomes a markdown-ish block::
+
+        ### user · 2026-04-17T10:00:00Z
+        <cleaned text>
+
+        ### assistant · 2026-04-17T10:00:01Z
+        <cleaned text with [Editing foo.py] style tool-use abbreviations>
+
+    Chosen over JSONL-per-turn because field names repeated per line would
+    waste tokens on no new information, and Haiku reasons more reliably
+    about a transcript-shaped input. Timestamps are kept so the prompt's
+    ``ts`` field requirement (ADR-018) has an authoritative source.
     """
-    turns = 0
-    last_assistant_mid: str | None = None
-
-    for line in raw.decode("utf-8", errors="replace").splitlines():
-        if not line.strip():
+    blocks: list[str] = []
+    for turn in turns:
+        role = turn.get("role", "user")
+        ts = turn.get("timestamp") or ""
+        header = f"### {role} · {ts}" if ts else f"### {role}"
+        text = (turn.get("text") or "").strip()
+        if not text:
             continue
-        try:
-            msg = json.loads(line)
-        except (json.JSONDecodeError, ValueError):
-            continue
-
-        mtype = msg.get("type")
-        if mtype == "user":
-            # Tool results arrive as ``type: "user"`` with ``toolUseResult``
-            # — they're machine output, not a user turn.
-            if msg.get("toolUseResult") is not None:
-                continue
-            turns += 1
-            last_assistant_mid = None
-        elif mtype == "assistant":
-            mid = msg.get("message", {}).get("id")
-            # Group streaming chunks: only the *first* chunk of a new
-            # message.id counts as a turn.
-            if mid is None or mid != last_assistant_mid:
-                turns += 1
-                last_assistant_mid = mid
-        # Other line types (summary, ai-title, system) don't contribute.
-
-    return turns
+        blocks.append(f"{header}\n{text}")
+    return "\n\n".join(blocks)
 
 
 def _read_new_bytes(
@@ -193,22 +186,20 @@ def _summary_message(turns: int, by_type: dict[str, int]) -> str:
     return f"Processed {turns} {turns_label}. {tail}."
 
 
-def _build_prompt(template: str, chunk: bytes, obs_path: Path) -> str:
-    """Splice the conversation chunk and output path into the prompt.
+def _build_prompt(template: str, transcript: str, obs_path: Path) -> str:
+    """Splice the cleaned transcript and output path into the prompt.
 
     Kept as plain string concat rather than a template engine — the
     observer prompt is a markdown file curated as part of the app, and
-    the only substitutions are the chunk body and the file path.
+    the only substitutions are the transcript body and the file path.
     """
-    chunk_text = chunk.decode("utf-8", errors="replace")
     return (
         f"{template.rstrip()}\n\n"
         "---\n\n"
         "## Conversation chunk\n\n"
         "<session_chunk>\n"
-        f"{chunk_text}"
-        + ("" if chunk_text.endswith("\n") else "\n")
-        + "</session_chunk>\n\n"
+        f"{transcript.strip()}\n"
+        "</session_chunk>\n\n"
         "## Output file\n\n"
         f"Append observations to: {obs_path}\n"
     )
@@ -335,7 +326,16 @@ def observe_session(
         offset = 0
 
     new_bytes, new_offset = _read_new_bytes(source_path, offset)
-    turns = _count_message_turns(new_bytes)
+
+    # Parse the new bytes through the same pipeline the FTS index uses
+    # (indexer.parse_byte_range): tool outputs dropped, system-reminders
+    # stripped, tool_use abbreviated, streaming chunks merged. This keeps
+    # Haiku's input token count small and ensures the observer reasons
+    # about the same view of the conversation the user reads in the TUI.
+    message_turns = indexer.parse_byte_range(
+        new_bytes, fallback_session_id=session_id,
+    )
+    turns = len(message_turns)
 
     # Ensure the observations directory exists before we risk any writes.
     db.OBS_DIR.mkdir(parents=True, exist_ok=True)
@@ -377,7 +377,8 @@ def observe_session(
             "error": f"read prompt {prompt_path}: {e}",
             "message": f"Could not read observer prompt: {e}",
         }
-    prompt = _build_prompt(prompt_template, new_bytes, obs_path)
+    transcript = _format_transcript(message_turns)
+    prompt = _build_prompt(prompt_template, transcript, obs_path)
 
     # --- Step 5: invoke claude -p -----------------------------------------
     # ``shutil.which`` gives a precise error before we pay for the fork.

--- a/observer.py
+++ b/observer.py
@@ -1,0 +1,484 @@
+"""Observer core function — extracts typed observations from session JSONL.
+
+This is the single observer used by every entry point (CLI ``threadhop
+observe``, the ``/threadhop:observe`` skill, ``/threadhop:handoff``, the TUI
+indicator, and CLI query commands). It is an **orchestrator**, not just a
+``claude -p`` wrapper — per ADR-018:
+
+  1. Read the per-session ``observation_state`` row to find where the last
+     run left off (``source_byte_offset``).
+  2. Open the source JSONL, seek to that offset, read to EOF.
+  3. Count *message turns* in the new bytes (user lines + assistant
+     ``message.id`` groups — streaming chunks are one turn, not many).
+  4. If fewer than ``BATCH_THRESHOLD`` new turns accumulated, return early —
+     Haiku with two turns of context tends to hallucinate or extract trivia.
+  5. Assemble the prompt: ``prompts/observer.md`` + the chunk + the output
+     file path (``~/.config/threadhop/observations/<session_id>.jsonl``).
+  6. Invoke ``claude -p --model haiku --permission-mode acceptEdits`` — the
+     Haiku process appends JSONL observations to the output file itself
+     (``acceptEdits`` is the minimum permission required for file append).
+  7. Diff the observation file line count before/after to compute how many
+     new entries were written, then advance ``source_byte_offset`` and
+     ``entry_count`` in SQLite via ``db.upsert_observation_state``.
+
+Per ADR-019: per-session observation files. Per ADR-020: observer and
+reflector share one file — the reflector appends ``type: "conflict"``
+entries to the same JSONL.
+
+Public API::
+
+    observe_session(conn, session_id, ...) -> dict
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import db
+
+
+# --- Configuration --------------------------------------------------------
+
+# Minimum human/assistant turns in a new chunk before extraction runs.
+# Below this, observer returns early — two-turn chunks don't contain enough
+# context for Haiku to distinguish a real decision from idle chatter, and
+# paying for the call just to get zero entries is wasteful.
+BATCH_THRESHOLD = 3
+
+# Location of the shared observer prompt. Bundled with the app — the runtime
+# does not need anything in ``~/.config/threadhop/prompts/``.
+PROMPT_PATH = Path(__file__).resolve().parent / "prompts" / "observer.md"
+
+# Default subprocess timeout. Haiku usually responds in seconds, but the
+# first call of a session can pay an auth/warmup cost, and extremely large
+# chunks (first-time catch-up on a long transcript) take longer.
+DEFAULT_TIMEOUT_SEC = 180.0
+
+# Known observation types, in display order for the summary line.
+_TYPE_ORDER = ("decision", "todo", "done", "adr", "observation", "conflict")
+
+
+# --- Helpers --------------------------------------------------------------
+
+
+def _count_message_turns(raw: bytes) -> int:
+    """Count distinct user/assistant turns in a JSONL byte range.
+
+    Mirrors ADR-003 chunk-merging: consecutive assistant lines sharing the
+    same ``message.id`` are one logical turn. User lines carrying a
+    ``toolUseResult`` are tool output (not user speech) and don't count.
+    Malformed JSON lines are skipped silently — the observer shouldn't
+    refuse to run just because one line is corrupt.
+    """
+    turns = 0
+    last_assistant_mid: str | None = None
+
+    for line in raw.decode("utf-8", errors="replace").splitlines():
+        if not line.strip():
+            continue
+        try:
+            msg = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+        mtype = msg.get("type")
+        if mtype == "user":
+            # Tool results arrive as ``type: "user"`` with ``toolUseResult``
+            # — they're machine output, not a user turn.
+            if msg.get("toolUseResult") is not None:
+                continue
+            turns += 1
+            last_assistant_mid = None
+        elif mtype == "assistant":
+            mid = msg.get("message", {}).get("id")
+            # Group streaming chunks: only the *first* chunk of a new
+            # message.id counts as a turn.
+            if mid is None or mid != last_assistant_mid:
+                turns += 1
+                last_assistant_mid = mid
+        # Other line types (summary, ai-title, system) don't contribute.
+
+    return turns
+
+
+def _read_new_bytes(
+    source_path: Path, offset: int
+) -> tuple[bytes, int]:
+    """Read from ``offset`` to the last complete newline.
+
+    Mirrors the indexer's partial-line guard: if the session is actively
+    being written, the tail may be mid-line — stop at the last ``\\n`` so
+    the trailing partial line is picked up on the next run.
+
+    Returns ``(processable_bytes, new_offset)``. ``new_offset`` is
+    unchanged if no complete line is available yet.
+    """
+    try:
+        with open(source_path, "rb") as f:
+            f.seek(offset)
+            raw = f.read()
+    except OSError:
+        return b"", offset
+
+    if not raw:
+        return b"", offset
+    last_newline = raw.rfind(b"\n")
+    if last_newline == -1:
+        return b"", offset
+    return raw[: last_newline + 1], offset + last_newline + 1
+
+
+def _count_obs_lines(obs_path: Path) -> int:
+    """Count non-empty lines in the observation JSONL (entry count)."""
+    if not obs_path.exists():
+        return 0
+    count = 0
+    with open(obs_path, "rb") as f:
+        for line in f:
+            if line.strip():
+                count += 1
+    return count
+
+
+def _count_new_entries_by_type(
+    obs_path: Path, skip_lines: int
+) -> dict[str, int]:
+    """Parse observation lines after ``skip_lines``, grouping by ``type``.
+
+    ``skip_lines`` is the line count recorded before the extraction ran;
+    anything past it was written by the current invocation (the file is
+    append-only per ADR-020, so this diff is safe).
+    """
+    counts: dict[str, int] = {}
+    if not obs_path.exists():
+        return counts
+    with open(obs_path) as f:
+        for i, line in enumerate(f):
+            if i < skip_lines:
+                continue
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            t = entry.get("type")
+            if isinstance(t, str):
+                counts[t] = counts.get(t, 0) + 1
+    return counts
+
+
+def _summary_message(turns: int, by_type: dict[str, int]) -> str:
+    """Format the human-readable summary line returned to the caller."""
+    parts: list[str] = []
+    for key in _TYPE_ORDER:
+        n = by_type.get(key, 0)
+        if n:
+            label = key if n == 1 else f"{key}s"
+            parts.append(f"{n} {label}")
+    # Extras Haiku invented (unlikely but defensive).
+    for key, n in by_type.items():
+        if key in _TYPE_ORDER or not n:
+            continue
+        parts.append(f"{n} {key}")
+    tail = ", ".join(parts) if parts else "no new observations"
+    turns_label = "turn" if turns == 1 else "turns"
+    return f"Processed {turns} {turns_label}. {tail}."
+
+
+def _build_prompt(template: str, chunk: bytes, obs_path: Path) -> str:
+    """Splice the conversation chunk and output path into the prompt.
+
+    Kept as plain string concat rather than a template engine — the
+    observer prompt is a markdown file curated as part of the app, and
+    the only substitutions are the chunk body and the file path.
+    """
+    chunk_text = chunk.decode("utf-8", errors="replace")
+    return (
+        f"{template.rstrip()}\n\n"
+        "---\n\n"
+        "## Conversation chunk\n\n"
+        "<session_chunk>\n"
+        f"{chunk_text}"
+        + ("" if chunk_text.endswith("\n") else "\n")
+        + "</session_chunk>\n\n"
+        "## Output file\n\n"
+        f"Append observations to: {obs_path}\n"
+    )
+
+
+# --- Main entry point -----------------------------------------------------
+
+
+def observe_session(
+    conn: sqlite3.Connection,
+    session_id: str,
+    *,
+    source_path: str | Path | None = None,
+    batch_threshold: int = BATCH_THRESHOLD,
+    claude_bin: str = "claude",
+    timeout: float = DEFAULT_TIMEOUT_SEC,
+    prompt_path: Path | None = None,
+) -> dict[str, Any]:
+    """Run one observer extraction pass for ``session_id``.
+
+    Args:
+        conn: Open DB connection with the schema applied.
+        session_id: Claude Code session UUID to observe.
+        source_path: Override for the source JSONL. Normally resolved from
+            the ``observation_state`` row (on resume) or the ``sessions``
+            row (on first observation). Passing this explicitly is mostly
+            useful for tests.
+        batch_threshold: Minimum number of new message turns required for
+            a Haiku call. Below this, the function returns without
+            invoking Claude and without advancing ``source_byte_offset``.
+        claude_bin: Name or path of the ``claude`` CLI binary. Tests pass
+            a fake shim that writes the expected observation JSONL.
+        timeout: Subprocess timeout for the Haiku call (seconds).
+        prompt_path: Override for the observer prompt file location.
+            Defaults to ``prompts/observer.md`` next to this module.
+
+    Returns:
+        A summary dict::
+
+            {
+              "status":  "extracted" | "up_to_date" | "below_threshold"
+                         | "no_source" | "failed",
+              "turns":   <int>,
+              "new_entries": <int>,
+              "by_type": {"decision": N, "todo": M, ...},
+              "source_byte_offset": <int>,  # post-run cursor
+              "entry_count": <int>,         # total lines in obs file
+              "obs_path": <str>,
+              "message": <human-readable summary>,
+              # on status == "failed":
+              "error": <str>,
+              "stderr": <str>,   # present when stderr was captured
+            }
+
+        Never raises on expected failures (subprocess error, missing
+        source file, etc.) — callers branch on ``status``.
+    """
+    prompt_path = prompt_path or PROMPT_PATH
+
+    # --- Step 1: load state, or seed it from the sessions table -----------
+    state = db.get_observation_state(conn, session_id)
+
+    if state is None:
+        # First observation for this session. Resolve source_path from
+        # the sessions row unless the caller supplied one.
+        if source_path is None:
+            sess = db.get_session(conn, session_id)
+            if sess is None or not sess.get("session_path"):
+                return {
+                    "status": "no_source",
+                    "turns": 0,
+                    "new_entries": 0,
+                    "by_type": {},
+                    "source_byte_offset": 0,
+                    "entry_count": 0,
+                    "obs_path": "",
+                    "message": (
+                        f"No source JSONL known for session {session_id}"
+                    ),
+                }
+            source_path = sess["session_path"]
+        source_path = Path(source_path)
+        obs_path = db.OBS_DIR / f"{session_id}.jsonl"
+        offset = 0
+    else:
+        # Resume from recorded cursor. ``source_path`` override is honoured
+        # (tests / file moves) but obs_path is always the recorded one.
+        source_path = Path(source_path or state["source_path"])
+        obs_path = Path(state["obs_path"])
+        offset = int(state["source_byte_offset"])
+
+    if not source_path.exists():
+        return {
+            "status": "no_source",
+            "turns": 0,
+            "new_entries": 0,
+            "by_type": {},
+            "source_byte_offset": offset,
+            "entry_count": int(state["entry_count"]) if state else 0,
+            "obs_path": str(obs_path),
+            "message": f"Source JSONL not found: {source_path}",
+        }
+
+    # --- Step 2: read new bytes -------------------------------------------
+    try:
+        file_size = source_path.stat().st_size
+    except OSError as e:
+        return {
+            "status": "failed",
+            "turns": 0,
+            "new_entries": 0,
+            "by_type": {},
+            "source_byte_offset": offset,
+            "entry_count": int(state["entry_count"]) if state else 0,
+            "obs_path": str(obs_path),
+            "error": f"stat {source_path}: {e}",
+            "message": f"Could not stat source JSONL: {e}",
+        }
+
+    # Truncation / rotation: re-read from byte 0. Observations already
+    # written stay — they're append-only per ADR-020 — but the cursor has
+    # to rewind since the old offset is past the new EOF.
+    if file_size < offset:
+        offset = 0
+
+    new_bytes, new_offset = _read_new_bytes(source_path, offset)
+    turns = _count_message_turns(new_bytes)
+
+    # Ensure the observations directory exists before we risk any writes.
+    db.OBS_DIR.mkdir(parents=True, exist_ok=True)
+
+    # --- Step 3: threshold check ------------------------------------------
+    if turns < batch_threshold:
+        # No state change: we want the next run to re-read the same bytes
+        # (plus whatever else has arrived) and try to clear the threshold.
+        existing_entries = (
+            int(state["entry_count"]) if state
+            else _count_obs_lines(obs_path)
+        )
+        return {
+            "status": "up_to_date" if turns == 0 else "below_threshold",
+            "turns": turns,
+            "new_entries": 0,
+            "by_type": {},
+            "source_byte_offset": offset,
+            "entry_count": existing_entries,
+            "obs_path": str(obs_path),
+            "message": (
+                "Already up to date." if turns == 0
+                else f"Only {turns} new turn(s) — need {batch_threshold}."
+            ),
+        }
+
+    # --- Step 4: assemble the prompt --------------------------------------
+    try:
+        prompt_template = prompt_path.read_text()
+    except OSError as e:
+        return {
+            "status": "failed",
+            "turns": turns,
+            "new_entries": 0,
+            "by_type": {},
+            "source_byte_offset": offset,
+            "entry_count": _count_obs_lines(obs_path),
+            "obs_path": str(obs_path),
+            "error": f"read prompt {prompt_path}: {e}",
+            "message": f"Could not read observer prompt: {e}",
+        }
+    prompt = _build_prompt(prompt_template, new_bytes, obs_path)
+
+    # --- Step 5: invoke claude -p -----------------------------------------
+    # ``shutil.which`` gives a precise error before we pay for the fork.
+    if shutil.which(claude_bin) is None and not Path(claude_bin).exists():
+        return {
+            "status": "failed",
+            "turns": turns,
+            "new_entries": 0,
+            "by_type": {},
+            "source_byte_offset": offset,
+            "entry_count": _count_obs_lines(obs_path),
+            "obs_path": str(obs_path),
+            "error": f"{claude_bin} not found on PATH",
+            "message": f"Could not find {claude_bin} on PATH.",
+        }
+
+    before_count = _count_obs_lines(obs_path)
+    try:
+        proc = subprocess.run(
+            [
+                claude_bin, "-p", prompt,
+                "--model", "haiku",
+                "--permission-mode", "acceptEdits",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "status": "failed",
+            "turns": turns,
+            "new_entries": 0,
+            "by_type": {},
+            "source_byte_offset": offset,
+            "entry_count": before_count,
+            "obs_path": str(obs_path),
+            "error": f"claude -p timed out after {timeout}s",
+            "message": f"claude -p timed out after {timeout}s.",
+        }
+    except OSError as e:
+        return {
+            "status": "failed",
+            "turns": turns,
+            "new_entries": 0,
+            "by_type": {},
+            "source_byte_offset": offset,
+            "entry_count": before_count,
+            "obs_path": str(obs_path),
+            "error": f"claude -p failed to start: {e}",
+            "message": f"Could not invoke {claude_bin}: {e}",
+        }
+
+    if proc.returncode != 0:
+        return {
+            "status": "failed",
+            "turns": turns,
+            "new_entries": 0,
+            "by_type": {},
+            "source_byte_offset": offset,
+            "entry_count": before_count,
+            "obs_path": str(obs_path),
+            "error": f"claude -p exited {proc.returncode}",
+            "stderr": (proc.stderr or "").strip(),
+            "message": (
+                f"claude -p exited {proc.returncode}. "
+                "State not advanced; next run will retry from same offset."
+            ),
+        }
+
+    # --- Step 6: diff observation file, advance state ---------------------
+    after_count = _count_obs_lines(obs_path)
+    new_entries = max(0, after_count - before_count)
+    by_type = (
+        _count_new_entries_by_type(obs_path, before_count)
+        if new_entries else {}
+    )
+
+    now = datetime.now().timestamp()
+    db.upsert_observation_state(
+        conn,
+        session_id,
+        str(source_path),
+        str(obs_path),
+        source_byte_offset=new_offset,
+        entry_count=after_count,
+        reflector_entry_offset=(
+            int(state["reflector_entry_offset"]) if state else 0
+        ),
+        last_observed_at=now,
+    )
+
+    # --- Step 7: summary --------------------------------------------------
+    return {
+        "status": "extracted",
+        "turns": turns,
+        "new_entries": new_entries,
+        "by_type": by_type,
+        "source_byte_offset": new_offset,
+        "entry_count": after_count,
+        "obs_path": str(obs_path),
+        "message": _summary_message(turns, by_type),
+    }

--- a/prompts/observer.md
+++ b/prompts/observer.md
@@ -1,8 +1,8 @@
 # ThreadHop Observer Prompt
 
 You are an observation extractor for Claude Code session transcripts. Your job
-is to read a chunk of conversation (JSONL transcript lines) and extract
-structured observations from what was **explicitly discussed**.
+is to read a cleaned conversation chunk and extract structured observations
+from what was **explicitly discussed**.
 
 ## Output rules
 
@@ -39,25 +39,40 @@ from this list:
 - **observation**: The catch-all for valuable knowledge that isn't a decision
   or task. Use sparingly — not every conversation remark is an observation.
 
-## What to read
+## Input shape
 
-The conversation chunk is JSONL — one JSON object per line. Each line has:
+The conversation chunk is a role-labelled transcript inside
+`<session_chunk>` tags. Each turn looks like:
 
-- `type`: `"human"` (user message) or `"assistant"` (Claude response)
-- `message.content`: Array of content blocks. Text blocks have `type: "text"`.
-  Tool-use blocks have `type: "tool_use"` with `name` and `input`.
-- `message.id`: Groups streaming chunks — multiple lines may share the same
-  `message.id`. Read them as one logical message.
+```
+### user · 2026-04-17T10:30:00Z
+What about rate limiting?
 
-**Focus on the human/assistant dialogue.** Tool calls (file reads, edits, bash
-commands) provide context but are not observations themselves. Extract
-observations from what was discussed *about* the tool results, not the raw
-tool output.
+### assistant · 2026-04-17T10:30:05Z
+Two options: leaky bucket vs token bucket. I'd go token bucket because
+the burst behaviour matches our traffic shape.
+[Editing ratelimit.go]
+Done — 60 rpm default, per-IP keyed.
+```
 
-**Skip entirely:**
-- `<system-reminder>` blocks — these are framework noise, not conversation
-- Lines with `type: "system"` — configuration, not discussion
-- Tool result content — raw output, not observations
+Key properties of this input:
+
+- **Tool outputs are already removed.** You will never see file contents,
+  `Bash` stdout, `Read` results, or other raw tool output — those are
+  filtered before you see them. Do not ask to see them.
+- **`tool_use` blocks are abbreviated in-line.** They appear as single
+  bracketed lines like `[Editing foo.py]`, `[Running npm]`,
+  `[Searching for pattern]`. Treat them as *context* for the surrounding
+  prose — evidence of what was done, not observations themselves.
+- **Streaming chunks are already merged.** One `### assistant · <ts>` block
+  is one logical response, even if Claude streamed it as multiple internal
+  chunks.
+- **`<system-reminder>` blocks are already stripped.** Internal reasoning
+  (`thinking`) blocks are also absent.
+
+Extract observations from what the **human and assistant said** — the
+prose around the tool calls. Tool abbreviations tell you *what was done*,
+but they are not observations on their own.
 
 ## JSON line format
 
@@ -74,8 +89,8 @@ Field details:
 - `context`: Brief rationale or surrounding context (1 sentence). Why this
   decision was made, what prompted this todo, etc. Empty string if none.
 - `ts`: ISO 8601 timestamp of the message where this was discussed.
-  Use the timestamp from the JSONL line. If spanning multiple messages,
-  use the timestamp of the message where the item was concluded.
+  Use the timestamp from the transcript header of the message where the
+  item was concluded (for multi-turn items, the final turn).
 
 **Do NOT include** `session`, `project`, or `source_offset` in the JSON lines.
 The session is encoded in the filename (`observations/<session_id>.jsonl`).
@@ -84,10 +99,10 @@ database, not in observation entries. Keep each line minimal.
 
 ## Multi-turn items
 
-Decisions often span several messages (user proposes → Claude analyzes →
-user decides → Claude confirms). Extract the **final form** — the decision
-as concluded, not each intermediate step. The `ts` should be the message
-where the decision was finalized.
+Decisions often span several turns (user proposes → assistant analyzes →
+user decides → assistant confirms). Extract the **final form** — the
+decision as concluded, not each intermediate step. The `ts` should be the
+turn where the decision was finalized.
 
-Similarly, if a todo is discussed across messages and then refined, extract
+Similarly, if a todo is discussed across turns and then refined, extract
 the final refined version only.

--- a/prompts/observer.md
+++ b/prompts/observer.md
@@ -1,0 +1,93 @@
+# ThreadHop Observer Prompt
+
+You are an observation extractor for Claude Code session transcripts. Your job
+is to read a chunk of conversation (JSONL transcript lines) and extract
+structured observations from what was **explicitly discussed**.
+
+## Output rules
+
+1. **Append only.** Write observations to the file path given at the end of this
+   prompt. Never delete, modify, or overwrite existing lines in that file.
+2. **One JSON line per observation.** If you find 3 decisions, write 3 separate
+   lines. Each line must be a complete, self-contained JSON object.
+3. **No output if nothing qualifies.** If the conversation chunk contains no
+   extractable items (e.g., routine debugging, file edits with no decisions),
+   write nothing. Do not force observations.
+
+## Observation types
+
+Extract **only** items that were explicitly discussed in the conversation.
+Do not infer, speculate, or synthesize. Each observation must have a `type`
+from this list:
+
+| Type | Extract when... | Example |
+|------|----------------|---------|
+| `decision` | A choice was made between alternatives, with rationale stated or implied. | "Decided on REST over gRPC because client SDK constraints." |
+| `todo` | A task was identified as needing to be done but was not completed in this conversation. | "Need to add rate limiting to the /api endpoint." |
+| `done` | A task was explicitly completed or confirmed working in this conversation. | "Auth flow tests now passing after the middleware fix." |
+| `adr` | An architectural decision was documented or discussed with enough detail to constitute a record. Must include context + decision + rationale. | "ADR: Use SQLite over Postgres for local state — single-file deployment, no daemon, WAL for concurrent reads." |
+| `observation` | A notable insight, constraint, or discovery that doesn't fit the above types but would be valuable to recall later. | "The JSONL files have duplicate message IDs across streaming chunks — must merge by message.id." |
+
+### Type boundaries
+
+- **decision vs adr**: A `decision` is a choice made. An `adr` is a decision
+  with enough documented context that it constitutes an architectural record.
+  Most decisions are NOT ADRs. Only use `adr` when the conversation explicitly
+  walks through context → decision → rationale.
+- **todo vs done**: If a task was both identified AND completed in the same
+  conversation, emit a `done` (not a `todo` followed by `done`).
+- **observation**: The catch-all for valuable knowledge that isn't a decision
+  or task. Use sparingly — not every conversation remark is an observation.
+
+## What to read
+
+The conversation chunk is JSONL — one JSON object per line. Each line has:
+
+- `type`: `"human"` (user message) or `"assistant"` (Claude response)
+- `message.content`: Array of content blocks. Text blocks have `type: "text"`.
+  Tool-use blocks have `type: "tool_use"` with `name` and `input`.
+- `message.id`: Groups streaming chunks — multiple lines may share the same
+  `message.id`. Read them as one logical message.
+
+**Focus on the human/assistant dialogue.** Tool calls (file reads, edits, bash
+commands) provide context but are not observations themselves. Extract
+observations from what was discussed *about* the tool results, not the raw
+tool output.
+
+**Skip entirely:**
+- `<system-reminder>` blocks — these are framework noise, not conversation
+- Lines with `type: "system"` — configuration, not discussion
+- Tool result content — raw output, not observations
+
+## JSON line format
+
+Each line you write must follow this exact schema:
+
+```json
+{"type":"<type>","text":"<concise description>","context":"<brief rationale or surrounding context>","ts":"<ISO 8601 timestamp>"}
+```
+
+Field details:
+- `type`: One of `decision`, `todo`, `done`, `adr`, `observation`
+- `text`: A concise, self-contained description (1-2 sentences max).
+  Should be understandable without reading the original conversation.
+- `context`: Brief rationale or surrounding context (1 sentence). Why this
+  decision was made, what prompted this todo, etc. Empty string if none.
+- `ts`: ISO 8601 timestamp of the message where this was discussed.
+  Use the timestamp from the JSONL line. If spanning multiple messages,
+  use the timestamp of the message where the item was concluded.
+
+**Do NOT include** `session`, `project`, or `source_offset` in the JSON lines.
+The session is encoded in the filename (`observations/<session_id>.jsonl`).
+The project is looked up from the database. Byte offsets are tracked in the
+database, not in observation entries. Keep each line minimal.
+
+## Multi-turn items
+
+Decisions often span several messages (user proposes → Claude analyzes →
+user decides → Claude confirms). Extract the **final form** — the decision
+as concluded, not each intermediate step. The `ts` should be the message
+where the decision was finalized.
+
+Similarly, if a todo is discussed across messages and then refined, extract
+the final refined version only.

--- a/prompts/reflector.md
+++ b/prompts/reflector.md
@@ -1,0 +1,71 @@
+# ThreadHop Reflector Prompt
+
+You are a contradiction detector for cross-session observations. Your job is
+to compare recent decisions from the current session against decisions from
+other sessions in the same project, and flag contradictions.
+
+## Output rules
+
+1. **Append only.** Write conflict entries to the file path given at the end
+   of this prompt. Never delete, modify, or overwrite existing lines.
+2. **One JSON line per conflict.** Each conflict is a self-contained entry.
+3. **Deduplicate.** Before writing a conflict, check the existing conflict
+   entries provided below. If a conflict with the same two sessions and same
+   topic already exists, skip it. Do not re-flag known contradictions.
+4. **No output if no contradictions found.** Do not force conflicts. Many
+   sessions will have compatible decisions — that's normal.
+
+## What constitutes a contradiction
+
+A contradiction exists when two decisions in the same project make
+incompatible commitments. Examples:
+
+- Session A: "REST for all APIs" / Session B: "gRPC for service-to-service"
+  → Conflict if both cover overlapping scope (service communication)
+- Session A: "SQLite for persistence" / Session B: "Postgres for persistence"
+  → Conflict: same concern, incompatible choices
+- Session A: "Auth via JWT" / Session B: "Auth via session cookies"
+  → Conflict: same concern, incompatible choices
+
+**NOT contradictions:**
+- Different concerns: "REST for client API" and "gRPC for internal metrics"
+  are complementary, not contradictory
+- Refinements: "Use SQLite" followed by "Use SQLite with WAL mode" is a
+  refinement, not a contradiction
+- Supersessions: If Session B explicitly says "overriding Session A's decision",
+  that's a conscious change, not a contradiction (but note it as context)
+
+## JSON line format
+
+```json
+{"type":"conflict","text":"<explanation of the contradiction>","refs":["<session_id_1>","<session_id_2>"],"topic":"<semantic grouping key>","ts":"<ISO 8601 now>"}
+```
+
+Field details:
+- `type`: Always `"conflict"`
+- `text`: Clear explanation of what contradicts what. Reference both sessions.
+  (2-3 sentences max)
+- `refs`: Array of the two session IDs involved. Current session first.
+- `topic`: A short semantic key for grouping (e.g., `"api-protocol"`,
+  `"persistence-layer"`, `"auth-strategy"`). Used for deduplication.
+- `ts`: Current ISO 8601 timestamp
+
+**Do NOT include** `session` or `project` in the JSON lines. The session is
+encoded in the filename. The project is looked up from the database.
+
+## Input sections
+
+You will receive three sections:
+
+### `<current_session_decisions>`
+Recent `type: "decision"` entries from the session currently being observed.
+These are the NEW decisions to check for contradictions.
+
+### `<project_decisions>`
+All `type: "decision"` entries from OTHER sessions in the same project.
+These are the existing decisions to compare against.
+
+### `<existing_conflicts>`
+Any `type: "conflict"` entries already in the current session's observation
+file. Check these before writing — if a conflict with the same `refs` pair
+(in either order) and same `topic` exists, skip it.

--- a/tests/test_incremental_index.py
+++ b/tests/test_incremental_index.py
@@ -460,9 +460,9 @@ def test_migration_003_from_v2(tmp_path):
     cols = {r[1] for r in conn.execute("PRAGMA table_info(messages)").fetchall()}
     assert "message_id" not in cols
 
-    # Apply pending migration
+    # Apply pending migrations (003 + any later ones)
     db.apply_migrations(conn)
-    assert db.get_schema_version(conn) == 3
+    assert db.get_schema_version(conn) == db.SCHEMA_VERSION
 
     # Verify index_state table exists
     tables = {

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -1,0 +1,426 @@
+"""Tests for the observer core function (task #18, ADR-018/019/020).
+
+The real observer shells out to ``claude -p --model haiku``. These tests
+inject a fake ``claude`` binary that appends a canned observation JSONL
+line to the output file, then verify the orchestrator's behaviour:
+
+  * Threshold gating (< 3 turns → skip, no subprocess).
+  * State seeding from ``sessions`` on first run.
+  * Byte-offset advancement on success, not on skip, not on failure.
+  * Line-count diffing for the ``by_type`` summary.
+  * Truncation / rotation handling.
+
+Run from the repo root::
+
+    python -m pytest tests/test_observer.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+import db
+import observer
+
+
+# --- Fixtures --------------------------------------------------------------
+
+
+@pytest.fixture
+def obs_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``db.OBS_DIR`` into the test's tmp_path.
+
+    The observer writes observation files under ``db.OBS_DIR``. Without
+    this redirect, tests would scribble into ``~/.config/threadhop``.
+    """
+    d = tmp_path / "observations"
+    d.mkdir()
+    monkeypatch.setattr(db, "OBS_DIR", d)
+    return d
+
+
+@pytest.fixture
+def fake_claude(tmp_path: Path) -> Callable[[list[dict] | str], Path]:
+    """Build a shell-script stand-in for the ``claude`` CLI.
+
+    The observer passes ``-p <prompt>`` followed by ``--model`` and
+    ``--permission-mode`` flags. Our fake ignores the prompt and appends
+    whatever observation lines the test specified to the output file
+    extracted from the prompt.
+
+    ``script_body`` may be:
+      * a ``list[dict]`` — serialized to one JSON line each and appended
+        to the observation file the real prompt names.
+      * a ``str`` — used as the raw shell body (for exit-code / error
+        paths).
+    """
+    def _make(script_body):
+        path = tmp_path / "fake_claude"
+        if isinstance(script_body, list):
+            # Extract the obs path from the prompt argument, then append
+            # the canned entries. The prompt contains a marker line
+            # "Append observations to: <path>" — grep it out.
+            entries = "\n".join(json.dumps(e) for e in script_body) + "\n"
+            payload_file = tmp_path / "fake_claude_payload.jsonl"
+            payload_file.write_text(entries)
+            body = f"""#!/usr/bin/env bash
+set -euo pipefail
+# -p <prompt> --model haiku --permission-mode acceptEdits
+prompt="$2"
+obs_path=$(printf '%s\\n' "$prompt" | sed -n 's/^Append observations to: //p')
+cat "{payload_file}" >> "$obs_path"
+"""
+        else:
+            body = script_body
+        path.write_text(body)
+        path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        return path
+    return _make
+
+
+# --- JSONL builders (mirror test_incremental_index.py) --------------------
+
+
+def _user_line(uuid: str, text: str, sid: str = "sess-1") -> str:
+    return json.dumps({
+        "type": "user",
+        "uuid": uuid,
+        "sessionId": sid,
+        "timestamp": "2026-04-17T10:00:00Z",
+        "message": {"id": f"umsg_{uuid}", "content": [{"type": "text", "text": text}]},
+    })
+
+
+def _assistant_line(uuid: str, mid: str, text: str, sid: str = "sess-1") -> str:
+    return json.dumps({
+        "type": "assistant",
+        "uuid": uuid,
+        "sessionId": sid,
+        "timestamp": "2026-04-17T10:00:01Z",
+        "message": {"id": mid, "content": [{"type": "text", "text": text}]},
+    })
+
+
+def _tool_result_user_line(uuid: str, sid: str = "sess-1") -> str:
+    """type:user with toolUseResult — must NOT count as a turn."""
+    return json.dumps({
+        "type": "user",
+        "uuid": uuid,
+        "sessionId": sid,
+        "timestamp": "2026-04-17T10:00:02Z",
+        "toolUseResult": {"type": "tool_result", "content": "ok"},
+    })
+
+
+def _write_session(tmp_path: Path, name: str, lines: list[str]) -> Path:
+    jsonl = tmp_path / f"{name}.jsonl"
+    jsonl.write_text("\n".join(lines) + "\n")
+    return jsonl
+
+
+def _seed_session_row(conn, session_id: str, session_path: Path):
+    db.upsert_session(
+        conn, session_id, str(session_path),
+        project="test-project",
+    )
+
+
+# --- Pure-function tests ---------------------------------------------------
+
+
+class TestCountMessageTurns:
+    def test_users_and_assistants_each_count(self):
+        raw = (
+            _user_line("u1", "hi") + "\n" +
+            _assistant_line("a1", "m1", "hello") + "\n" +
+            _user_line("u2", "more") + "\n"
+        ).encode()
+        assert observer._count_message_turns(raw) == 3
+
+    def test_assistant_streaming_chunks_collapse_to_one_turn(self):
+        # Three assistant lines, same message.id → one turn.
+        raw = (
+            _user_line("u1", "q") + "\n" +
+            _assistant_line("a1", "m1", "part 1") + "\n" +
+            _assistant_line("a2", "m1", "part 2") + "\n" +
+            _assistant_line("a3", "m1", "part 3") + "\n"
+        ).encode()
+        assert observer._count_message_turns(raw) == 2
+
+    def test_tool_result_user_lines_are_not_turns(self):
+        raw = (
+            _user_line("u1", "do a thing") + "\n" +
+            _tool_result_user_line("tr1") + "\n" +
+            _assistant_line("a1", "m1", "done") + "\n"
+        ).encode()
+        assert observer._count_message_turns(raw) == 2
+
+    def test_malformed_lines_skipped(self):
+        raw = (
+            _user_line("u1", "hi") + "\n" +
+            "not json at all\n" +
+            _assistant_line("a1", "m1", "hey") + "\n"
+        ).encode()
+        assert observer._count_message_turns(raw) == 2
+
+
+class TestReadNewBytes:
+    def test_partial_line_at_eof_is_held_back(self, tmp_path: Path):
+        p = tmp_path / "s.jsonl"
+        p.write_bytes(b"first\nsecond\nthird-unfinished")
+        out, new_off = observer._read_new_bytes(p, 0)
+        assert out == b"first\nsecond\n"
+        assert new_off == len(b"first\nsecond\n")
+
+    def test_no_complete_line_returns_unchanged_offset(self, tmp_path: Path):
+        p = tmp_path / "s.jsonl"
+        p.write_bytes(b"just-partial")
+        out, new_off = observer._read_new_bytes(p, 0)
+        assert out == b""
+        assert new_off == 0
+
+
+# --- Orchestrator tests ---------------------------------------------------
+
+
+class TestObserveSession:
+    def test_below_threshold_skips_without_subprocess(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        # Only 2 turns — threshold is 3. Fake claude would succeed, but
+        # we want to prove it's not even invoked.
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "hi"),
+            _assistant_line("a1", "m1", "hello"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        # Script that would fail loudly if called — proves we skipped.
+        claude = fake_claude("#!/usr/bin/env bash\nexit 99\n")
+
+        result = observer.observe_session(
+            conn, "sess-1", claude_bin=str(claude),
+        )
+
+        assert result["status"] == "below_threshold"
+        assert result["turns"] == 2
+        assert result["new_entries"] == 0
+        # Cursor did NOT advance — next run will re-read same bytes.
+        state = db.get_observation_state(conn, "sess-1")
+        # Below-threshold on first run doesn't even create a state row —
+        # caller sees the offset in the return value.
+        if state is not None:
+            assert state["source_byte_offset"] == 0
+
+    def test_up_to_date_when_no_new_bytes(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "a"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+        # Pre-seed state at EOF — nothing left to read.
+        size = jsonl.stat().st_size
+        obs_path = obs_dir / "sess-1.jsonl"
+        db.upsert_observation_state(
+            conn, "sess-1", str(jsonl), str(obs_path),
+            source_byte_offset=size,
+            entry_count=0,
+        )
+
+        claude = fake_claude("#!/usr/bin/env bash\nexit 99\n")
+        result = observer.observe_session(
+            conn, "sess-1", claude_bin=str(claude),
+        )
+
+        assert result["status"] == "up_to_date"
+        assert result["turns"] == 0
+
+    def test_no_source_when_session_row_missing(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        result = observer.observe_session(
+            conn, "ghost-session", claude_bin=str(fake_claude([])),
+        )
+        assert result["status"] == "no_source"
+
+    def test_no_source_when_file_gone(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        missing = tmp_path / "gone.jsonl"
+        _seed_session_row(conn, "sess-1", missing)
+        result = observer.observe_session(
+            conn, "sess-1", claude_bin=str(fake_claude([])),
+        )
+        assert result["status"] == "no_source"
+
+    def test_extraction_appends_and_advances_state(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        # 3 turns → meets threshold.
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "Should we use SQLite?"),
+            _assistant_line("a1", "m1", "Yes, SQLite fits the use case."),
+            _user_line("u2", "Great, decided."),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        canned = [
+            {
+                "type": "decision",
+                "text": "Use SQLite for local state",
+                "context": "single-file deployment",
+                "ts": "2026-04-17T10:00:03Z",
+            },
+            {
+                "type": "todo",
+                "text": "Write the schema migration",
+                "context": "",
+                "ts": "2026-04-17T10:00:03Z",
+            },
+        ]
+        claude = fake_claude(canned)
+
+        result = observer.observe_session(
+            conn, "sess-1", claude_bin=str(claude),
+        )
+
+        assert result["status"] == "extracted"
+        assert result["turns"] == 3
+        assert result["new_entries"] == 2
+        assert result["by_type"] == {"decision": 1, "todo": 1}
+
+        # State row exists with cursor at EOF and matching entry count.
+        expected_offset = jsonl.stat().st_size
+        state = db.get_observation_state(conn, "sess-1")
+        assert state is not None
+        assert state["source_byte_offset"] == expected_offset
+        assert state["entry_count"] == 2
+        assert state["status"] == "idle"  # observer function itself
+                                         # doesn't flip to running — that
+                                         # belongs to the sidecar (#34)
+        assert state["last_observed_at"] is not None
+
+        # Observation file contains exactly our two lines.
+        obs_path = Path(result["obs_path"])
+        lines = obs_path.read_text().strip().splitlines()
+        assert len(lines) == 2
+        assert json.loads(lines[0])["type"] == "decision"
+
+    def test_resume_reads_only_appended_bytes(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        # First extraction.
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "q"),
+            _assistant_line("a1", "m1", "a"),
+            _user_line("u2", "q2"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        claude = fake_claude([
+            {"type": "decision", "text": "x", "context": "", "ts": "2026-04-17T10:00:00Z"},
+        ])
+        r1 = observer.observe_session(conn, "sess-1", claude_bin=str(claude))
+        assert r1["status"] == "extracted"
+
+        # Append more messages — meets threshold again.
+        with open(jsonl, "a") as f:
+            f.write(_assistant_line("a2", "m2", "b") + "\n")
+            f.write(_user_line("u3", "q3") + "\n")
+            f.write(_assistant_line("a3", "m3", "c") + "\n")
+
+        # Second run: verify the fake only sees the appended bytes.
+        # We do that by checking the turn count the observer computed.
+        claude2 = fake_claude([
+            {"type": "todo", "text": "y", "context": "", "ts": "2026-04-17T10:01:00Z"},
+        ])
+        r2 = observer.observe_session(conn, "sess-1", claude_bin=str(claude2))
+
+        assert r2["status"] == "extracted"
+        # Only the 3 new turns, not the original 3.
+        assert r2["turns"] == 3
+        assert r2["new_entries"] == 1
+
+        # Observation file now has 2 lines total.
+        obs_path = Path(r2["obs_path"])
+        assert len(obs_path.read_text().strip().splitlines()) == 2
+
+    def test_subprocess_failure_does_not_advance_state(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "x"),
+            _assistant_line("a1", "m1", "y"),
+            _user_line("u2", "z"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        claude = fake_claude(
+            "#!/usr/bin/env bash\necho oops >&2\nexit 2\n"
+        )
+        result = observer.observe_session(
+            conn, "sess-1", claude_bin=str(claude),
+        )
+
+        assert result["status"] == "failed"
+        assert "exited 2" in result["error"]
+        # State row either doesn't exist or is at offset 0 — we must NOT
+        # have advanced past the un-processed bytes.
+        state = db.get_observation_state(conn, "sess-1")
+        if state is not None:
+            assert state["source_byte_offset"] == 0
+
+    def test_claude_bin_missing_is_a_failure_not_a_crash(
+        self, tmp_path, conn, obs_dir
+    ):
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "a"),
+            _assistant_line("a1", "m1", "b"),
+            _user_line("u2", "c"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        result = observer.observe_session(
+            conn, "sess-1",
+            claude_bin="/does/not/exist/claude-ghost",
+        )
+        assert result["status"] == "failed"
+        assert "not found" in result["error"]
+
+    def test_truncation_rewinds_cursor(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        # Start with a session and pretend we've observed past its EOF
+        # (simulates a rotated-and-replaced file with fewer bytes).
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "new-a"),
+            _assistant_line("a1", "m1", "new-b"),
+            _user_line("u2", "new-c"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+        obs_path = obs_dir / "sess-1.jsonl"
+        # Pretend prior run recorded a huge offset from an earlier,
+        # now-discarded version of the file.
+        db.upsert_observation_state(
+            conn, "sess-1", str(jsonl), str(obs_path),
+            source_byte_offset=10**9,  # way past current EOF
+            entry_count=0,
+        )
+
+        claude = fake_claude([
+            {"type": "decision", "text": "x", "context": "", "ts": "2026-04-17T10:00:00Z"},
+        ])
+        result = observer.observe_session(
+            conn, "sess-1", claude_bin=str(claude),
+        )
+
+        assert result["status"] == "extracted"
+        # All 3 turns should be read (cursor rewound to 0).
+        assert result["turns"] == 3

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -134,40 +134,71 @@ def _seed_session_row(conn, session_id: str, session_path: Path):
 # --- Pure-function tests ---------------------------------------------------
 
 
-class TestCountMessageTurns:
-    def test_users_and_assistants_each_count(self):
+class TestTranscriptRendering:
+    """The observer now feeds Haiku the cleaned transcript produced by
+    indexer.parse_byte_range (tool outputs stripped, tool_use abbreviated,
+    streaming chunks merged). These tests cover the assembly step — both
+    turn counting (which is just ``len(message_turns)`` now) and the
+    transcript-format helper the prompt splices in.
+    """
+
+    def test_users_and_assistants_each_count_as_turns(self):
+        import indexer
         raw = (
             _user_line("u1", "hi") + "\n" +
             _assistant_line("a1", "m1", "hello") + "\n" +
             _user_line("u2", "more") + "\n"
         ).encode()
-        assert observer._count_message_turns(raw) == 3
+        assert len(indexer.parse_byte_range(raw)) == 3
 
     def test_assistant_streaming_chunks_collapse_to_one_turn(self):
-        # Three assistant lines, same message.id → one turn.
+        import indexer
         raw = (
             _user_line("u1", "q") + "\n" +
             _assistant_line("a1", "m1", "part 1") + "\n" +
             _assistant_line("a2", "m1", "part 2") + "\n" +
             _assistant_line("a3", "m1", "part 3") + "\n"
         ).encode()
-        assert observer._count_message_turns(raw) == 2
+        turns = indexer.parse_byte_range(raw)
+        assert len(turns) == 2
+        # The assistant turn is the *merged* text, not three separate ones.
+        assistant_turn = next(t for t in turns if t["role"] == "assistant")
+        assert "part 1" in assistant_turn["text"]
+        assert "part 2" in assistant_turn["text"]
+        assert "part 3" in assistant_turn["text"]
 
     def test_tool_result_user_lines_are_not_turns(self):
+        import indexer
         raw = (
             _user_line("u1", "do a thing") + "\n" +
             _tool_result_user_line("tr1") + "\n" +
             _assistant_line("a1", "m1", "done") + "\n"
         ).encode()
-        assert observer._count_message_turns(raw) == 2
+        turns = indexer.parse_byte_range(raw)
+        assert len(turns) == 2
+        assert [t["role"] for t in turns] == ["user", "assistant"]
 
-    def test_malformed_lines_skipped(self):
-        raw = (
-            _user_line("u1", "hi") + "\n" +
-            "not json at all\n" +
-            _assistant_line("a1", "m1", "hey") + "\n"
-        ).encode()
-        assert observer._count_message_turns(raw) == 2
+    def test_format_transcript_uses_role_and_timestamp_headers(self):
+        turns = [
+            {"role": "user", "timestamp": "2026-04-17T10:00:00Z",
+             "text": "Should we use SQLite?"},
+            {"role": "assistant", "timestamp": "2026-04-17T10:00:01Z",
+             "text": "Yes — single-file deployment wins."},
+        ]
+        out = observer._format_transcript(turns)
+        assert "### user · 2026-04-17T10:00:00Z" in out
+        assert "### assistant · 2026-04-17T10:00:01Z" in out
+        assert "Should we use SQLite?" in out
+        assert "single-file deployment wins" in out
+
+    def test_format_transcript_skips_empty_text(self):
+        turns = [
+            {"role": "user", "timestamp": "t1", "text": "hello"},
+            {"role": "assistant", "timestamp": "t2", "text": ""},
+        ]
+        out = observer._format_transcript(turns)
+        assert "### user" in out
+        assert "### assistant" not in out
 
 
 class TestReadNewBytes:
@@ -393,6 +424,65 @@ class TestObserveSession:
         )
         assert result["status"] == "failed"
         assert "not found" in result["error"]
+
+    def test_prompt_contains_cleaned_transcript_not_raw_jsonl(
+        self, tmp_path, conn, obs_dir
+    ):
+        """The observer must send Haiku the cleaned transcript — not raw
+        JSONL with message.content blocks, tool results, or system-reminders.
+        We capture the prompt arg via a fake claude that dumps it to a file.
+        """
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "Should we cache this?"),
+            _assistant_line("a1", "m1", "Yes <system-reminder>internal</system-reminder> definitely"),
+            _user_line("u2", "Great"),
+            # A tool_result user line that must NOT appear in the prompt.
+            _tool_result_user_line("tr1"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        # Fake claude that writes its prompt arg to a known file.
+        captured = tmp_path / "captured_prompt.txt"
+        script = tmp_path / "fake_claude"
+        script.write_text(
+            "#!/usr/bin/env bash\n"
+            f"printf '%s' \"$2\" > {captured}\n"
+        )
+        script.chmod(
+            script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH
+        )
+
+        result = observer.observe_session(
+            conn, "sess-1", claude_bin=str(script),
+        )
+        assert result["status"] == "extracted"
+
+        prompt_body = captured.read_text()
+
+        # Isolate the transcript section — the prompt template itself
+        # references `<session_chunk>` and `<system-reminder>` in its
+        # instructions, so we can only assert stripping happened inside
+        # the actual delimited chunk. The delimiter sits on its own line,
+        # which lets us skip the backticked mentions in the guidance.
+        start = (
+            prompt_body.index("<session_chunk>\n")
+            + len("<session_chunk>\n")
+        )
+        end = prompt_body.index("\n</session_chunk>")
+        chunk = prompt_body[start:end]
+
+        # Role-labelled transcript headers present.
+        assert "### user" in chunk
+        assert "### assistant" in chunk
+
+        # Raw JSONL artifacts MUST NOT appear in the transcript.
+        assert "\"sessionId\"" not in chunk
+        assert "\"toolUseResult\"" not in chunk
+        assert "<system-reminder>" not in chunk
+
+        # Cleaned text still makes it through.
+        assert "Should we cache this?" in chunk
+        assert "definitely" in chunk
 
     def test_truncation_rewinds_cursor(
         self, tmp_path, conn, obs_dir, fake_claude

--- a/threadhop
+++ b/threadhop
@@ -2122,35 +2122,7 @@ class ClaudeSessions(App):
                 if len(parts) < 2:
                     continue
                 pid_str, args = parts
-                # Only match CLI claude, not Claude.app or IDE extensions
-                if "/Claude.app/" in args or "/native-binary/" in args:
-                    continue
-                # Match: "claude -r <id>" or "claude --resume <id>"
-                if "claude" not in args:
-                    continue
-                # Check if it's an interactive session (has -r/--resume or -c/--continue)
-                arg_parts = args.split()
-                is_interactive = False
-                explicit_id = None
-                for i, a in enumerate(arg_parts):
-                    if a in ("-r", "--resume") and "-p" not in arg_parts:
-                        is_interactive = True
-                        # Check if next arg is a session ID (UUID format)
-                        if i + 1 < len(arg_parts):
-                            candidate = arg_parts[i + 1]
-                            if len(candidate) == 36 and candidate.count("-") == 4:
-                                explicit_id = candidate
-                    elif a in ("-c", "--continue") and "-p" not in arg_parts:
-                        is_interactive = True
-
-                if not is_interactive:
-                    # Also detect bare "claude" (new interactive session)
-                    if arg_parts[-1] == "claude" or (
-                        len(arg_parts) >= 1 and arg_parts[0].endswith("/claude")
-                        and "-p" not in arg_parts and "--print" not in arg_parts
-                    ):
-                        is_interactive = True
-
+                is_interactive, explicit_id = _parse_claude_process_args(args)
                 if not is_interactive:
                     continue
 
@@ -2180,21 +2152,9 @@ class ClaudeSessions(App):
                 for pid, cwd in cwd_pids.items():
                     if not cwd:
                         continue
-                    project_dir_name = cwd.replace("/", "-")
-                    project_path = CLAUDE_PROJECTS / project_dir_name
-                    if project_path.is_dir():
-                        # Find most recently modified JSONL
-                        best = None
-                        best_mtime = 0
-                        for jf in project_path.glob("*.jsonl"):
-                            if jf.name.startswith("agent-"):
-                                continue
-                            mt = jf.stat().st_mtime
-                            if mt > best_mtime:
-                                best_mtime = mt
-                                best = jf.stem
-                        if best:
-                            active_ids.add(best)
+                    sid = _resolve_session_id_by_cwd(cwd)
+                    if sid:
+                        active_ids.add(sid)
         except Exception:
             pass
 
@@ -3415,6 +3375,129 @@ class ClaudeSessions(App):
         )
 
 
+def _parse_claude_process_args(args: str) -> tuple[bool, str | None]:
+    """Classify a `ps` args line as an interactive `claude` CLI process.
+
+    Returns (is_interactive_claude_cli, explicit_session_id_if_any). Excludes
+    Claude.app and IDE-embedded binaries, and non-interactive `-p/--print`
+    invocations. Used by both `_get_active_claude_sessions()` (scans all
+    processes) and `detect_current_session_id()` (walks parent chain).
+    """
+    if "/Claude.app/" in args or "/native-binary/" in args:
+        return (False, None)
+    if "claude" not in args:
+        return (False, None)
+    arg_parts = args.split()
+    if not arg_parts:
+        return (False, None)
+    is_interactive = False
+    explicit_id: str | None = None
+    for i, a in enumerate(arg_parts):
+        if a in ("-r", "--resume") and "-p" not in arg_parts:
+            is_interactive = True
+            if i + 1 < len(arg_parts):
+                candidate = arg_parts[i + 1]
+                if len(candidate) == 36 and candidate.count("-") == 4:
+                    explicit_id = candidate
+        elif a in ("-c", "--continue") and "-p" not in arg_parts:
+            is_interactive = True
+    if not is_interactive:
+        if arg_parts[-1] == "claude" or (
+            arg_parts[0].endswith("/claude")
+            and "-p" not in arg_parts and "--print" not in arg_parts
+        ):
+            is_interactive = True
+    return (is_interactive, explicit_id)
+
+
+def _resolve_session_id_by_cwd(cwd: str) -> str | None:
+    """Given a claude process CWD, return the most-recently-modified session id
+    in the matching `~/.claude/projects/<encoded>` directory."""
+    project_path = CLAUDE_PROJECTS / cwd.replace("/", "-")
+    if not project_path.is_dir():
+        return None
+    best: str | None = None
+    best_mtime = 0.0
+    for jf in project_path.glob("*.jsonl"):
+        if jf.name.startswith("agent-"):
+            continue
+        mt = jf.stat().st_mtime
+        if mt > best_mtime:
+            best_mtime = mt
+            best = jf.stem
+    return best
+
+
+def _get_process_cwd(pid: int) -> str | None:
+    """Resolve a process's working directory via `lsof`. macOS-only."""
+    try:
+        result = subprocess.run(
+            ["lsof", "-a", "-d", "cwd", "-p", str(pid), "-Fn"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except Exception:
+        return None
+    for line in result.stdout.strip().split("\n"):
+        if line.startswith("n"):
+            return line[1:]
+    return None
+
+
+def detect_current_session_id() -> str | None:
+    """Detect the Claude session id for the current terminal's process tree.
+
+    Walks ancestors of `os.getpid()` looking for a `claude` CLI process. When
+    one is found, resolves its session id from args (explicit `--resume <id>`)
+    or its CWD (most-recently-modified JSONL in the matching project dir).
+    Returns None if no claude ancestor is found or the id can't be resolved.
+
+    macOS-only — uses `ps` and `lsof` (matches the rest of threadhop's
+    detection surface). Same contract as `_get_active_claude_sessions()`,
+    but scoped to the caller's process tree rather than every running claude.
+    """
+    try:
+        result = subprocess.run(
+            ["ps", "-eo", "pid,ppid,args"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except Exception:
+        return None
+
+    procs: dict[int, tuple[int, str]] = {}
+    lines = result.stdout.strip().split("\n")
+    for line in lines[1:]:  # skip header
+        parts = line.strip().split(None, 2)
+        if len(parts) < 3:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+        except ValueError:
+            continue
+        procs[pid] = (ppid, parts[2])
+
+    pid = os.getpid()
+    visited: set[int] = set()
+    while pid and pid > 0 and pid not in visited:
+        visited.add(pid)
+        entry = procs.get(pid)
+        if not entry:
+            break
+        ppid, args = entry
+        is_claude, explicit_id = _parse_claude_process_args(args)
+        if is_claude:
+            if explicit_id:
+                return explicit_id
+            cwd = _get_process_cwd(pid)
+            if cwd:
+                sid = _resolve_session_id_by_cwd(cwd)
+                if sid:
+                    return sid
+            return None
+        pid = ppid
+    return None
+
+
 def detect_project_from_cwd() -> str | None:
     """Auto-detect project by matching CWD to Claude's project directory names.
 
@@ -3437,6 +3520,27 @@ def _cli_stub(command):
     """Print a stub notice and exit 0. Real implementation lands in later tasks."""
     print(f"threadhop {command}: not yet implemented (stub)", file=sys.stderr)
     return 0
+
+
+def _resolve_tag_session(args) -> int:
+    """Populate args.session via auto-detection when omitted.
+
+    Returns 0 on success (args.session is set), non-zero on failure (already
+    printed an error). macOS-only — detection relies on `ps`/`lsof`.
+    """
+    if args.session:
+        return 0
+    detected = detect_current_session_id()
+    if detected:
+        args.session = detected
+        return 0
+    print(
+        "threadhop tag: could not auto-detect the current session id.\n"
+        "  Run this from inside a `claude` terminal, or pass --session <id> explicitly.\n"
+        "  (Auto-detection walks the current process tree for a claude CLI ancestor; macOS only — relies on `ps`/`lsof`.)",
+        file=sys.stderr,
+    )
+    return 2
 
 
 def _run_tui(args):
@@ -3545,6 +3649,12 @@ def main():
 
     if args.command is None:
         return _run_tui(args)
+    if args.command == "tag":
+        rc = _resolve_tag_session(args)
+        if rc != 0:
+            return rc
+        print(f"threadhop tag: resolved session={args.session} status={args.status} (stub — #16)", file=sys.stderr)
+        return 0
     return _cli_stub(args.command)
 
 

--- a/threadhop
+++ b/threadhop
@@ -22,7 +22,7 @@ from rich.markup import escape
 from rich.text import Text
 from textual.app import App, ComposeResult
 from textual.binding import Binding
-from textual.containers import Vertical, VerticalScroll
+from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import Footer, Header, Input, ListItem, ListView, Static, TextArea
 from textual.worker import Worker
@@ -314,6 +314,17 @@ class TranscriptView(VerticalScroll):
         # the refresh would reload whatever the sidebar highlights and
         # yank the user back to the original view.
         self._foreign_session_path: Path | None = None
+
+        # Find-in-transcript state (Ctrl+F-style persistent bar).
+        # Non-empty _find_query means find mode is active — all
+        # transcript reloads re-apply highlights across every matching
+        # message widget, and n/N navigation cycles _find_current
+        # through _find_matches (widget-index positions). Cleared by
+        # App._close_find which also force-reloads to drop the inline
+        # highlight rewrites and restore Markdown formatting.
+        self._find_query: str = ""
+        self._find_matches: list[int] = []
+        self._find_current: int = -1
 
     def _get_message_widgets(self):
         """Return all message widgets in order."""
@@ -750,13 +761,22 @@ class TranscriptView(VerticalScroll):
 
         # Decide the post-mount scroll behavior, in priority order:
         #
-        # 1. Search just handed us a jump-to-source → honor it.
-        # 2. A previous jump is still "active" (highlight state survived
+        # 1. Find mode is active → re-apply highlights across every
+        #    matching widget and park the cursor on the current match
+        #    (or the pending jump-target uuid, if any).
+        # 2. Search just handed us a jump-to-source → honor it.
+        # 3. A previous jump is still "active" (highlight state survived
         #    into this reload, e.g. the 5-second refresh hit while the
         #    user is still reading a match) → re-apply the highlight
         #    so it isn't lost on every tick.
-        # 3. Normal reload → scroll to the bottom (live tail).
-        if self._pending_scroll_uuid is not None:
+        # 4. Normal reload → scroll to the bottom (live tail).
+        if self._find_query:
+            target_uuid = self._pending_scroll_uuid
+            self._pending_scroll_uuid = None
+            self._pending_scroll_terms = None
+            self._apply_find_highlights(self._find_query, anchor_uuid=target_uuid)
+            self._report_find_status()
+        elif self._pending_scroll_uuid is not None:
             target = self._pending_scroll_uuid
             terms = self._pending_scroll_terms
             self._pending_scroll_uuid = None
@@ -933,6 +953,138 @@ class TranscriptView(VerticalScroll):
             return max(lowest, 0)
         except Exception:
             return 0
+
+    def activate_find(
+        self,
+        query: str,
+        anchor_uuid: str | None = None,
+    ) -> tuple[int, int]:
+        """Turn on find mode for ``query`` and return ``(current, total)``.
+
+        Walks every message widget, rebuilding any that contain the term
+        so matches are visible inline, and records the list of matching
+        widget indices in ``_find_matches``. If ``anchor_uuid`` is given
+        and belongs to a matching widget, cursor starts on that match —
+        otherwise on the first match. ``current`` is 1-based (0 if no
+        matches); ``total`` is the number of matching widgets.
+        """
+        self._find_query = query or ""
+        if not self._find_query.strip():
+            self._find_matches = []
+            self._find_current = -1
+            return 0, 0
+        self._apply_find_highlights(self._find_query, anchor_uuid=anchor_uuid)
+        total = len(self._find_matches)
+        current = (self._find_current + 1) if self._find_current >= 0 else 0
+        return current, total
+
+    def next_match(self) -> tuple[int, int]:
+        """Advance to the next match (wraps). ``(0, 0)`` when none exist."""
+        if not self._find_matches:
+            return 0, 0
+        self._find_current = (self._find_current + 1) % len(self._find_matches)
+        self._scroll_to_match_index(self._find_current)
+        return self._find_current + 1, len(self._find_matches)
+
+    def prev_match(self) -> tuple[int, int]:
+        """Step back to the previous match (wraps). ``(0, 0)`` when none."""
+        if not self._find_matches:
+            return 0, 0
+        self._find_current = (self._find_current - 1) % len(self._find_matches)
+        self._scroll_to_match_index(self._find_current)
+        return self._find_current + 1, len(self._find_matches)
+
+    def clear_find_state(self) -> None:
+        """Drop find mode state. Caller must force-reload the transcript
+        to restore the pre-highlight rendering (Markdown, etc.)."""
+        self._find_query = ""
+        self._find_matches = []
+        self._find_current = -1
+
+    def _apply_find_highlights(
+        self,
+        query: str,
+        anchor_uuid: str | None = None,
+    ) -> None:
+        """Highlight every occurrence of ``query`` across all messages
+        and rebuild ``_find_matches`` / ``_find_current``.
+
+        Case-insensitive substring match against each widget's
+        ``_raw_text``. When ``anchor_uuid`` lands on a matching widget
+        the cursor snaps there; otherwise we clamp the previous cursor
+        into range (so widget-add on reload doesn't yank focus) or fall
+        back to the first match.
+        """
+        if not query:
+            self._find_matches = []
+            self._find_current = -1
+            return
+
+        try:
+            pattern = re.compile(re.escape(query), re.IGNORECASE)
+        except re.error:
+            self._find_matches = []
+            self._find_current = -1
+            return
+
+        widgets = self._get_message_widgets()
+        matches: list[int] = []
+        for idx, widget in enumerate(widgets):
+            raw = getattr(widget, "_raw_text", "") or ""
+            if not raw:
+                continue
+            if not pattern.search(raw):
+                continue
+            matches.append(idx)
+            self._rebuild_widget_with_highlights(widget, [query])
+
+        self._find_matches = matches
+
+        if not matches:
+            self._find_current = -1
+            return
+
+        anchor_pos = -1
+        if anchor_uuid:
+            for pos, idx in enumerate(matches):
+                if idx < len(widgets) and getattr(widgets[idx], "_uuid", None) == anchor_uuid:
+                    anchor_pos = pos
+                    break
+
+        if anchor_pos >= 0:
+            self._find_current = anchor_pos
+        elif self._find_current >= 0:
+            self._find_current = min(self._find_current, len(matches) - 1)
+        else:
+            self._find_current = 0
+
+        self._scroll_to_match_index(self._find_current)
+
+    def _scroll_to_match_index(self, match_pos: int) -> None:
+        """Scroll so the widget at ``_find_matches[match_pos]`` is on screen."""
+        if not self._find_matches:
+            return
+        if match_pos < 0 or match_pos >= len(self._find_matches):
+            return
+        widgets = self._get_message_widgets()
+        widget_idx = self._find_matches[match_pos]
+        if widget_idx >= len(widgets):
+            return
+        widget = widgets[widget_idx]
+        try:
+            widget.scroll_visible(animate=False, top=True)
+        except Exception:
+            pass
+
+    def _report_find_status(self) -> None:
+        """Push the current match counter to the find bar."""
+        try:
+            find_bar = self.app.query_one("#find-bar", FindBar)
+        except Exception:
+            return
+        total = len(self._find_matches)
+        current = self._find_current + 1 if total else 0
+        find_bar.update_status(current, total, bool(self._find_query.strip()))
 
     async def _remove_all_messages(self):
         """Remove all message widgets, awaiting completion"""
@@ -1533,6 +1685,79 @@ class SearchScreen(ModalScreen):
         self.dismiss((row["session_id"], row["uuid"], terms))
 
 
+class FindBar(Horizontal):
+    """Persistent Ctrl+F-style find bar shown above the transcript.
+
+    Stays open until the user dismisses it (Esc, ×, or Ctrl+F again), so
+    the active query remains editable and the match counter remains
+    visible across session switches. Unlike ``SearchScreen`` (which
+    issues FTS5 queries across ALL indexed sessions), this bar operates
+    purely on widgets already rendered in the current ``TranscriptView``
+    — it's a within-transcript "find in page", not a cross-session
+    search.
+
+    Hidden by default via ``display = False``; App.action_open_find
+    toggles it visible and focuses the input.
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Input(
+            placeholder="Find in transcript… (Enter=next, ↑/↓ prev/next, Esc=close)",
+            id="find-input",
+        )
+        yield Static("", id="find-status")
+        yield Static("[×]", id="find-close")
+
+    def update_status(self, current: int, total: int, has_query: bool) -> None:
+        """Set the match counter. ``has_query=False`` blanks the status."""
+        status = self.query_one("#find-status", Static)
+        if not has_query:
+            status.update("")
+        elif total == 0:
+            status.update("No matches")
+        elif total == 1:
+            status.update("1 match")
+        else:
+            status.update(f"{current} of {total} matches")
+
+    def on_key(self, event) -> None:
+        """Arrow / Escape bubble up from the Input — keep them here.
+
+        Up/Down navigate matches without leaving the input. Escape
+        closes the bar and clears highlights. Enter is handled by the
+        app's ``on_input_submitted`` because Input fires Submitted on
+        Enter, not a raw key event here.
+        """
+        key = event.key
+        if key == "escape":
+            event.stop()
+            event.prevent_default()
+            self.app._close_find()
+        elif key == "down":
+            event.stop()
+            event.prevent_default()
+            self.app.action_find_next()
+        elif key == "up":
+            event.stop()
+            event.prevent_default()
+            self.app.action_find_prev()
+
+    def on_click(self, event) -> None:
+        """Click on the × static to dismiss.
+
+        Textual's Click event bubbles up the widget tree; checking the
+        event's widget id here lets the whole bar act as a click host
+        without extra message plumbing.
+        """
+        try:
+            target = getattr(event, "widget", None)
+            if target is not None and target.id == "find-close":
+                event.stop()
+                self.app._close_find()
+        except Exception:
+            pass
+
+
 class ClaudeSessions(App):
     """Cross-session context manager for Claude Code"""
 
@@ -1554,10 +1779,52 @@ class ClaudeSessions(App):
         border-title-color: $text;
     }
 
-    #transcript-scroll {
+    #transcript-column {
         height: 100%;
+        layout: vertical;
+    }
+
+    #transcript-scroll {
+        height: 1fr;
         border: solid $secondary;
         border-title-color: $text;
+    }
+
+    FindBar {
+        height: 1;
+        background: $boost;
+        layout: horizontal;
+    }
+
+    #find-input {
+        width: 1fr;
+        height: 1;
+        border: none;
+        padding: 0 1;
+        background: $boost;
+    }
+
+    #find-input:focus {
+        background: $surface;
+    }
+
+    #find-status {
+        width: auto;
+        height: 1;
+        padding: 0 2;
+        color: $text-muted;
+    }
+
+    #find-close {
+        width: 3;
+        height: 1;
+        content-align: center middle;
+        color: $error;
+        background: $error 15%;
+    }
+
+    #find-close:hover {
+        background: $error 30%;
     }
 
     #input-container {
@@ -1685,6 +1952,8 @@ class ClaudeSessions(App):
         Binding("enter", "start_reply_or_send", "Reply/Send", show=True, priority=True),
         Binding("alt+enter", "insert_newline", "Newline", show=False),
         Binding("/", "open_search", "Search"),
+        Binding("ctrl+f", "open_find", "Find"),
+        Binding("N", "find_prev", "Prev match", show=False),
         Binding("escape", "cancel_reply", "Cancel", show=False),
         Binding("right", "focus_transcript", "Transcript", show=False),
         Binding("left", "focus_list", "Sessions", show=False),
@@ -1726,6 +1995,9 @@ class ClaudeSessions(App):
         self._spinner_frame = 0
         self._renaming_session_id = None
         self._show_archived = False
+        # Debounce timer for the in-transcript find bar so fast typing
+        # collapses into a single highlight pass.
+        self._find_timer = None
 
         # Open the SQLite store and run the one-time config.json → SQLite
         # migration (ADR-001). Both calls are idempotent — init_db applies
@@ -1757,7 +2029,11 @@ class ClaudeSessions(App):
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
         yield ListView(id="session-list")
-        yield TranscriptView(id="transcript-scroll")
+        yield Vertical(
+            FindBar(id="find-bar"),
+            TranscriptView(id="transcript-scroll"),
+            id="transcript-column",
+        )
         yield Vertical(TextArea(id="reply-input"), id="input-container")
         yield Footer()
 
@@ -1766,6 +2042,15 @@ class ClaudeSessions(App):
         width = self.config.get("sidebar_width", self.SIDEBAR_DEFAULT)
         width = max(self.SIDEBAR_MIN, min(self.SIDEBAR_MAX, int(width)))
         self._apply_sidebar_width(width)
+
+        # Find bar is hidden until the user invokes Ctrl+F or jumps in
+        # from the cross-session SearchScreen. Setting ``display`` (not
+        # a CSS class) keeps the bar out of the layout flow entirely,
+        # so the transcript fills the column while it's inactive.
+        try:
+            self.query_one("#find-bar", FindBar).display = False
+        except Exception:
+            pass
 
         self.update_titles()
         self.load_sessions()
@@ -2302,9 +2587,14 @@ class ClaudeSessions(App):
             # foreign-session search jump, even when the user re-selects
             # the row that was already highlighted — Highlighted doesn't
             # fire in that case, but Selected does.
+            #
+            # Keep ``_find_query`` alive so the find bar applies to the
+            # reselected transcript too; just reset the match cursor.
             transcript._foreign_session_path = None
             transcript._active_highlight_uuid = None
             transcript._active_highlight_terms = None
+            if transcript._find_query:
+                transcript._find_current = -1
 
             await transcript.load_transcript(event.item.session_data["path"])
 
@@ -2320,9 +2610,17 @@ class ClaudeSessions(App):
             # reloads don't try to re-apply stale highlights. The
             # search-flow sets these fresh after this handler runs, via
             # queue_scroll_to_uuid, so same-sidebar jumps aren't broken.
+            #
+            # ``_find_query`` is DELIBERATELY preserved — the find bar
+            # follows the user across session switches so the same term
+            # keeps highlighting in each transcript they browse. Reset
+            # the match cursor so the re-run lands on the first match
+            # in the new transcript rather than a stale index.
             transcript._foreign_session_path = None
             transcript._active_highlight_uuid = None
             transcript._active_highlight_terms = None
+            if transcript._find_query:
+                transcript._find_current = -1
 
             await transcript.load_transcript(event.item.session_data["path"])
 
@@ -2375,6 +2673,12 @@ class ClaudeSessions(App):
     def action_rename_session(self) -> None:
         if self._input_has_focus():
             return
+        # `n` doubles as next-match while find mode is active so the
+        # Ctrl+F workflow stays keyboard-only without colliding with
+        # the rename shortcut the rest of the time.
+        if self._find_is_active():
+            self.action_find_next()
+            return
         list_view = self.query_one("#session-list", ListView)
         if not list_view.highlighted_child or not isinstance(
             list_view.highlighted_child, SessionItem
@@ -2416,7 +2720,27 @@ class ClaudeSessions(App):
             self.notify(f"Resume: {cmd}", timeout=10)
 
     def _input_has_focus(self) -> bool:
-        return self.query_one("#reply-input", TextArea).has_focus
+        if self.query_one("#reply-input", TextArea).has_focus:
+            return True
+        # The find-bar Input counts as an active text input too — stops
+        # top-level bindings like `q`, `/`, `n` from firing while the
+        # user is typing a query in the bar.
+        try:
+            if self.query_one("#find-input", Input).has_focus:
+                return True
+        except Exception:
+            pass
+        return False
+
+    def _find_bar(self) -> "FindBar | None":
+        try:
+            return self.query_one("#find-bar", FindBar)
+        except Exception:
+            return None
+
+    def _find_is_active(self) -> bool:
+        bar = self._find_bar()
+        return bool(bar and bar.display)
 
     def action_maybe_quit(self) -> None:
         if not self._input_has_focus():
@@ -2452,6 +2776,110 @@ class ClaudeSessions(App):
             return
         self.push_screen(SearchScreen(self.conn), self._on_search_dismissed)
 
+    def action_open_find(self) -> None:
+        """Toggle the persistent in-transcript find bar.
+
+        Pressing Ctrl+F from anywhere in the app pops the bar open,
+        focuses the input, and (if it already contains a query) re-runs
+        the find so highlights reflect the current transcript. Pressing
+        Ctrl+F again with the bar already open refocuses the input —
+        never closes the bar (Escape / × do that) so the query isn't
+        accidentally lost.
+        """
+        bar = self._find_bar()
+        if bar is None:
+            return
+        bar.display = True
+        input_widget = bar.query_one("#find-input", Input)
+        input_widget.focus()
+        existing = (input_widget.value or "").strip()
+        if existing:
+            self._run_find(input_widget.value)
+
+    def action_find_next(self) -> None:
+        if not self._find_is_active():
+            return
+        transcript = self.query_one("#transcript-scroll", TranscriptView)
+        current, total = transcript.next_match()
+        self._update_find_status(current, total)
+
+    def action_find_prev(self) -> None:
+        if not self._find_is_active():
+            return
+        transcript = self.query_one("#transcript-scroll", TranscriptView)
+        current, total = transcript.prev_match()
+        self._update_find_status(current, total)
+
+    def _run_find(self, query: str, anchor_uuid: str | None = None) -> None:
+        """Apply ``query`` as the find-bar term and refresh the counter."""
+        transcript = self.query_one("#transcript-scroll", TranscriptView)
+        current, total = transcript.activate_find(query, anchor_uuid=anchor_uuid)
+        self._update_find_status(current, total)
+
+    def _update_find_status(self, current: int, total: int) -> None:
+        bar = self._find_bar()
+        if bar is None:
+            return
+        try:
+            query = bar.query_one("#find-input", Input).value or ""
+        except Exception:
+            query = ""
+        bar.update_status(current, total, bool(query.strip()))
+
+    def _close_find(self) -> None:
+        """Dismiss the find bar and drop all highlights.
+
+        Force-reloads the transcript so the inline-highlight rewrites
+        (which replace Markdown bodies with plain-text Rich renderables)
+        are reverted on all widgets. Focus lands back on the sidebar —
+        the typical resting position after a find session.
+        """
+        bar = self._find_bar()
+        transcript = self.query_one("#transcript-scroll", TranscriptView)
+        transcript.clear_find_state()
+        transcript._active_highlight_uuid = None
+        transcript._active_highlight_terms = None
+        if bar is not None:
+            try:
+                bar.query_one("#find-input", Input).value = ""
+            except Exception:
+                pass
+            bar.update_status(0, 0, False)
+            bar.display = False
+        if transcript.current_path:
+            self.call_later(transcript.load_transcript, transcript.current_path, True)
+        try:
+            self.query_one("#session-list", ListView).focus()
+        except Exception:
+            pass
+
+    def on_input_changed(self, event) -> None:
+        """Debounce keystrokes in the find bar into a single highlight pass."""
+        try:
+            if event.input.id != "find-input":
+                return
+        except AttributeError:
+            return
+        if self._find_timer is not None:
+            try:
+                self._find_timer.stop()
+            except Exception:
+                pass
+        value = event.value
+        self._find_timer = self.set_timer(
+            0.1, lambda v=value: self._run_find(v)
+        )
+
+    def on_input_submitted(self, event) -> None:
+        """Enter in the find input = jump to the next match."""
+        try:
+            if event.input.id != "find-input":
+                return
+        except AttributeError:
+            return
+        event.stop()
+        self.action_find_next()
+
     def _on_search_dismissed(self, result) -> None:
         """Dismiss callback: the user either selected a row or pressed Esc."""
         if result is None:
@@ -2465,6 +2893,34 @@ class ClaudeSessions(App):
                 terms = None
         except (TypeError, ValueError):
             return
+
+        # Pre-activate find mode BEFORE the jump so the post-load hook
+        # in TranscriptView.load_transcript applies highlights across
+        # every matching widget (not just the jump target) as soon as
+        # the transcript finishes loading. The anchor_uuid parameter is
+        # passed through via the pending-scroll path so the match
+        # cursor lands on the result the user actually clicked.
+        query = " ".join(terms) if terms else ""
+        transcript = self.query_one("#transcript-scroll", TranscriptView)
+        bar = self._find_bar()
+        if query and bar is not None:
+            bar.display = True
+            input_widget = bar.query_one("#find-input", Input)
+            # Set the find-mode state directly so the transcript reload
+            # sees it immediately; also mirror it in the visible Input
+            # so the user can edit. Suppress the debounce re-run since
+            # activate_find on load will handle the initial highlight.
+            transcript._find_query = query
+            if self._find_timer is not None:
+                try:
+                    self._find_timer.stop()
+                except Exception:
+                    pass
+            # Setting Input.value triggers Changed → debounced _run_find;
+            # that's fine — it just re-runs the same query after load,
+            # keeping state consistent if the user edits the value next.
+            input_widget.value = query
+
         self._jump_to_search_result(session_id, message_uuid, terms)
 
     def _jump_to_search_result(
@@ -2502,9 +2958,22 @@ class ClaudeSessions(App):
             # foreign-session lock from a previous cross-project jump.
             transcript._foreign_session_path = None
             if list_view.index == target_idx:
+                # Same session already loaded — no reload will fire, so
+                # the post-load find hook won't run. If find mode is
+                # live, apply highlights across every matching widget
+                # right here and anchor the cursor on the jump target.
+                # Otherwise fall back to the legacy single-widget
+                # highlight path (keeps behavior identical when find
+                # mode is off).
                 transcript._pending_scroll_uuid = None
                 transcript._pending_scroll_terms = None
-                if not transcript._scroll_to_uuid(message_uuid, search_terms):
+                if transcript._find_query:
+                    current, total = transcript.activate_find(
+                        transcript._find_query,
+                        anchor_uuid=message_uuid,
+                    )
+                    self._update_find_status(current, total)
+                elif not transcript._scroll_to_uuid(message_uuid, search_terms):
                     self.notify(
                         "Message not found in loaded transcript",
                         severity="warning",
@@ -2557,14 +3026,21 @@ class ClaudeSessions(App):
         )
 
     def check_action(self, action: str, parameters):
-        """Disable the priority Enter binding while a modal is up.
+        """Disable the priority Enter binding while a modal is up OR the
+        find-bar input has focus.
 
-        Returning False here tells Textual the binding doesn't match, so
-        the key event passes through to the modal screen's own bindings
-        and widgets instead of being swallowed by this app-level handler.
+        Returning False tells Textual the binding doesn't match, so the
+        key event passes through to whatever owns focus (the modal, or
+        the find input's own Submitted handler).
         """
-        if action == "start_reply_or_send" and len(self.screen_stack) > 1:
-            return False
+        if action == "start_reply_or_send":
+            if len(self.screen_stack) > 1:
+                return False
+            try:
+                if self.query_one("#find-input", Input).has_focus:
+                    return False
+            except Exception:
+                pass
         return True
 
     def action_start_reply_or_send(self) -> None:
@@ -2588,6 +3064,12 @@ class ClaudeSessions(App):
             text_area.insert("\n")
 
     def action_cancel_reply(self) -> None:
+        # Escape closes the find bar first if it's up (Ctrl+F semantics):
+        # users expect it to peel off the overlay rather than clear the
+        # reply buffer underneath.
+        if self._find_is_active():
+            self._close_find()
+            return
         text_area = self.query_one("#reply-input", TextArea)
         text_area.clear()
         self._renaming_session_id = None

--- a/threadhop
+++ b/threadhop
@@ -316,6 +316,10 @@ class TranscriptView(VerticalScroll):
                 self._toggle_range()
                 event.stop()
                 event.prevent_default()
+            elif event.key == "y":
+                self._copy_selection()
+                event.stop()
+                event.prevent_default()
             elif event.key == "escape":
                 self._exit_selection_mode()
                 event.stop()
@@ -330,7 +334,7 @@ class TranscriptView(VerticalScroll):
         # Start at the last message — recent context is usually what you want
         self._selected_index = len(messages) - 1
         self._update_selection(messages)
-        self.app.notify("Selection mode: j/k move, v range, m/Esc exit")
+        self.app.notify("Selection mode: j/k move, v range, y copy, m/Esc exit")
 
     def _exit_selection_mode(self):
         self._clear_selection()
@@ -396,6 +400,82 @@ class TranscriptView(VerticalScroll):
         for widget in self._get_message_widgets():
             widget.remove_class("message-selected")
 
+    def _copy_selection(self):
+        """Copy selected messages to clipboard with source labels (ADR-008)."""
+        messages = self._get_message_widgets()
+        lo, hi = self._get_selected_range()
+        if lo < 0 or hi < 0:
+            return
+
+        selected = messages[lo:hi + 1]
+        if not selected:
+            return
+
+        # Resolve session metadata from the app
+        app = self.app
+        session_id = app._selected_session_id
+        session_data = next(
+            (s for s in app.sessions if s.get("session_id") == session_id),
+            None,
+        )
+
+        if session_data:
+            custom_name = app.config.get("session_names", {}).get(session_id)
+            session_name = (
+                custom_name
+                or session_data.get("title")
+                or session_data.get("project", "unknown")
+            )
+            cwd = session_data.get("project", "")
+        else:
+            session_name = "unknown"
+            cwd = ""
+
+        # Use the first selected message's timestamp for the label
+        first_ts = next(
+            (getattr(w, "_timestamp", None) for w in selected
+             if getattr(w, "_timestamp", None)),
+            None,
+        )
+        ts_str = ""
+        if first_ts:
+            try:
+                dt = datetime.fromisoformat(first_ts.replace("Z", "+00:00"))
+                ts_str = dt.strftime("%Y-%m-%d %H:%M")
+            except (ValueError, AttributeError):
+                pass
+
+        # Build source label — contract parsed by /threadhop:context
+        label_parts = [f'[From "{session_name}"']
+        if cwd:
+            label_parts.append(f" — {cwd}")
+        if ts_str:
+            label_parts.append(f" — {ts_str}")
+        label_parts.append("]")
+        label = "".join(label_parts)
+
+        # Build message content
+        lines = [label]
+        for w in selected:
+            raw = getattr(w, "_raw_text", "")
+            if isinstance(w, UserMessage):
+                lines.append(f"User: {raw}")
+            elif isinstance(w, AssistantMessage):
+                lines.append(f"Claude: {raw}")
+            elif isinstance(w, ToolMessage):
+                lines.append(raw)
+
+        text = "\n".join(lines)
+
+        # Copy to clipboard via pbcopy (macOS)
+        try:
+            subprocess.run(["pbcopy"], input=text.encode(), check=True)
+            count = len(selected)
+            noun = "message" if count == 1 else "messages"
+            app.notify(f"Copied {count} {noun} to clipboard")
+        except Exception:
+            app.notify("Failed to copy to clipboard", severity="error")
+
     async def load_transcript(self, session_path: Path, force: bool = False):
         """Load and display full conversation from transcript"""
         if not session_path or not session_path.exists():
@@ -440,21 +520,30 @@ class TranscriptView(VerticalScroll):
             if not tool_batch:
                 return
             lines = Text()
-            for j, (tr, tc) in enumerate(tool_batch):
+            first_ts = None
+            raw_parts = []
+            for j, (tr, tc, ts) in enumerate(tool_batch):
+                if first_ts is None:
+                    first_ts = ts
                 if tr == "tool":
                     lines.append("⚙ ", style="dim yellow")
                     lines.append(str(tc) if tc else "", style="dim")
+                    raw_parts.append(f"⚙ {tc}")
                 else:
                     lines.append("  ↳ ", style="dim green")
                     lines.append(str(tc) if tc else "", style="dim green")
+                    raw_parts.append(f"  ↳ {tc}")
                 if j < len(tool_batch) - 1:
                     lines.append("\n")
-            widgets.append(ToolMessage(lines))
+            w = ToolMessage(lines)
+            w._raw_text = "\n".join(raw_parts)
+            w._timestamp = first_ts
+            widgets.append(w)
             tool_batch.clear()
 
-        for role, content in messages:
+        for role, content, timestamp in messages:
             if role in ("tool", "tool_result"):
-                tool_batch.append((role, content))
+                tool_batch.append((role, content, timestamp))
                 continue
 
             flush_tools()
@@ -463,7 +552,10 @@ class TranscriptView(VerticalScroll):
                 user_text = Text()
                 user_text.append("You\n", style="bold cyan")
                 user_text.append(str(content) if content else "")
-                widgets.append(UserMessage(user_text))
+                w = UserMessage(user_text)
+                w._raw_text = str(content) if content else ""
+                w._timestamp = timestamp
+                widgets.append(w)
             else:
                 header = Text()
                 header.append("Claude\n", style="bold green")
@@ -473,7 +565,10 @@ class TranscriptView(VerticalScroll):
                         renderables.append(Markdown(str(content)))
                     except:
                         renderables.append(Text(str(content)))
-                widgets.append(AssistantMessage(Group(*renderables)))
+                w = AssistantMessage(Group(*renderables))
+                w._raw_text = str(content) if content else ""
+                w._timestamp = timestamp
+                widgets.append(w)
 
         flush_tools()
 
@@ -491,8 +586,11 @@ class TranscriptView(VerticalScroll):
         await self._remove_all_messages()
         await self.mount(AssistantMessage(text))
 
-    def _parse_messages(self, session_path: Path) -> list[tuple[str, str]]:
-        """Parse JSONL file and extract displayable messages"""
+    def _parse_messages(self, session_path: Path) -> list[tuple[str, str, str | None]]:
+        """Parse JSONL file and extract displayable messages.
+
+        Returns list of (role, content, timestamp) tuples.
+        """
         messages = []
         try:
             with open(session_path) as f:
@@ -500,6 +598,7 @@ class TranscriptView(VerticalScroll):
                     try:
                         msg = json.loads(line)
                         msg_type = msg.get("type")
+                        timestamp = msg.get("timestamp")
 
                         # Only process user and assistant messages
                         if msg_type not in ("user", "assistant"):
@@ -510,7 +609,7 @@ class TranscriptView(VerticalScroll):
                             if tool_result and isinstance(tool_result, dict):
                                 result_info = self._format_tool_result(tool_result)
                                 if result_info:
-                                    messages.append(("tool_result", result_info))
+                                    messages.append(("tool_result", result_info, timestamp))
                             elif "toolUseResult" not in msg:
                                 content = msg.get("message", {}).get("content", "")
                                 if isinstance(content, list):
@@ -524,7 +623,7 @@ class TranscriptView(VerticalScroll):
                                     # Strip system-reminder tags
                                     content = SYSTEM_REMINDER_RE.sub("", content).strip()
                                     if content:
-                                        messages.append(("user", content))
+                                        messages.append(("user", content, timestamp))
 
                         elif msg_type == "assistant":
                             content = msg.get("message", {}).get("content", [])
@@ -543,10 +642,10 @@ class TranscriptView(VerticalScroll):
                                         tool_desc = self._format_tool_use(
                                             tool_name, tool_input
                                         )
-                                        messages.append(("tool", tool_desc))
+                                        messages.append(("tool", tool_desc, timestamp))
                                 if text_parts:
                                     messages.append(
-                                        ("assistant", " ".join(text_parts))
+                                        ("assistant", " ".join(text_parts), timestamp)
                                     )
                     except (json.JSONDecodeError, KeyError):
                         pass

--- a/threadhop
+++ b/threadhop
@@ -13,6 +13,7 @@ import re
 import sqlite3
 import subprocess
 import sys
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -24,7 +25,7 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
-from textual.widgets import Footer, Header, Input, ListItem, ListView, Static, TextArea
+from textual.widgets import Header, Input, ListItem, ListView, Static, TextArea
 from textual.worker import Worker
 
 # Local package: SQLite DB module (init, migrations, session helpers).
@@ -146,6 +147,227 @@ STATUS_CYCLE: list[str] = [s for s in STATUS_ORDER if s != "archived"]
 
 # Regex to strip <system-reminder>...</system-reminder> blocks from text
 SYSTEM_REMINDER_RE = re.compile(r"<system-reminder>.*?</system-reminder>", re.DOTALL)
+
+
+# --- Command metadata registry (ADR-017, task #42) ---
+#
+# One source of truth for app-level bindings, widget-local keys, the
+# contextual footer, and the help overlay. Any new command lands here
+# and automatically becomes discoverable everywhere.
+#
+# Scopes group commands by where they're reachable. Widget-local
+# handlers (TranscriptView selection mode, FindBar, SearchScreen) own
+# their behaviour — the registry just records the metadata so the rest
+# of the UI can surface it.
+
+SCOPE_GLOBAL = "global"
+SCOPE_SESSION_LIST = "session_list"
+SCOPE_TRANSCRIPT = "transcript"
+SCOPE_SELECTION = "selection"
+SCOPE_REPLY = "reply"
+SCOPE_FIND = "find"
+SCOPE_SEARCH = "search"
+
+SCOPE_ORDER: list[str] = [
+    SCOPE_GLOBAL,
+    SCOPE_SESSION_LIST,
+    SCOPE_TRANSCRIPT,
+    SCOPE_SELECTION,
+    SCOPE_REPLY,
+    SCOPE_FIND,
+    SCOPE_SEARCH,
+]
+
+SCOPE_LABELS: dict[str, str] = {
+    SCOPE_GLOBAL: "Global",
+    SCOPE_SESSION_LIST: "Session list",
+    SCOPE_TRANSCRIPT: "Transcript",
+    SCOPE_SELECTION: "Selection mode",
+    SCOPE_REPLY: "Reply input",
+    SCOPE_FIND: "Find bar",
+    SCOPE_SEARCH: "Search modal",
+}
+
+# Pretty-print Textual key strings for the help overlay and footer.
+# Lookup is exact-match first, then falls back to capitalizing the raw
+# string so unknown keys still show up reasonably.
+_KEY_DISPLAY: dict[str, str] = {
+    "up": "↑",
+    "down": "↓",
+    "left": "←",
+    "right": "→",
+    "enter": "Enter",
+    "escape": "Esc",
+    "pageup": "PgUp",
+    "pagedown": "PgDn",
+    "home": "Home",
+    "end": "End",
+    "space": "Space",
+    "tab": "Tab",
+    "left_square_bracket": "[",
+    "right_square_bracket": "]",
+    "shift+up": "⇧↑",
+    "shift+down": "⇧↓",
+    "alt+enter": "⌥Enter",
+    "alt+j": "⌥j",
+    "alt+k": "⌥k",
+    "ctrl+f": "^F",
+    "ctrl+n": "^N",
+    "ctrl+p": "^P",
+}
+
+
+def format_key(key: str) -> str:
+    return _KEY_DISPLAY.get(key, key)
+
+
+@dataclass(frozen=True)
+class Command:
+    """One row of the command registry.
+
+    ``keys`` holds Textual-valid key names (``"ctrl+f"``, ``"shift+down"``,
+    ``"left_square_bracket"``) — prettification for display happens in
+    ``format_key``. When ``action`` is set the command is wired as an
+    App-level ``Binding``; otherwise the command is widget-local and the
+    registry entry exists purely for discoverability (footer, help
+    overlay).
+    """
+
+    keys: tuple[str, ...]
+    description: str
+    scope: str
+    action: str | None = None
+    priority: bool = False
+    # Footer commands are the minimal contextual hint row — only the
+    # highest-value bindings for each scope are marked ``footer=True``.
+    footer: bool = False
+
+
+COMMAND_REGISTRY: list[Command] = [
+    # --- Global ---
+    Command(("?",), "Help", SCOPE_GLOBAL, "open_help", footer=True),
+    Command(("q",), "Quit", SCOPE_GLOBAL, "maybe_quit", footer=True),
+    Command(("r",), "Refresh sessions", SCOPE_GLOBAL, "maybe_refresh"),
+    Command(("t",), "Next theme", SCOPE_GLOBAL, "toggle_theme_next"),
+    Command(("T",), "Previous theme", SCOPE_GLOBAL, "toggle_theme_prev"),
+    Command(("/",), "Search all sessions", SCOPE_GLOBAL, "open_search", footer=True),
+    Command(("ctrl+f",), "Find in transcript", SCOPE_GLOBAL, "open_find", footer=True),
+    Command(("left_square_bracket",), "Shrink sidebar", SCOPE_GLOBAL, "shrink_sidebar"),
+    Command(("right_square_bracket",), "Grow sidebar", SCOPE_GLOBAL, "grow_sidebar"),
+
+    # --- Session list ---
+    Command(("j",), "Next session", SCOPE_SESSION_LIST, "cursor_down", footer=True),
+    Command(("k",), "Previous session", SCOPE_SESSION_LIST, "cursor_up", footer=True),
+    Command(("l", "right"), "Focus transcript", SCOPE_SESSION_LIST, "focus_transcript"),
+    Command(
+        ("enter",), "Reply to session", SCOPE_SESSION_LIST,
+        "start_reply_or_send", priority=True, footer=True,
+    ),
+    Command(("n",), "Rename session", SCOPE_SESSION_LIST, "rename_session", footer=True),
+    Command(("g",), "Copy resume command", SCOPE_SESSION_LIST, "copy_session_id"),
+    Command(("s",), "Cycle status forward", SCOPE_SESSION_LIST, "cycle_status_forward"),
+    Command(("S",), "Cycle status backward", SCOPE_SESSION_LIST, "cycle_status_backward"),
+    Command(("a",), "Archive session", SCOPE_SESSION_LIST, "archive_session"),
+    Command(("A",), "Toggle archived view", SCOPE_SESSION_LIST, "toggle_archive_view"),
+    Command(
+        ("J", "shift+down"), "Move session down",
+        SCOPE_SESSION_LIST, "move_session_down",
+    ),
+    Command(
+        ("K", "shift+up"), "Move session up",
+        SCOPE_SESSION_LIST, "move_session_up",
+    ),
+
+    # --- Transcript ---
+    Command(("h", "left"), "Focus session list", SCOPE_TRANSCRIPT, "focus_list"),
+    Command(
+        ("pageup",), "Scroll page up", SCOPE_TRANSCRIPT,
+        "scroll_transcript_up", priority=True,
+    ),
+    Command(
+        ("pagedown",), "Scroll page down", SCOPE_TRANSCRIPT,
+        "scroll_transcript_down", priority=True,
+    ),
+    Command(
+        ("home",), "Scroll to top", SCOPE_TRANSCRIPT,
+        "scroll_transcript_home", priority=True,
+    ),
+    Command(
+        ("end",), "Scroll to bottom", SCOPE_TRANSCRIPT,
+        "scroll_transcript_end", priority=True,
+    ),
+    Command(("m",), "Enter selection mode", SCOPE_TRANSCRIPT, footer=True),
+
+    # --- Selection mode (widget-local; TranscriptView.on_key) ---
+    Command(("j", "down"), "Next message", SCOPE_SELECTION, footer=True),
+    Command(("k", "up"), "Previous message", SCOPE_SELECTION, footer=True),
+    Command(("v",), "Toggle range select", SCOPE_SELECTION, footer=True),
+    Command(("y",), "Copy selection", SCOPE_SELECTION, footer=True),
+    Command(("e",), "Export to /tmp", SCOPE_SELECTION, footer=True),
+    Command(("m", "escape"), "Exit selection", SCOPE_SELECTION, footer=True),
+
+    # --- Reply input ---
+    Command(
+        ("enter",), "Send message", SCOPE_REPLY,
+        "start_reply_or_send", priority=True, footer=True,
+    ),
+    Command(("alt+enter",), "Newline", SCOPE_REPLY, "insert_newline", footer=True),
+    Command(("escape",), "Cancel / return to list", SCOPE_REPLY, "cancel_reply", footer=True),
+    Command(("alt+j",), "Nav sessions while replying", SCOPE_REPLY, "nav_down_from_reply"),
+    Command(("alt+k",), "Nav sessions while replying", SCOPE_REPLY, "nav_up_from_reply"),
+
+    # --- Find bar (widget-local; FindBar.on_key + Input.Submitted) ---
+    Command(("enter",), "Next match", SCOPE_FIND, footer=True),
+    Command(("down",), "Next match", SCOPE_FIND, footer=True),
+    Command(("up",), "Previous match", SCOPE_FIND, footer=True),
+    Command(("N",), "Previous match (app-wide)", SCOPE_FIND, "find_prev"),
+    Command(("escape",), "Close find", SCOPE_FIND, footer=True),
+
+    # --- Search modal (widget-local; SearchScreen.on_key) ---
+    Command(("up", "down", "ctrl+n", "ctrl+p"), "Navigate results", SCOPE_SEARCH, footer=True),
+    Command(("enter",), "Open result", SCOPE_SEARCH, footer=True),
+    Command(("escape",), "Close search", SCOPE_SEARCH, footer=True),
+]
+
+
+def commands_for_scope(scope: str) -> list[Command]:
+    return [c for c in COMMAND_REGISTRY if c.scope == scope]
+
+
+def format_command_keys(cmd: Command) -> str:
+    """Render a command's keys as a slash-separated list for display."""
+    return "/".join(format_key(k) for k in cmd.keys)
+
+
+def app_bindings_from_registry() -> list[Binding]:
+    """Derive App-level ``Binding`` entries from the registry.
+
+    Every Command with an ``action`` is bound at the App level. The
+    scope field is advisory for display — app bindings fire globally,
+    but each action already gates itself on focus / mode state (see
+    e.g. ``_input_has_focus`` in action handlers). Widget-local keys
+    (selection mode, find bar, search modal) are deliberately skipped
+    because their widgets handle the key in ``on_key`` and stop the
+    event before it reaches an app binding.
+    """
+    bindings: list[Binding] = []
+    for cmd in COMMAND_REGISTRY:
+        if cmd.action is None:
+            continue
+        for key in cmd.keys:
+            bindings.append(
+                Binding(
+                    key,
+                    cmd.action,
+                    cmd.description,
+                    show=False,
+                    priority=cmd.priority,
+                )
+            )
+    # Escape on the reply input action is the app-level cancel_reply;
+    # it doubles as "close find bar" when the bar is up (see
+    # action_cancel_reply). Registered via the SCOPE_REPLY entry above.
+    return bindings
 
 
 def format_age(timestamp: float) -> str:
@@ -384,6 +606,11 @@ class TranscriptView(VerticalScroll):
         self._selected_index = len(messages) - 1
         self._update_selection(messages)
         self.app.notify("Selection mode: j/k move, v range, y copy, e export, m/Esc exit")
+        # Nudge the contextual footer — selection mode has its own scope.
+        try:
+            self.app.refresh_footer()
+        except Exception:
+            pass
 
     def _exit_selection_mode(self):
         self._range_mode = False
@@ -392,6 +619,10 @@ class TranscriptView(VerticalScroll):
         self._selection_mode = False
         self._selected_index = -1
         self.border_title = "Transcript"
+        try:
+            self.app.refresh_footer()
+        except Exception:
+            pass
 
     def _enter_range_mode(self):
         self._range_mode = True
@@ -1686,6 +1917,167 @@ class SearchScreen(ModalScreen):
         self.dismiss((row["session_id"], row["uuid"], terms))
 
 
+class HelpScreen(ModalScreen):
+    """Full-app help overlay grouped by scope (ADR-017, task #42).
+
+    Mirrors the search modal layout so the two discoverability surfaces
+    feel consistent. Reads entirely from ``COMMAND_REGISTRY`` — anything
+    new added there appears here automatically.
+    """
+
+    BINDINGS = [
+        Binding("escape", "close", "Close", priority=True),
+        Binding("?", "close", "Close", priority=True),
+        Binding("q", "close", "Close", priority=True),
+    ]
+
+    CSS = """
+    HelpScreen {
+        layout: vertical;
+        align: center top;
+        background: $background 70%;
+    }
+
+    #help-container {
+        width: 90%;
+        max-width: 120;
+        height: 85%;
+        margin-top: 1;
+        background: $surface;
+        border: thick $accent;
+        layout: vertical;
+    }
+
+    #help-title {
+        height: 1;
+        padding: 0 1;
+        background: $boost;
+        color: $text;
+        text-style: bold;
+    }
+
+    #help-body {
+        height: 1fr;
+        padding: 1 2;
+    }
+
+    #help-hint {
+        height: 1;
+        padding: 0 1;
+        color: $text-muted;
+        background: $boost;
+        text-style: italic;
+    }
+
+    .help-scope {
+        margin-top: 1;
+        text-style: bold;
+        color: $accent;
+    }
+
+    .help-scope:first-of-type {
+        margin-top: 0;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="help-container") as container:
+            container.border_title = "Help — keys grouped by context"
+            yield Static("ThreadHop commands", id="help-title")
+            yield VerticalScroll(id="help-body")
+            yield Static(
+                "Esc / ? / q close • keys are grouped by where they're live",
+                id="help-hint",
+            )
+
+    def on_mount(self) -> None:
+        body = self.query_one("#help-body", VerticalScroll)
+        for scope in SCOPE_ORDER:
+            commands = commands_for_scope(scope)
+            if not commands:
+                continue
+            body.mount(Static(SCOPE_LABELS[scope], classes="help-scope"))
+            # Width of the keys column is computed per-scope so shorter
+            # sections don't pay for a long key name in another scope.
+            key_width = max(len(format_command_keys(c)) for c in commands)
+            key_width = max(key_width, 6)
+            for cmd in commands:
+                keys = format_command_keys(cmd).ljust(key_width)
+                body.mount(Static(f"  {keys}   {cmd.description}"))
+
+    def action_close(self) -> None:
+        self.dismiss(None)
+
+
+class ContextualFooter(Static):
+    """Single-line footer that shows scope-relevant hints from the registry.
+
+    The stock ``Footer`` widget lists every visible binding at once, which
+    turns into noise once the app has focus-aware and mode-specific
+    commands. Instead we read ``COMMAND_REGISTRY`` and render only
+    commands whose scope matches the caller-supplied context, preferring
+    those marked ``footer=True``.
+    """
+
+    DEFAULT_CSS = """
+    ContextualFooter {
+        dock: bottom;
+        height: 1;
+        background: $boost;
+        color: $text-muted;
+        padding: 0 1;
+    }
+    ContextualFooter > .footer-sep {
+        color: $text-disabled;
+    }
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__("", *args, **kwargs)
+        self._last_scopes: tuple[str, ...] = ()
+
+    def render_for(self, scopes: list[str]) -> None:
+        """Rebuild the footer content for the given list of active scopes.
+
+        Scopes are evaluated in the order passed — the registry entries
+        for later scopes win when a key appears in multiple (e.g. Enter
+        is Reply/Send globally but Send in the reply scope).
+        """
+        scope_tuple = tuple(scopes)
+        if scope_tuple == self._last_scopes:
+            # Footer already reflects the right context — skip the rebuild.
+            return
+        self._last_scopes = scope_tuple
+
+        # Keep the help shortcut pinned on the far left so it stays
+        # discoverable regardless of current focus.
+        parts: list[str] = []
+        seen_keys: set[tuple[str, ...]] = set()
+
+        def add(cmd: Command) -> None:
+            if cmd.keys in seen_keys:
+                return
+            seen_keys.add(cmd.keys)
+            parts.append(f"[b]{format_command_keys(cmd)}[/b] {cmd.description}")
+
+        # Global "?" first, so it's always in the same spot.
+        for cmd in commands_for_scope(SCOPE_GLOBAL):
+            if cmd.keys == ("?",):
+                add(cmd)
+                break
+
+        for scope in scopes:
+            for cmd in commands_for_scope(scope):
+                if cmd.footer and cmd.keys != ("?",):
+                    add(cmd)
+
+        if not parts:
+            self.update("")
+            return
+        sep = "  [dim]·[/dim]  "
+        self.update(sep.join(parts))
+
+
 class FindBar(Horizontal):
     """Persistent Ctrl+F-style find bar shown above the transcript.
 
@@ -1943,44 +2335,10 @@ class ClaudeSessions(App):
     }
     """
 
-    BINDINGS = [
-        Binding("q", "maybe_quit", "Quit"),
-        Binding("r", "maybe_refresh", "Refresh"),
-        Binding("t", "toggle_theme_next", "Theme"),
-        Binding("T", "toggle_theme_prev", "Theme Prev", show=False),
-        Binding("n", "rename_session", "Rename"),
-        Binding("g", "copy_session_id", "Copy ID"),
-        Binding("enter", "start_reply_or_send", "Reply/Send", show=True, priority=True),
-        Binding("alt+enter", "insert_newline", "Newline", show=False),
-        Binding("/", "open_search", "Search"),
-        Binding("ctrl+f", "open_find", "Find"),
-        Binding("N", "find_prev", "Prev match", show=False),
-        Binding("escape", "cancel_reply", "Cancel", show=False),
-        Binding("right", "focus_transcript", "Transcript", show=False),
-        Binding("left", "focus_list", "Sessions", show=False),
-        Binding("l", "focus_transcript", "Transcript", show=False),
-        Binding("h", "focus_list", "Sessions", show=False),
-        Binding("j", "cursor_down", "Down", show=False),
-        Binding("k", "cursor_up", "Up", show=False),
-        Binding("J", "move_session_down", "Move Down", show=False),
-        Binding("K", "move_session_up", "Move Up", show=False),
-        Binding("shift+down", "move_session_down", "Move Down", show=False),
-        Binding("shift+up", "move_session_up", "Move Up", show=False),
-        Binding("alt+j", "nav_down_from_reply", "Nav Down", show=False),
-        Binding("alt+k", "nav_up_from_reply", "Nav Up", show=False),
-        Binding("a", "archive_session", "Archive", show=False),
-        Binding("A", "toggle_archive_view", "Show Archived", show=False),
-        Binding("pageup", "scroll_transcript_up", "PgUp", show=False, priority=True),
-        Binding(
-            "pagedown", "scroll_transcript_down", "PgDn", show=False, priority=True
-        ),
-        Binding("home", "scroll_transcript_home", "Top", show=False, priority=True),
-        Binding("end", "scroll_transcript_end", "Bottom", show=False, priority=True),
-        Binding("s", "cycle_status_forward", "Status", show=False),
-        Binding("S", "cycle_status_backward", "Status Back", show=False),
-        Binding("left_square_bracket", "shrink_sidebar", "Narrow", show=False),
-        Binding("right_square_bracket", "grow_sidebar", "Widen", show=False),
-    ]
+    # Bindings come from the shared command registry (ADR-017). Add new
+    # App-level commands to COMMAND_REGISTRY above, not here — footer and
+    # help overlay both read from the same list.
+    BINDINGS = app_bindings_from_registry()
 
     SIDEBAR_MIN = 20
     SIDEBAR_MAX = 60
@@ -2036,7 +2394,7 @@ class ClaudeSessions(App):
             id="transcript-column",
         )
         yield Vertical(TextArea(id="reply-input"), id="input-container")
-        yield Footer()
+        yield ContextualFooter(id="contextual-footer")
 
     def on_mount(self) -> None:
         # Apply persisted sidebar width (defaults to CSS value of 36).
@@ -2059,6 +2417,11 @@ class ClaudeSessions(App):
         self.set_interval(REFRESH_INTERVAL, self.auto_refresh_background)
         self._spinner_frame = 0
         self.set_interval(SPINNER_INTERVAL, self.animate_spinners)
+        # Prime the contextual footer now that all widgets are mounted
+        # and the sidebar has focus. on_descendant_focus also covers
+        # this, but calling refresh_footer directly makes startup
+        # deterministic in tests that don't emit focus events.
+        self.refresh_footer()
 
     def update_titles(self) -> None:
         filter_info = ""
@@ -2703,6 +3066,75 @@ class ClaudeSessions(App):
         bar = self._find_bar()
         return bool(bar and bar.display)
 
+    def _current_scopes(self) -> list[str]:
+        """Resolve which registry scopes are live right now.
+
+        Ordered from outer to inner (``global`` first, most-specific
+        last) so the contextual footer and any downstream consumer
+        can give precedence to the innermost scope when a key appears
+        in more than one.
+        """
+        scopes = [SCOPE_GLOBAL]
+        focused = self.focused
+
+        # Selection mode is inside the transcript but displaces its
+        # regular bindings, so it's surfaced as its own scope first.
+        try:
+            transcript = self.query_one("#transcript-scroll", TranscriptView)
+        except Exception:
+            transcript = None
+        in_selection = bool(transcript and transcript._selection_mode)
+
+        # Find bar is modeless — it can be up while focus is elsewhere.
+        # Surface it as its own scope whenever it's visible.
+        if self._find_is_active():
+            scopes.append(SCOPE_FIND)
+
+        if focused is not None:
+            fid = getattr(focused, "id", None)
+            if fid == "reply-input":
+                scopes.append(SCOPE_REPLY)
+            elif fid == "session-list":
+                scopes.append(SCOPE_SESSION_LIST)
+            elif fid == "find-input":
+                # Already covered by SCOPE_FIND above.
+                pass
+            elif transcript is not None and focused is transcript:
+                scopes.append(SCOPE_SELECTION if in_selection else SCOPE_TRANSCRIPT)
+
+        if in_selection and SCOPE_SELECTION not in scopes:
+            scopes.append(SCOPE_SELECTION)
+        return scopes
+
+    def refresh_footer(self) -> None:
+        """Re-render the contextual footer for the current scope stack.
+
+        Called whenever focus moves, selection mode toggles, or the
+        find bar opens/closes — the footer picks up the new scope set
+        and redraws. No-ops if the footer hasn't mounted yet.
+        """
+        try:
+            footer = self.query_one("#contextual-footer", ContextualFooter)
+        except Exception:
+            return
+        footer.render_for(self._current_scopes())
+
+    def on_descendant_focus(self, event) -> None:
+        self.refresh_footer()
+
+    def on_descendant_blur(self, event) -> None:
+        self.refresh_footer()
+
+    def action_open_help(self) -> None:
+        """Show the context-aware help overlay.
+
+        Skips when an input widget has focus so `?` still types
+        normally while composing a reply or a search query.
+        """
+        if self._input_has_focus():
+            return
+        self.push_screen(HelpScreen())
+
     def action_maybe_quit(self) -> None:
         if not self._input_has_focus():
             self.exit()
@@ -2756,6 +3188,7 @@ class ClaudeSessions(App):
         existing = (input_widget.value or "").strip()
         if existing:
             self._run_find(input_widget.value)
+        self.refresh_footer()
 
     def action_find_next(self) -> None:
         if not self._find_is_active():
@@ -2813,6 +3246,7 @@ class ClaudeSessions(App):
             self.query_one("#session-list", ListView).focus()
         except Exception:
             pass
+        self.refresh_footer()
 
     def on_input_changed(self, event) -> None:
         """Debounce keystrokes in the find bar into a single highlight pass."""

--- a/threadhop
+++ b/threadhop
@@ -506,10 +506,9 @@ class TranscriptView(VerticalScroll):
 
     async def load_transcript(self, session_path: Path, force: bool = False):
         """Load and display full conversation from transcript"""
-        if self._selection_mode:
-            self._exit_selection_mode()
-
         if not session_path or not session_path.exists():
+            if self._selection_mode:
+                self._exit_selection_mode()
             await self._clear_and_show("No transcript available")
             return
 
@@ -520,10 +519,15 @@ class TranscriptView(VerticalScroll):
                 and session_path == self.current_path
                 and mtime == self._last_mtime
             ):
+                # File unchanged — keep selection mode alive
                 return
             self._last_mtime = mtime
         except:
             pass
+
+        # Transcript is actually reloading — exit selection mode now
+        if self._selection_mode:
+            self._exit_selection_mode()
 
         self.current_path = session_path
 

--- a/threadhop
+++ b/threadhop
@@ -741,9 +741,13 @@ class TranscriptView(VerticalScroll):
     def _scroll_to_uuid(self, uuid: str) -> bool:
         """Scroll the widget with matching _uuid into view and flash-highlight.
 
-        Returns True if a match was found and scrolled to. The flash
-        highlight uses the existing `.message-selected` class so no new
-        CSS is needed.
+        Returns True if a match was found and scrolled to. We can't
+        scroll to the exact matched token within the message because
+        Rich-rendered Static widgets don't expose per-line positions to
+        Textual — so we scroll the widget's top near the viewport top
+        (with a small offset so the message header isn't flush against
+        the border) and let the flash highlight + the widget itself
+        guide the reader's eye.
         """
         for widget in self._get_message_widgets():
             if getattr(widget, "_uuid", None) == uuid:
@@ -1135,15 +1139,21 @@ class SearchScreen(ModalScreen):
     ]
 
     CSS = """
+    /* Explicitly reset layout here — the app's top-level
+       `Screen { layout: grid; grid-columns: 36 1fr; ... }` rule cascades
+       to ModalScreen subclasses too, which would otherwise squeeze the
+       modal into the 36-col first grid cell. */
     SearchScreen {
+        layout: vertical;
         align: center top;
+        background: $background 70%;
     }
 
     #search-container {
         width: 90%;
-        max-width: 120;
-        height: 80%;
-        margin-top: 2;
+        max-width: 140;
+        height: 85%;
+        margin-top: 1;
         background: $surface;
         border: thick $accent;
         layout: vertical;
@@ -2241,9 +2251,15 @@ class ClaudeSessions(App):
     def _jump_to_search_result(self, session_id: str, message_uuid: str) -> None:
         """Switch to ``session_id`` and scroll its transcript to ``message_uuid``.
 
-        If the target session isn't currently in the sidebar (e.g. older
-        than ``--days`` or archived with view off), surface a toast
-        rather than silently no-op'ing.
+        Three cases:
+          1. Session is already the selected one → scroll directly.
+          2. Session is in the sidebar → change ``list_view.index`` and
+             queue the scroll; the normal highlight handler loads the
+             transcript then applies the pending scroll.
+          3. Session isn't in the sidebar (older than ``--days``, or
+             archive hidden) → look up its path from the DB and load
+             the transcript directly so search is useful across ALL
+             indexed history, not just what's visible in the sidebar.
         """
         list_view = self.query_one("#session-list", ListView)
         transcript = self.query_one("#transcript-scroll", TranscriptView)
@@ -2257,27 +2273,57 @@ class ClaudeSessions(App):
                 target_idx = i
                 break
 
-        if target_idx is None:
+        if target_idx is not None:
+            # Case 1 & 2: session is in the sidebar.
+            if list_view.index == target_idx:
+                transcript._pending_scroll_uuid = None
+                if not transcript._scroll_to_uuid(message_uuid):
+                    self.notify(
+                        "Message not found in loaded transcript",
+                        severity="warning",
+                    )
+            else:
+                transcript.queue_scroll_to_uuid(message_uuid)
+                list_view.index = target_idx
+            list_view.focus()
+            return
+
+        # Case 3: session is outside the current sidebar view. Fall back
+        # to a direct transcript load using the DB-recorded session_path.
+        row = db.get_session(self.conn, session_id)
+        if not row or not row.get("session_path"):
             self.notify(
-                "Source session not in current view "
-                "(try increasing --days or toggling archive view)",
+                "Session metadata not found in DB",
+                severity="error",
+            )
+            return
+        session_path = Path(row["session_path"])
+        if not session_path.exists():
+            self.notify(
+                "Session file no longer exists on disk",
                 severity="warning",
-                timeout=6,
             )
             return
 
-        # Already on the target session: transcript is loaded, just scroll.
-        # Otherwise queue the scroll so it runs at the end of the load
-        # that the highlight change will trigger.
-        if list_view.index == target_idx:
-            transcript._pending_scroll_uuid = None
-            if not transcript._scroll_to_uuid(message_uuid):
-                self.notify("Message not found in loaded transcript", severity="warning")
-        else:
-            transcript.queue_scroll_to_uuid(message_uuid)
-            list_view.index = target_idx
+        self._selected_session_id = session_id
+        transcript.queue_scroll_to_uuid(message_uuid)
+        # load_transcript is async; schedule and let the pending scroll
+        # fire at the end of the load.
+        self.call_later(transcript.load_transcript, session_path)
 
-        list_view.focus()
+        # Put the foreign session's identity in the transcript border
+        # title so the user knows the panel is showing a session that
+        # isn't in their sidebar. Gets reset to "Transcript" by the
+        # normal selection-exit flow when they click back into a
+        # sidebar session.
+        name = row.get("custom_name") or row.get("project") or session_id[:8]
+        project = row.get("project") or ""
+        label = f"Transcript ── [{project}] {name}" if project else f"Transcript ── {name}"
+        transcript.border_title = label + "  (from search — not in sidebar)"
+        self.notify(
+            f"Jumped to out-of-view session: {name}",
+            timeout=4,
+        )
 
     def check_action(self, action: str, parameters):
         """Disable the priority Enter binding while a modal is up.

--- a/threadhop
+++ b/threadhop
@@ -32,6 +32,7 @@ from textual.worker import Worker
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import db  # noqa: E402
 import indexer  # noqa: E402
+import observer  # noqa: E402
 
 
 def get_available_themes():
@@ -3529,11 +3530,13 @@ def _cli_stub(command):
     return 0
 
 
-def _resolve_tag_session(args) -> int:
+def _resolve_cli_session(args) -> int:
     """Populate args.session via auto-detection when omitted.
 
-    Returns 0 on success (args.session is set), non-zero on failure (already
-    printed an error). macOS-only — detection relies on `ps`/`lsof`.
+    Shared by every CLI subcommand that takes ``--session`` (tag, observe,
+    …). Returns 0 on success (args.session is set), non-zero on failure
+    (already printed an error). macOS-only — detection relies on
+    ``ps``/``lsof``.
     """
     if args.session:
         return 0
@@ -3542,7 +3545,7 @@ def _resolve_tag_session(args) -> int:
         args.session = detected
         return 0
     print(
-        "threadhop tag: could not auto-detect the current session id.\n"
+        f"threadhop {args.command}: could not auto-detect the current session id.\n"
         "  Run this from inside a `claude` terminal, or pass --session <id> explicitly.\n"
         "  (Auto-detection walks the current process tree for a claude CLI ancestor; macOS only — relies on `ps`/`lsof`.)",
         file=sys.stderr,
@@ -3648,7 +3651,80 @@ def build_parser():
         description="List everything in the memory ledger. Use --project/--session to filter.",
     )
 
+    observe_p = subparsers.add_parser(
+        "observe",
+        parents=[shared],
+        help="Run the observer once on a session (on-demand mode)",
+        description=(
+            "Run the Haiku observer on new messages for a session, once. "
+            "Reads from the recorded source_byte_offset, extracts typed "
+            "observations into ~/.config/threadhop/observations/<id>.jsonl, "
+            "and advances the cursor. This is the on-demand mode of the "
+            "observer — the background sidecar / watch mode (task #34) "
+            "lands separately."
+        ),
+    )
+    observe_p.add_argument(
+        "--batch-threshold",
+        type=int,
+        default=observer.BATCH_THRESHOLD,
+        help=(
+            f"Minimum new message turns before extraction runs "
+            f"(default {observer.BATCH_THRESHOLD}). Lower for demos."
+        ),
+    )
+
     return parser
+
+
+def cmd_observe(args) -> int:
+    """Run the observer once for the given session and print a summary.
+
+    Partial implementation of task #34 — on-demand only. No watch mode,
+    no PID tracking, no fsevents — those belong to the background
+    sidecar. This handler is what the demo uses and what the
+    ``/threadhop:observe`` skill will eventually shell out to.
+    """
+    rc = _resolve_cli_session(args)
+    if rc != 0:
+        return rc
+    session_path = find_session_path(args.session)
+    if session_path is None:
+        print(
+            f"threadhop observe: no transcript found for session "
+            f"{args.session} under {CLAUDE_PROJECTS}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    conn = db.init_db()
+    try:
+        # Seed the sessions row so the observer can resolve source_path on
+        # its first run (same pattern the `tag` handler uses).
+        db.upsert_session(
+            conn, args.session, str(session_path),
+            project=session_path.parent.name,
+        )
+        result = observer.observe_session(
+            conn, args.session,
+            batch_threshold=args.batch_threshold,
+        )
+    finally:
+        conn.close()
+
+    print(result.get("message", "(no message)"))
+    if result.get("obs_path"):
+        print(f"  obs file: {result['obs_path']}")
+    if result.get("status") == "extracted":
+        print(
+            f"  cursor:   {result['source_byte_offset']} bytes  "
+            f"({result['entry_count']} observations on file)"
+        )
+    if result.get("status") == "failed":
+        if result.get("stderr"):
+            print(f"  stderr:   {result['stderr']}", file=sys.stderr)
+        return 1
+    return 0
 
 
 def main():
@@ -3658,7 +3734,7 @@ def main():
     if args.command is None:
         return _run_tui(args)
     if args.command == "tag":
-        rc = _resolve_tag_session(args)
+        rc = _resolve_cli_session(args)
         if rc != 0:
             return rc
         # Ensure the session row exists (CLI may run before TUI discovery).
@@ -3678,6 +3754,8 @@ def main():
             conn.close()
         print(f"Tagged session {args.session} as {args.status}")
         return 0
+    if args.command == "observe":
+        return cmd_observe(args)
     return _cli_stub(args.command)
 
 

--- a/threadhop
+++ b/threadhop
@@ -600,9 +600,18 @@ class TranscriptView(VerticalScroll):
 
             count = len(selected)
             noun = "message" if count == 1 else "messages"
-            # Show full path so user can copy it for use in other sessions
+
+            # Copy the export path to clipboard so the user can paste it
+            # directly into another session (e.g. "Read /tmp/threadhop/...")
+            try:
+                subprocess.run(
+                    ["pbcopy"], input=str(export_path).encode(), check=True,
+                )
+            except Exception:
+                pass
+
             app.notify(
-                f"Exported {count} {noun} → {export_path}",
+                f"Exported {count} {noun} → {export_path} (path copied)",
                 timeout=10,
             )
         except Exception as e:

--- a/threadhop
+++ b/threadhop
@@ -3498,6 +3498,13 @@ def detect_current_session_id() -> str | None:
     return None
 
 
+def find_session_path(session_id: str) -> Path | None:
+    """Locate the JSONL transcript for a session ID under ~/.claude/projects/."""
+    for path in CLAUDE_PROJECTS.glob(f"*/{session_id}.jsonl"):
+        return path
+    return None
+
+
 def detect_project_from_cwd() -> str | None:
     """Auto-detect project by matching CWD to Claude's project directory names.
 
@@ -3616,7 +3623,8 @@ def build_parser():
     )
     tag_p.add_argument(
         "status",
-        help="Status value to set (e.g. backlog, in_progress, in_review, done, archived)",
+        choices=db.SESSION_STATUS_ORDER,
+        help="Status value to set",
     )
 
     subparsers.add_parser(
@@ -3653,7 +3661,22 @@ def main():
         rc = _resolve_tag_session(args)
         if rc != 0:
             return rc
-        print(f"threadhop tag: resolved session={args.session} status={args.status} (stub — #16)", file=sys.stderr)
+        # Ensure the session row exists (CLI may run before TUI discovery).
+        session_path = find_session_path(args.session)
+        if session_path is None:
+            print(
+                f"threadhop tag: no transcript found for session {args.session} "
+                f"under {CLAUDE_PROJECTS}.",
+                file=sys.stderr,
+            )
+            return 1
+        conn = db.init_db()
+        try:
+            db.upsert_session(conn, args.session, str(session_path))
+            db.set_session_status(conn, args.session, args.status)
+        finally:
+            conn.close()
+        print(f"Tagged session {args.session} as {args.status}")
         return 0
     return _cli_stub(args.command)
 

--- a/threadhop
+++ b/threadhop
@@ -285,7 +285,8 @@ class TranscriptView(VerticalScroll):
         self._last_mtime = 0
         self._selection_mode = False
         self._selected_index = -1
-        self._range_anchor = -1  # -1 = no range; >= 0 = anchor index
+        self._range_mode = False
+        self._range_anchor = -1
 
     def _get_message_widgets(self):
         """Return all message widgets in order."""
@@ -295,7 +296,7 @@ class TranscriptView(VerticalScroll):
         ]
 
     def on_key(self, event) -> None:
-        """Handle keys for message selection mode."""
+        """Handle keys for message selection and range selection modes."""
         if event.key == "m":
             if self._selection_mode:
                 self._exit_selection_mode()
@@ -304,7 +305,14 @@ class TranscriptView(VerticalScroll):
             event.stop()
             event.prevent_default()
         elif self._selection_mode:
-            if event.key in ("j", "down"):
+            if event.key == "v":
+                if self._range_mode:
+                    self._exit_range_mode()
+                else:
+                    self._enter_range_mode()
+                event.stop()
+                event.prevent_default()
+            elif event.key in ("j", "down"):
                 self._select_next()
                 event.stop()
                 event.prevent_default()
@@ -312,12 +320,11 @@ class TranscriptView(VerticalScroll):
                 self._select_previous()
                 event.stop()
                 event.prevent_default()
-            elif event.key == "v":
-                self._toggle_range()
-                event.stop()
-                event.prevent_default()
             elif event.key == "escape":
-                self._exit_selection_mode()
+                if self._range_mode:
+                    self._exit_range_mode()
+                else:
+                    self._exit_selection_mode()
                 event.stop()
                 event.prevent_default()
 
@@ -326,28 +333,47 @@ class TranscriptView(VerticalScroll):
         if not messages:
             return
         self._selection_mode = True
-        self._range_anchor = -1
         # Start at the last message — recent context is usually what you want
         self._selected_index = len(messages) - 1
         self._update_selection(messages)
         self.app.notify("Selection mode: j/k move, v range, m/Esc exit")
 
     def _exit_selection_mode(self):
+        self._range_mode = False
+        self._range_anchor = -1
         self._clear_selection()
         self._selection_mode = False
         self._selected_index = -1
-        self._range_anchor = -1
         self.border_title = "Transcript"
 
-    def _toggle_range(self):
-        if self._range_anchor >= 0:
-            # Deactivate range, keep cursor where it is
-            self._range_anchor = -1
-            self.app.notify("Range cancelled")
-        else:
-            self._range_anchor = self._selected_index
-            self.app.notify("Range started — move j/k to extend, v to cancel")
+    def _enter_range_mode(self):
+        self._range_mode = True
+        self._range_anchor = self._selected_index
         self._update_selection()
+        self.app.notify("Range select: j/k extend, v/Esc cancel")
+
+    def _exit_range_mode(self):
+        self._range_mode = False
+        self._range_anchor = -1
+        self._update_selection()
+
+    def get_selected_messages(self):
+        """Return the list of message widgets in the current selection.
+
+        Single selection mode returns a one-element list; range mode
+        returns all messages between the anchor and cursor (inclusive).
+        Useful for downstream copy (task #12) and export (task #13).
+        """
+        messages = self._get_message_widgets()
+        if not messages or not self._selection_mode:
+            return []
+        if self._range_mode and self._range_anchor >= 0:
+            lo = min(self._range_anchor, self._selected_index)
+            hi = max(self._range_anchor, self._selected_index)
+            return messages[lo:hi + 1]
+        if 0 <= self._selected_index < len(messages):
+            return [messages[self._selected_index]]
+        return []
 
     def _select_next(self):
         messages = self._get_message_widgets()
@@ -363,44 +389,52 @@ class TranscriptView(VerticalScroll):
         self._selected_index = max(self._selected_index - 1, 0)
         self._update_selection(messages)
 
-    def _get_selected_range(self) -> tuple[int, int]:
-        """Return (start, end) indices of the current selection (inclusive)."""
-        if self._range_anchor >= 0:
-            lo = min(self._range_anchor, self._selected_index)
-            hi = max(self._range_anchor, self._selected_index)
-            return (lo, hi)
-        return (self._selected_index, self._selected_index)
-
     def _update_selection(self, messages=None):
         if messages is None:
             messages = self._get_message_widgets()
-        lo, hi = self._get_selected_range()
+
+        if self._range_mode and self._range_anchor >= 0:
+            lo = min(self._range_anchor, self._selected_index)
+            hi = max(self._range_anchor, self._selected_index)
+        else:
+            lo = hi = -1  # no range
+
         for i, widget in enumerate(messages):
-            if lo <= i <= hi:
+            # Cursor position highlight (single selected message)
+            if i == self._selected_index:
                 widget.add_class("message-selected")
+                widget.scroll_visible()
             else:
                 widget.remove_class("message-selected")
-        # Scroll the cursor (not the anchor) into view
-        if 0 <= self._selected_index < len(messages):
-            messages[self._selected_index].scroll_visible()
-        # Update border title with position info
+            # Range highlight (all messages between anchor and cursor)
+            if lo <= i <= hi:
+                widget.add_class("message-range-selected")
+            else:
+                widget.remove_class("message-range-selected")
+
+        # Update position counter in border title
         total = len(messages)
         pos = self._selected_index + 1
-        count = hi - lo + 1
-        if count > 1:
-            self.border_title = f"Transcript ── SELECT {pos}/{total} ({count} selected)"
+        if self._range_mode and self._range_anchor >= 0:
+            count = hi - lo + 1
+            self.border_title = (
+                f"Transcript ── RANGE {count} selected "
+                f"({pos}/{total}) (j/k extend, v/Esc cancel)"
+            )
         else:
-            self.border_title = f"Transcript ── SELECT {pos}/{total} (j/k move, v range)"
+            self.border_title = f"Transcript ── SELECT {pos}/{total} (j/k move, v range, m/Esc exit)"
 
     def _clear_selection(self):
         for widget in self._get_message_widgets():
             widget.remove_class("message-selected")
+            widget.remove_class("message-range-selected")
 
     async def load_transcript(self, session_path: Path, force: bool = False):
         """Load and display full conversation from transcript"""
+        if self._selection_mode:
+            self._exit_selection_mode()
+
         if not session_path or not session_path.exists():
-            if self._selection_mode:
-                self._exit_selection_mode()
             await self._clear_and_show("No transcript available")
             return
 
@@ -411,15 +445,10 @@ class TranscriptView(VerticalScroll):
                 and session_path == self.current_path
                 and mtime == self._last_mtime
             ):
-                # File unchanged — keep selection mode alive
                 return
             self._last_mtime = mtime
         except:
             pass
-
-        # Transcript is actually reloading — exit selection mode now
-        if self._selection_mode:
-            self._exit_selection_mode()
 
         self.current_path = session_path
 
@@ -734,6 +763,24 @@ class ClaudeSessions(App):
     UserMessage.message-selected,
     AssistantMessage.message-selected,
     ToolMessage.message-selected {
+        background: $warning 20%;
+        border-left: thick $warning;
+        tint: $warning 8%;
+    }
+
+    /* Range selection highlight — softer tint for non-cursor messages */
+    UserMessage.message-range-selected,
+    AssistantMessage.message-range-selected,
+    ToolMessage.message-range-selected {
+        background: $accent 15%;
+        border-left: thick $accent;
+        tint: $accent 5%;
+    }
+
+    /* Cursor within a range — keep the stronger warning highlight */
+    UserMessage.message-selected.message-range-selected,
+    AssistantMessage.message-selected.message-range-selected,
+    ToolMessage.message-selected.message-range-selected {
         background: $warning 20%;
         border-left: thick $warning;
         tint: $warning 8%;

--- a/threadhop
+++ b/threadhop
@@ -8,6 +8,7 @@
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -324,6 +325,10 @@ class TranscriptView(VerticalScroll):
                 self._copy_selection()
                 event.stop()
                 event.prevent_default()
+            elif event.key == "e":
+                self._export_selection()
+                event.stop()
+                event.prevent_default()
             elif event.key == "escape":
                 if self._range_mode:
                     self._exit_range_mode()
@@ -340,7 +345,7 @@ class TranscriptView(VerticalScroll):
         # Start at the last message — recent context is usually what you want
         self._selected_index = len(messages) - 1
         self._update_selection(messages)
-        self.app.notify("Selection mode: j/k move, v range, y copy, m/Esc exit")
+        self.app.notify("Selection mode: j/k move, v range, y copy, e export, m/Esc exit")
 
     def _exit_selection_mode(self):
         self._range_mode = False
@@ -426,7 +431,7 @@ class TranscriptView(VerticalScroll):
                 f"({pos}/{total}) (j/k extend, v/Esc cancel)"
             )
         else:
-            self.border_title = f"Transcript ── SELECT {pos}/{total} (j/k move, v range, m/Esc exit)"
+            self.border_title = f"Transcript ── SELECT {pos}/{total} (j/k move, v range, y/e copy/export, m/Esc exit)"
 
     def _clear_selection(self):
         for widget in self._get_message_widgets():
@@ -503,6 +508,105 @@ class TranscriptView(VerticalScroll):
             app.notify(f"Copied {count} {noun} to clipboard")
         except Exception:
             app.notify("Failed to copy to clipboard", severity="error")
+
+    def _export_selection(self):
+        """Export selected messages to a temp markdown file (ADR-008).
+
+        Writes to /tmp/threadhop/<session_id>-<timestamp>.md.
+        The /tmp directory is auto-cleaned by macOS on reboot — these are
+        ephemeral reference files, not permanent exports. Users reference
+        them from other sessions via: Read /tmp/threadhop/<file>.md
+        """
+        selected = self.get_selected_messages()
+        if not selected:
+            return
+
+        app = self.app
+        session_id = app._selected_session_id or "unknown"
+        session_data = next(
+            (s for s in app.sessions if s.get("session_id") == session_id),
+            None,
+        )
+
+        if session_data:
+            custom_name = app.config.get("session_names", {}).get(session_id)
+            session_name = (
+                custom_name
+                or session_data.get("title")
+                or session_data.get("project", "unknown")
+            )
+            project = session_data.get("project", "")
+            cwd = session_data.get("cwd", "")
+        else:
+            session_name = "unknown"
+            project = ""
+            cwd = ""
+
+        # Build markdown content
+        ts_now = datetime.now().strftime("%Y%m%d-%H%M%S")
+        lines = [
+            f"# Exported from: {session_name}",
+            "",
+            "| Field | Value |",
+            "| --- | --- |",
+            f"| Session ID | `{session_id}` |",
+        ]
+        if project:
+            lines.append(f"| Project | {project} |")
+        if cwd:
+            lines.append(f"| CWD | `{cwd}` |")
+        lines.append(f"| Exported | {datetime.now().strftime('%Y-%m-%d %H:%M:%S')} |")
+        lines.append(f"| Messages | {len(selected)} |")
+        lines.append("")
+        lines.append("---")
+        lines.append("")
+
+        for w in selected:
+            raw = getattr(w, "_raw_text", "")
+            ts = getattr(w, "_timestamp", None)
+            ts_str = ""
+            if ts:
+                try:
+                    dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                    ts_str = dt.strftime("%Y-%m-%d %H:%M:%S")
+                except (ValueError, AttributeError):
+                    pass
+
+            if isinstance(w, UserMessage):
+                role_label = "User"
+            elif isinstance(w, AssistantMessage):
+                role_label = "Claude"
+            else:
+                role_label = "Tool"
+
+            if ts_str:
+                lines.append(f"### {role_label} — {ts_str}")
+            else:
+                lines.append(f"### {role_label}")
+            lines.append("")
+            lines.append(raw)
+            lines.append("")
+
+        content = "\n".join(lines)
+
+        # /tmp/threadhop/ is auto-cleaned by macOS on reboot — no manual
+        # cleanup needed. This is intentional: exports are ephemeral
+        # reference files for cross-session context sharing.
+        export_dir = Path("/tmp/threadhop")
+        try:
+            os.makedirs(export_dir, exist_ok=True)
+            export_path = export_dir / f"{session_id}-{ts_now}.md"
+            export_path.write_text(content)
+
+            count = len(selected)
+            noun = "message" if count == 1 else "messages"
+            # Show full path so user can copy it for use in other sessions
+            app.notify(
+                f"Exported {count} {noun} → {export_path}",
+                timeout=10,
+            )
+        except Exception as e:
+            app.notify(f"Export failed: {e}", severity="error")
 
     async def load_transcript(self, session_path: Path, force: bool = False):
         """Load and display full conversation from transcript"""

--- a/threadhop
+++ b/threadhop
@@ -2951,40 +2951,120 @@ def detect_project_from_cwd() -> str | None:
     return None
 
 
-def main():
+def _cli_stub(command):
+    """Print a stub notice and exit 0. Real implementation lands in later tasks."""
+    print(f"threadhop {command}: not yet implemented (stub)", file=sys.stderr)
+    return 0
+
+
+def _run_tui(args):
+    project = args.project
+    if not project and not args.all:
+        detected = detect_project_from_cwd()
+        if detected:
+            project = detected
+    app = ClaudeSessions(project_filter=project, days=args.days)
+    app.run()
+    return 0
+
+
+def build_parser():
+    # No-subcommand path keeps the original TUI flags (--project/--days/--all).
+    # Subcommands route to CLI mode and share --project/--session via a parent
+    # parser (ADR-011).
     parser = argparse.ArgumentParser(
-        description="TUI transcript viewer for Claude Code sessions"
+        prog="threadhop",
+        description=(
+            "ThreadHop — Claude Code session browser.\n"
+            "  No subcommand  → launch the TUI.\n"
+            "  Subcommand     → CLI mode (tag, todos, decisions, observations)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "--project",
         type=str,
         default=None,
-        help="Filter sessions by project (substring match on directory name)",
+        help="TUI: filter sessions by project (substring match on directory name)",
     )
     parser.add_argument(
         "--days",
         type=int,
         default=10,
-        help="Show sessions from the last N days (default: 10)",
+        help="TUI: show sessions from the last N days (default: 10)",
     )
     parser.add_argument(
         "--all",
         action="store_true",
         default=False,
-        help="Show all projects (ignore CWD auto-detection)",
+        help="TUI: show all projects (ignore CWD auto-detection)",
     )
+
+    # Shared flags for CLI subcommands. Parent parser with add_help=False so
+    # each subcommand inherits --project/--session without duplicating help.
+    shared = argparse.ArgumentParser(add_help=False)
+    shared.add_argument(
+        "--project",
+        type=str,
+        default=None,
+        help="Filter by project (substring match on directory name)",
+    )
+    shared.add_argument(
+        "--session",
+        type=str,
+        default=None,
+        help="Target a specific session id (defaults to current terminal's session)",
+    )
+
+    subparsers = parser.add_subparsers(
+        dest="command",
+        metavar="<command>",
+        title="subcommands",
+    )
+
+    tag_p = subparsers.add_parser(
+        "tag",
+        parents=[shared],
+        help="Tag a session with a status",
+        description="Tag a session with a status (backlog, in_progress, in_review, done, archived).",
+    )
+    tag_p.add_argument(
+        "status",
+        help="Status value to set (e.g. backlog, in_progress, in_review, done, archived)",
+    )
+
+    subparsers.add_parser(
+        "todos",
+        parents=[shared],
+        help="List open TODOs from project memory",
+        description="List open TODOs. Use --project to filter.",
+    )
+
+    subparsers.add_parser(
+        "decisions",
+        parents=[shared],
+        help="List decisions from project memory",
+        description="List decisions. Use --project to filter.",
+    )
+
+    subparsers.add_parser(
+        "observations",
+        parents=[shared],
+        help="List all memory entries (todos, decisions, observations)",
+        description="List everything in the memory ledger. Use --project/--session to filter.",
+    )
+
+    return parser
+
+
+def main():
+    parser = build_parser()
     args = parser.parse_args()
 
-    project = args.project
-    if not project and not args.all:
-        # Auto-detect from CWD
-        detected = detect_project_from_cwd()
-        if detected:
-            project = detected
-
-    app = ClaudeSessions(project_filter=project, days=args.days)
-    app.run()
+    if args.command is None:
+        return _run_tui(args)
+    return _cli_stub(args.command)
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main() or 0)

--- a/threadhop
+++ b/threadhop
@@ -299,6 +299,22 @@ class TranscriptView(VerticalScroll):
         # handler so the match position is visible inside long messages.
         self._pending_scroll_terms: list[str] | None = None
 
+        # Active highlight state — survives transcript reloads so the
+        # 5-second refresh cycle doesn't wipe out search highlights when
+        # the session file's mtime changes (e.g. claude is actively
+        # writing to it). Set in _scroll_to_uuid, cleared by a sidebar
+        # selection (App.on_list_view_highlighted).
+        self._active_highlight_uuid: str | None = None
+        self._active_highlight_terms: list[str] | None = None
+
+        # Foreign-session lock: non-None while showing a transcript
+        # whose source session isn't in the sidebar (cross-project or
+        # out-of-view search jump). Tells App.refresh_transcript to
+        # leave this transcript alone on auto-refresh ticks — otherwise
+        # the refresh would reload whatever the sidebar highlights and
+        # yank the user back to the original view.
+        self._foreign_session_path: Path | None = None
+
     def _get_message_widgets(self):
         """Return all message widgets in order."""
         return [
@@ -723,15 +739,28 @@ class TranscriptView(VerticalScroll):
         # Await mount to ensure all widgets are in the DOM before scrolling
         await self.mount_all(widgets)
 
-        # If the search panel queued a jump-to-source, honor it here —
-        # after the widgets are mounted. Otherwise scroll to the newest
-        # message as usual.
+        # Decide the post-mount scroll behavior, in priority order:
+        #
+        # 1. Search just handed us a jump-to-source → honor it.
+        # 2. A previous jump is still "active" (highlight state survived
+        #    into this reload, e.g. the 5-second refresh hit while the
+        #    user is still reading a match) → re-apply the highlight
+        #    so it isn't lost on every tick.
+        # 3. Normal reload → scroll to the bottom (live tail).
         if self._pending_scroll_uuid is not None:
             target = self._pending_scroll_uuid
             terms = self._pending_scroll_terms
             self._pending_scroll_uuid = None
             self._pending_scroll_terms = None
             self._scroll_to_uuid(target, terms)
+        elif (
+            self._active_highlight_uuid is not None
+            and self._active_highlight_terms
+        ):
+            self._scroll_to_uuid(
+                self._active_highlight_uuid,
+                self._active_highlight_terms,
+            )
         else:
             self.scroll_end(animate=False)
 
@@ -793,6 +822,14 @@ class TranscriptView(VerticalScroll):
                         pass
 
                 self.set_timer(1.5, clear_flash)
+
+                # Remember so we can re-apply after a refresh-driven
+                # reload (file mtime changed) without losing the match
+                # anchor. Cleared by sidebar navigation.
+                self._active_highlight_uuid = uuid
+                self._active_highlight_terms = (
+                    list(search_terms) if search_terms else None
+                )
                 return True
         return False
 
@@ -2224,11 +2261,20 @@ class ClaudeSessions(App):
                                 pass
 
     def refresh_transcript(self) -> None:
+        transcript = self.query_one("#transcript-scroll", TranscriptView)
+
+        # Foreign-session lock: the user jumped from search to a session
+        # that isn't in the sidebar. The sidebar highlight still points
+        # at the ORIGINAL session, so reloading from it here would yank
+        # the transcript panel back to that original — wiping out what
+        # the user is actually reading. Skip the refresh in that case.
+        if transcript._foreign_session_path is not None:
+            return
+
         list_view = self.query_one("#session-list", ListView)
         if list_view.highlighted_child and isinstance(
             list_view.highlighted_child, SessionItem
         ):
-            transcript = self.query_one("#transcript-scroll", TranscriptView)
             # Schedule the async load
             self.call_later(
                 transcript.load_transcript,
@@ -2242,6 +2288,15 @@ class ClaudeSessions(App):
     async def on_list_view_selected(self, event: ListView.Selected) -> None:
         if isinstance(event.item, SessionItem):
             transcript = self.query_one("#transcript-scroll", TranscriptView)
+
+            # Explicit sidebar selection (click / Enter) always ends a
+            # foreign-session search jump, even when the user re-selects
+            # the row that was already highlighted — Highlighted doesn't
+            # fire in that case, but Selected does.
+            transcript._foreign_session_path = None
+            transcript._active_highlight_uuid = None
+            transcript._active_highlight_terms = None
+
             await transcript.load_transcript(event.item.session_data["path"])
 
     async def on_list_view_highlighted(self, event: ListView.Highlighted) -> None:
@@ -2249,6 +2304,17 @@ class ClaudeSessions(App):
             session_id = event.item.session_data.get("session_id")
             self._selected_session_id = session_id
             transcript = self.query_one("#transcript-scroll", TranscriptView)
+
+            # Manual sidebar navigation ends any in-progress search-jump
+            # context. Clear the foreign-session lock AND the active
+            # highlight state so the 5s auto-refresh can resume and new
+            # reloads don't try to re-apply stale highlights. The
+            # search-flow sets these fresh after this handler runs, via
+            # queue_scroll_to_uuid, so same-sidebar jumps aren't broken.
+            transcript._foreign_session_path = None
+            transcript._active_highlight_uuid = None
+            transcript._active_highlight_terms = None
+
             await transcript.load_transcript(event.item.session_data["path"])
 
             if "last_viewed" not in self.config:
@@ -2423,7 +2489,9 @@ class ClaudeSessions(App):
                 break
 
         if target_idx is not None:
-            # Case 1 & 2: session is in the sidebar.
+            # Case 1 & 2: session is in the sidebar. Clear any stale
+            # foreign-session lock from a previous cross-project jump.
+            transcript._foreign_session_path = None
             if list_view.index == target_idx:
                 transcript._pending_scroll_uuid = None
                 transcript._pending_scroll_terms = None
@@ -2456,6 +2524,10 @@ class ClaudeSessions(App):
             return
 
         self._selected_session_id = session_id
+        # Lock the foreign session in so the 5s refresh tick doesn't
+        # reload the sidebar's selection over the top of this panel.
+        # Cleared by the user selecting anything in the sidebar.
+        transcript._foreign_session_path = session_path
         transcript.queue_scroll_to_uuid(message_uuid, search_terms)
         # load_transcript is async; schedule and let the pending scroll
         # fire at the end of the load.

--- a/threadhop
+++ b/threadhop
@@ -294,6 +294,10 @@ class TranscriptView(VerticalScroll):
         # of the next load_transcript() call so the target widget exists
         # by the time we try to scroll to it.
         self._pending_scroll_uuid: str | None = None
+        # Search terms to inline-highlight when _scroll_to_uuid runs.
+        # Populated alongside _pending_scroll_uuid by the search dismiss
+        # handler so the match position is visible inside long messages.
+        self._pending_scroll_terms: list[str] | None = None
 
     def _get_message_widgets(self):
         """Return all message widgets in order."""
@@ -724,35 +728,63 @@ class TranscriptView(VerticalScroll):
         # message as usual.
         if self._pending_scroll_uuid is not None:
             target = self._pending_scroll_uuid
+            terms = self._pending_scroll_terms
             self._pending_scroll_uuid = None
-            self._scroll_to_uuid(target)
+            self._pending_scroll_terms = None
+            self._scroll_to_uuid(target, terms)
         else:
             self.scroll_end(animate=False)
 
-    def queue_scroll_to_uuid(self, uuid: str) -> None:
+    def queue_scroll_to_uuid(
+        self,
+        uuid: str,
+        search_terms: list[str] | None = None,
+    ) -> None:
         """Remember a uuid to scroll into view on the next load_transcript().
 
-        Called by the search dismiss handler before (or in place of)
-        switching sessions. If the transcript is already loaded,
-        _scroll_to_uuid can be called directly instead.
+        When ``search_terms`` is supplied, every occurrence of each term
+        in the target widget gets highlighted so the match is visible
+        inside long messages.
         """
         self._pending_scroll_uuid = uuid
+        self._pending_scroll_terms = search_terms
 
-    def _scroll_to_uuid(self, uuid: str) -> bool:
-        """Scroll the widget with matching _uuid into view and flash-highlight.
+    def _scroll_to_uuid(
+        self,
+        uuid: str,
+        search_terms: list[str] | None = None,
+    ) -> bool:
+        """Scroll to the widget with matching ``_uuid``.
 
-        Returns True if a match was found and scrolled to. We can't
-        scroll to the exact matched token within the message because
-        Rich-rendered Static widgets don't expose per-line positions to
-        Textual — so we scroll the widget's top near the viewport top
-        (with a small offset so the message header isn't flush against
-        the border) and let the flash highlight + the widget itself
-        guide the reader's eye.
+        If ``search_terms`` are supplied, the widget's content is
+        rebuilt with each term highlighted in black-on-yellow so the
+        exact match position is visible even inside long messages. We
+        also try to scroll past the widget's top proportionally to the
+        first match's line offset in the raw text, so a match deep in
+        a long message isn't hidden below the fold. Approximate — line
+        wrapping means it can overshoot or undershoot by a few rows.
         """
         for widget in self._get_message_widgets():
             if getattr(widget, "_uuid", None) == uuid:
+                match_line = 0
+                if search_terms:
+                    # Rebuild with highlights and get back the exact
+                    # rendered-line offset of the first match (computed
+                    # by Rich at the widget's current width).
+                    match_line = self._rebuild_widget_with_highlights(
+                        widget, search_terms
+                    )
                 widget.scroll_visible(animate=False, top=True)
                 widget.add_class("message-selected")
+
+                if match_line > 2:
+                    # A couple lines of breathing room so the message
+                    # header / preceding context stays visible above
+                    # the match.
+                    self.scroll_to(
+                        y=self.scroll_y + match_line - 2,
+                        animate=False,
+                    )
 
                 def clear_flash(w=widget):
                     try:
@@ -763,6 +795,98 @@ class TranscriptView(VerticalScroll):
                 self.set_timer(1.5, clear_flash)
                 return True
         return False
+
+    def _rebuild_widget_with_highlights(
+        self,
+        widget,
+        search_terms: list[str],
+    ) -> int:
+        """Re-render a message widget with search terms highlighted inline.
+
+        Returns the 0-based rendered-line index of the first search
+        match in the rebuilt widget, computed by Rich at the widget's
+        current width. Returns 0 if the widget is empty or the line
+        count couldn't be computed.
+
+        Trade-off: AssistantMessage originally renders its body through
+        Rich's Markdown. To inject highlights reliably we replace the
+        Markdown block with a plain Text body for the single widget —
+        that loses fenced-code / heading formatting on the jumped-to
+        message, but gains a precise visual anchor at the match. The
+        formatting comes back on the next transcript reload.
+        """
+        raw = getattr(widget, "_raw_text", "") or ""
+        if not raw:
+            return 0
+
+        body = Text(raw)
+        for term in search_terms:
+            if not term:
+                continue
+            try:
+                body.highlight_regex(
+                    rf"(?i){re.escape(term)}",
+                    style="bold black on yellow",
+                )
+            except Exception:
+                continue
+
+        if isinstance(widget, UserMessage):
+            new_renderable = Text.assemble(
+                Text("You\n", style="bold cyan"),
+                body,
+            )
+        elif isinstance(widget, AssistantMessage):
+            new_renderable = Group(
+                Text("Claude\n", style="bold green"),
+                body,
+            )
+        else:
+            # ToolMessage: body is already a simple Text block.
+            new_renderable = body
+
+        try:
+            widget.update(new_renderable)
+        except Exception:
+            pass
+
+        # Compute the rendered-line offset of the first match using
+        # Rich's own renderer at the widget's current width. This is
+        # the same layout engine Textual uses internally, so the line
+        # count reflects the actual on-screen layout (wrap, padding,
+        # indentation). Widget padding added by CSS isn't counted here
+        # — that introduces a ±1 row error we absorb with the -2 line
+        # breathing-room offset in the caller.
+        width = widget.size.width
+        if width <= 0:
+            width = self.size.width or 80
+        try:
+            from rich.console import Console
+
+            console = Console(
+                width=width,
+                color_system=None,
+                legacy_windows=False,
+                force_terminal=False,
+                record=False,
+                tab_size=4,
+            )
+            options = console.options.update_width(width)
+            lines = console.render_lines(new_renderable, options, pad=False)
+            lowest = -1
+            for term in search_terms:
+                if not term:
+                    continue
+                needle = term.lower()
+                for i, line in enumerate(lines):
+                    line_text = "".join(s.text for s in line).lower()
+                    if needle in line_text:
+                        if lowest < 0 or i < lowest:
+                            lowest = i
+                        break
+            return max(lowest, 0)
+        except Exception:
+            return 0
 
     async def _remove_all_messages(self):
         """Remove all message widgets, awaiting completion"""
@@ -1329,12 +1453,17 @@ class SearchScreen(ModalScreen):
         lv.index = new_idx
 
     def _open_selected(self) -> None:
-        """Dismiss with (session_id, uuid) from the highlighted result.
+        """Dismiss with (session_id, uuid, search_terms).
 
         Reads ``children[index]`` directly rather than ``highlighted_child``
         because ``highlighted_child`` may not be synchronously up to date
         after a programmatic ``index`` change — the reactive update lands
         on the next message cycle, not before we're called.
+
+        ``search_terms`` is the raw query parsed into prefix-stripped
+        words so the caller can inline-highlight matches in the target
+        widget. Filter tokens (``project:``, ``user:``, ``assistant:``)
+        are not included.
         """
         lv = self.query_one("#search-results", ListView)
         if not lv.children:
@@ -1343,9 +1472,19 @@ class SearchScreen(ModalScreen):
         if idx < 0 or idx >= len(lv.children):
             idx = 0
         item = lv.children[idx]
-        if isinstance(item, SearchResultItem):
-            row = item.result
-            self.dismiss((row["session_id"], row["uuid"]))
+        if not isinstance(item, SearchResultItem):
+            return
+
+        raw_query = ""
+        try:
+            raw_query = self.query_one("#search-input", Input).value or ""
+        except Exception:
+            pass
+        fts_expr, _role, _project = _build_fts_query(raw_query)
+        terms = [t.rstrip("*") for t in fts_expr.split() if t]
+
+        row = item.result
+        self.dismiss((row["session_id"], row["uuid"], terms))
 
 
 class ClaudeSessions(App):
@@ -2242,13 +2381,23 @@ class ClaudeSessions(App):
         """Dismiss callback: the user either selected a row or pressed Esc."""
         if result is None:
             return
+        # Legacy 2-tuple tolerated so stale callers don't break.
         try:
-            session_id, message_uuid = result
+            if len(result) == 3:
+                session_id, message_uuid, terms = result
+            else:
+                session_id, message_uuid = result
+                terms = None
         except (TypeError, ValueError):
             return
-        self._jump_to_search_result(session_id, message_uuid)
+        self._jump_to_search_result(session_id, message_uuid, terms)
 
-    def _jump_to_search_result(self, session_id: str, message_uuid: str) -> None:
+    def _jump_to_search_result(
+        self,
+        session_id: str,
+        message_uuid: str,
+        search_terms: list[str] | None = None,
+    ) -> None:
         """Switch to ``session_id`` and scroll its transcript to ``message_uuid``.
 
         Three cases:
@@ -2277,13 +2426,14 @@ class ClaudeSessions(App):
             # Case 1 & 2: session is in the sidebar.
             if list_view.index == target_idx:
                 transcript._pending_scroll_uuid = None
-                if not transcript._scroll_to_uuid(message_uuid):
+                transcript._pending_scroll_terms = None
+                if not transcript._scroll_to_uuid(message_uuid, search_terms):
                     self.notify(
                         "Message not found in loaded transcript",
                         severity="warning",
                     )
             else:
-                transcript.queue_scroll_to_uuid(message_uuid)
+                transcript.queue_scroll_to_uuid(message_uuid, search_terms)
                 list_view.index = target_idx
             list_view.focus()
             return
@@ -2306,7 +2456,7 @@ class ClaudeSessions(App):
             return
 
         self._selected_session_id = session_id
-        transcript.queue_scroll_to_uuid(message_uuid)
+        transcript.queue_scroll_to_uuid(message_uuid, search_terms)
         # load_transcript is async; schedule and let the pending scroll
         # fire at the end of the load.
         self.call_later(transcript.load_transcript, session_path)

--- a/threadhop
+++ b/threadhop
@@ -10,6 +10,7 @@ import argparse
 import json
 import os
 import re
+import sqlite3
 import subprocess
 import sys
 from datetime import datetime, timedelta
@@ -22,7 +23,8 @@ from rich.text import Text
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical, VerticalScroll
-from textual.widgets import Footer, Header, ListItem, ListView, Static, TextArea
+from textual.screen import ModalScreen
+from textual.widgets import Footer, Header, Input, ListItem, ListView, Static, TextArea
 from textual.worker import Worker
 
 # Local package: SQLite DB module (init, migrations, session helpers).
@@ -288,6 +290,10 @@ class TranscriptView(VerticalScroll):
         self._selected_index = -1
         self._range_mode = False
         self._range_anchor = -1
+        # Queued by the search-result dismiss handler: applied at the end
+        # of the next load_transcript() call so the target widget exists
+        # by the time we try to scroll to it.
+        self._pending_scroll_uuid: str | None = None
 
     def _get_message_widgets(self):
         """Return all message widgets in order."""
@@ -653,10 +659,13 @@ class TranscriptView(VerticalScroll):
                 return
             lines = Text()
             first_ts = None
+            first_uuid = None
             raw_parts = []
-            for j, (tr, tc, ts) in enumerate(tool_batch):
+            for j, (tr, tc, ts, tu) in enumerate(tool_batch):
                 if first_ts is None:
                     first_ts = ts
+                if first_uuid is None:
+                    first_uuid = tu
                 if tr == "tool":
                     lines.append("⚙ ", style="dim yellow")
                     lines.append(str(tc) if tc else "", style="dim")
@@ -670,12 +679,13 @@ class TranscriptView(VerticalScroll):
             w = ToolMessage(lines)
             w._raw_text = "\n".join(raw_parts)
             w._timestamp = first_ts
+            w._uuid = first_uuid
             widgets.append(w)
             tool_batch.clear()
 
-        for role, content, timestamp in messages:
+        for role, content, timestamp, uuid in messages:
             if role in ("tool", "tool_result"):
-                tool_batch.append((role, content, timestamp))
+                tool_batch.append((role, content, timestamp, uuid))
                 continue
 
             flush_tools()
@@ -687,6 +697,7 @@ class TranscriptView(VerticalScroll):
                 w = UserMessage(user_text)
                 w._raw_text = str(content) if content else ""
                 w._timestamp = timestamp
+                w._uuid = uuid
                 widgets.append(w)
             else:
                 header = Text()
@@ -700,13 +711,54 @@ class TranscriptView(VerticalScroll):
                 w = AssistantMessage(Group(*renderables))
                 w._raw_text = str(content) if content else ""
                 w._timestamp = timestamp
+                w._uuid = uuid
                 widgets.append(w)
 
         flush_tools()
 
         # Await mount to ensure all widgets are in the DOM before scrolling
         await self.mount_all(widgets)
-        self.scroll_end(animate=False)
+
+        # If the search panel queued a jump-to-source, honor it here —
+        # after the widgets are mounted. Otherwise scroll to the newest
+        # message as usual.
+        if self._pending_scroll_uuid is not None:
+            target = self._pending_scroll_uuid
+            self._pending_scroll_uuid = None
+            self._scroll_to_uuid(target)
+        else:
+            self.scroll_end(animate=False)
+
+    def queue_scroll_to_uuid(self, uuid: str) -> None:
+        """Remember a uuid to scroll into view on the next load_transcript().
+
+        Called by the search dismiss handler before (or in place of)
+        switching sessions. If the transcript is already loaded,
+        _scroll_to_uuid can be called directly instead.
+        """
+        self._pending_scroll_uuid = uuid
+
+    def _scroll_to_uuid(self, uuid: str) -> bool:
+        """Scroll the widget with matching _uuid into view and flash-highlight.
+
+        Returns True if a match was found and scrolled to. The flash
+        highlight uses the existing `.message-selected` class so no new
+        CSS is needed.
+        """
+        for widget in self._get_message_widgets():
+            if getattr(widget, "_uuid", None) == uuid:
+                widget.scroll_visible(animate=False, top=True)
+                widget.add_class("message-selected")
+
+                def clear_flash(w=widget):
+                    try:
+                        w.remove_class("message-selected")
+                    except Exception:
+                        pass
+
+                self.set_timer(1.5, clear_flash)
+                return True
+        return False
 
     async def _remove_all_messages(self):
         """Remove all message widgets, awaiting completion"""
@@ -718,10 +770,14 @@ class TranscriptView(VerticalScroll):
         await self._remove_all_messages()
         await self.mount(AssistantMessage(text))
 
-    def _parse_messages(self, session_path: Path) -> list[tuple[str, str, str | None]]:
+    def _parse_messages(
+        self, session_path: Path
+    ) -> list[tuple[str, str, str | None, str | None]]:
         """Parse JSONL file and extract displayable messages.
 
-        Returns list of (role, content, timestamp) tuples.
+        Returns list of (role, content, timestamp, uuid) tuples. The uuid
+        is the JSONL line's own uuid — used by the search jump-to-source
+        flow to scroll the correct widget into view.
         """
         messages = []
         try:
@@ -731,6 +787,7 @@ class TranscriptView(VerticalScroll):
                         msg = json.loads(line)
                         msg_type = msg.get("type")
                         timestamp = msg.get("timestamp")
+                        uuid = msg.get("uuid")
 
                         # Only process user and assistant messages
                         if msg_type not in ("user", "assistant"):
@@ -741,7 +798,7 @@ class TranscriptView(VerticalScroll):
                             if tool_result and isinstance(tool_result, dict):
                                 result_info = self._format_tool_result(tool_result)
                                 if result_info:
-                                    messages.append(("tool_result", result_info, timestamp))
+                                    messages.append(("tool_result", result_info, timestamp, uuid))
                             elif "toolUseResult" not in msg:
                                 content = msg.get("message", {}).get("content", "")
                                 if isinstance(content, list):
@@ -755,7 +812,7 @@ class TranscriptView(VerticalScroll):
                                     # Strip system-reminder tags
                                     content = SYSTEM_REMINDER_RE.sub("", content).strip()
                                     if content:
-                                        messages.append(("user", content, timestamp))
+                                        messages.append(("user", content, timestamp, uuid))
 
                         elif msg_type == "assistant":
                             content = msg.get("message", {}).get("content", [])
@@ -774,10 +831,10 @@ class TranscriptView(VerticalScroll):
                                         tool_desc = self._format_tool_use(
                                             tool_name, tool_input
                                         )
-                                        messages.append(("tool", tool_desc, timestamp))
+                                        messages.append(("tool", tool_desc, timestamp, uuid))
                                 if text_parts:
                                     messages.append(
-                                        ("assistant", " ".join(text_parts), timestamp)
+                                        ("assistant", " ".join(text_parts), timestamp, uuid)
                                     )
                     except (json.JSONDecodeError, KeyError):
                         pass
@@ -849,6 +906,436 @@ class TranscriptView(VerticalScroll):
             return status
 
         return None
+
+
+# --- Real-time search panel (task #14, ADR-002 / ADR-007) -----------------
+#
+# FTS5 prefix matching against the `messages` table populated by the
+# indexer. Each keystroke in the search input debounces (~80 ms) and
+# re-runs the query. Results render as a ListView of SearchResultItem
+# rows; dismissing the modal with a selection jumps the main TUI to the
+# source message.
+#
+# Filter syntax parsed from the raw query string:
+#   project:<name>  — substring match against sessions.project
+#   user:           — only role = 'user'
+#   assistant:      — only role = 'assistant'
+# Remaining whitespace-separated tokens become FTS5 prefix terms.
+
+# Sentinel characters bracketing matched spans in the SQL `snippet()`
+# output. Using control chars avoids collisions with user text. Parsed
+# back out by `_render_snippet` into Rich Text with a highlight style.
+_FTS_MATCH_START = "\x01"
+_FTS_MATCH_END = "\x02"
+
+
+def _build_fts_query(raw: str) -> tuple[str, str | None, str | None]:
+    """Parse raw input into (fts_match_expr, role_filter, project_filter).
+
+    The FTS5 expression uses AND semantics across prefix terms
+    (e.g. ``rate* lim*``). Non-filter tokens are sanitized to word chars
+    only so stray punctuation can't produce an invalid MATCH expression.
+    An empty expression means no searchable terms were supplied —
+    callers may still return filter-only results (see `search_messages`).
+    """
+    tokens = raw.strip().split()
+    role: str | None = None
+    project: str | None = None
+    terms: list[str] = []
+    for tok in tokens:
+        low = tok.lower()
+        if low == "user:":
+            role = "user"
+        elif low == "assistant:":
+            role = "assistant"
+        elif low.startswith("project:"):
+            val = tok[len("project:"):]
+            if val:
+                project = val
+        else:
+            # Keep only word chars (letters/digits/underscore). FTS5's
+            # unicode61 tokenizer is fine with these, and stripping
+            # punctuation prevents syntax errors at MATCH time.
+            clean = re.sub(r"[^\w]", "", tok)
+            if clean:
+                terms.append(clean + "*")
+    return " ".join(terms), role, project
+
+
+def search_messages(
+    conn: sqlite3.Connection,
+    raw_query: str,
+    limit: int = 50,
+) -> list[dict]:
+    """Run the FTS5 search for the search panel.
+
+    Returns rows with keys: uuid, session_id, role, timestamp, snippet,
+    custom_name, project, session_path. ``snippet`` contains
+    _FTS_MATCH_START / _FTS_MATCH_END sentinels around each match span.
+
+    A malformed FTS5 expression (shouldn't happen after sanitization, but
+    defensive) returns an empty list rather than propagating the
+    exception up into the TUI event loop.
+    """
+    fts_expr, role, project = _build_fts_query(raw_query)
+
+    # No search terms: allow a filter-only query so typing just
+    # `project:foo` lists recent messages in that project.
+    if not fts_expr:
+        if not role and not project:
+            return []
+        sql = (
+            "SELECT m.uuid AS uuid, m.session_id AS session_id, "
+            "m.role AS role, m.timestamp AS timestamp, "
+            "substr(m.text, 1, 160) AS snippet, "
+            "s.custom_name AS custom_name, s.project AS project, "
+            "s.session_path AS session_path "
+            "FROM messages m "
+            "LEFT JOIN sessions s ON s.session_id = m.session_id "
+            "WHERE 1=1"
+        )
+        params: dict = {}
+        if role:
+            sql += " AND m.role = :role"
+            params["role"] = role
+        if project:
+            sql += " AND s.project LIKE :project"
+            params["project"] = f"%{project}%"
+        sql += " ORDER BY m.timestamp DESC LIMIT :lim"
+        params["lim"] = limit
+        try:
+            return db.query_all(conn, sql, params)
+        except sqlite3.OperationalError:
+            return []
+
+    sql = (
+        "SELECT m.uuid AS uuid, m.session_id AS session_id, "
+        "m.role AS role, m.timestamp AS timestamp, "
+        "snippet(messages_fts, 0, :mstart, :mend, '…', 16) AS snippet, "
+        "s.custom_name AS custom_name, s.project AS project, "
+        "s.session_path AS session_path "
+        "FROM messages_fts "
+        "JOIN messages m ON m.rowid = messages_fts.rowid "
+        "LEFT JOIN sessions s ON s.session_id = m.session_id "
+        "WHERE messages_fts MATCH :q"
+    )
+    params = {
+        "q": fts_expr,
+        "mstart": _FTS_MATCH_START,
+        "mend": _FTS_MATCH_END,
+    }
+    if role:
+        sql += " AND m.role = :role"
+        params["role"] = role
+    if project:
+        sql += " AND s.project LIKE :project"
+        params["project"] = f"%{project}%"
+    sql += " ORDER BY rank LIMIT :lim"
+    params["lim"] = limit
+
+    try:
+        return db.query_all(conn, sql, params)
+    except sqlite3.OperationalError:
+        # Malformed expressions still slip through on edge cases
+        # (e.g. a bare `*`). Surface as "no results" rather than crash.
+        return []
+
+
+def _render_snippet(snippet: str) -> Text:
+    """Convert an FTS5 snippet with sentinel-wrapped matches to Rich Text."""
+    out = Text()
+    remaining = snippet or ""
+    while True:
+        i = remaining.find(_FTS_MATCH_START)
+        if i < 0:
+            out.append(remaining)
+            break
+        out.append(remaining[:i])
+        remaining = remaining[i + len(_FTS_MATCH_START):]
+        j = remaining.find(_FTS_MATCH_END)
+        if j < 0:
+            # Unterminated — highlight the rest and stop.
+            out.append(remaining, style="bold black on yellow")
+            break
+        out.append(remaining[:j], style="bold black on yellow")
+        remaining = remaining[j + len(_FTS_MATCH_END):]
+    return out
+
+
+class SearchResultItem(ListItem):
+    """One row in the search-results list.
+
+    Holds the raw result dict so the dismiss handler can pull the
+    session_id + uuid for jump-to-source without another DB lookup.
+    """
+
+    def __init__(self, row: dict):
+        self.result = row
+        super().__init__()
+
+    def compose(self) -> ComposeResult:
+        role = self.result.get("role", "")
+        role_icon = "▶" if role == "user" else "●"
+        role_style = "bold cyan" if role == "user" else "bold green"
+
+        # Snippet line: colored role marker + highlighted text span.
+        snippet_line = Text()
+        snippet_line.append(f"{role_icon} ", style=role_style)
+        snippet_line.append_text(
+            _render_snippet(self.result.get("snippet") or "")
+        )
+
+        # Metadata line: session name · project · formatted timestamp.
+        session_name = (
+            self.result.get("custom_name")
+            or self.result.get("project")
+            or (self.result.get("session_id", "") or "")[:8]
+        )
+        project = self.result.get("project") or ""
+        ts_raw = self.result.get("timestamp") or ""
+        ts_str = ts_raw[:16]
+        try:
+            dt = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+            ts_str = dt.strftime("%Y-%m-%d %H:%M")
+        except (ValueError, AttributeError):
+            pass
+
+        meta = Text()
+        meta.append("  ", style="dim")
+        meta.append(str(session_name), style="bold")
+        if project and project != session_name:
+            meta.append("  ·  ", style="dim")
+            meta.append(str(project), style="cyan")
+        meta.append("  ·  ", style="dim")
+        meta.append(ts_str, style="dim")
+
+        yield Static(Group(snippet_line, meta), classes="search-result")
+
+
+class SearchScreen(ModalScreen):
+    """Modal full-text search over indexed messages (task #14).
+
+    Focus stays on the Input; arrow keys (and Ctrl+N/Ctrl+P) navigate
+    the results list without losing typing focus — matches common
+    fuzzy-finder UX (fzf, Helm). Enter returns ``(session_id, uuid)``
+    to the dismiss callback; Escape dismisses with ``None``.
+    """
+
+    # Debounce delay between keystroke and the FTS query. 80 ms keeps
+    # typing responsive while avoiding a query per character on fast
+    # typists — plenty of headroom over FTS5's sub-ms query time.
+    DEBOUNCE_SECONDS = 0.08
+
+    # The app binds `enter` with priority=True to start_reply_or_send, and
+    # app priority bindings fire even while a modal is up. Re-bind enter
+    # here with priority so the modal wins and Input.Submitted actually
+    # reaches our handler.
+    BINDINGS = [
+        Binding("enter", "open_result", "Open", priority=True, show=False),
+    ]
+
+    CSS = """
+    SearchScreen {
+        align: center top;
+    }
+
+    #search-container {
+        width: 90%;
+        max-width: 120;
+        height: 80%;
+        margin-top: 2;
+        background: $surface;
+        border: thick $accent;
+        layout: vertical;
+    }
+
+    #search-input {
+        margin: 0;
+        border: none;
+        background: $boost;
+    }
+
+    #search-input:focus {
+        background: $boost;
+    }
+
+    #search-results {
+        height: 1fr;
+        background: $surface;
+    }
+
+    #search-status {
+        height: 1;
+        padding: 0 1;
+        color: $text-muted;
+        background: $boost;
+    }
+
+    #search-help {
+        height: 1;
+        padding: 0 1;
+        color: $text-muted;
+        background: $boost;
+        text-style: italic;
+    }
+
+    .search-result {
+        padding: 0 1;
+    }
+
+    SearchResultItem {
+        padding: 0;
+    }
+    """
+
+    def __init__(self, conn: sqlite3.Connection):
+        super().__init__()
+        self.conn = conn
+        # Single outstanding debounce timer. Each new keystroke stops
+        # the previous timer before scheduling the next one, so only
+        # the final keystroke in a typing burst triggers a query.
+        self._search_timer = None
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="search-container") as container:
+            container.border_title = "Search"
+            yield Input(
+                placeholder=(
+                    "Search (prefix match) — "
+                    "filters: project:<name> user: assistant:"
+                ),
+                id="search-input",
+            )
+            yield Static("Type to search…", id="search-status")
+            yield ListView(id="search-results")
+            yield Static(
+                "↑/↓ or ctrl+n/ctrl+p navigate • Enter jump • Esc close",
+                id="search-help",
+            )
+
+    def on_mount(self) -> None:
+        self.query_one("#search-input", Input).focus()
+
+    def on_input_changed(self, event) -> None:
+        """Debounced re-run on every keystroke."""
+        try:
+            if event.input.id != "search-input":
+                return
+        except AttributeError:
+            return
+        if self._search_timer is not None:
+            try:
+                self._search_timer.stop()
+            except Exception:
+                pass
+        value = event.value
+        self._search_timer = self.set_timer(
+            self.DEBOUNCE_SECONDS, lambda v=value: self._execute_search(v)
+        )
+
+    def _execute_search(self, raw_query: str) -> None:
+        results_list = self.query_one("#search-results", ListView)
+        status = self.query_one("#search-status", Static)
+
+        raw = raw_query.strip()
+        if not raw:
+            results_list.clear()
+            status.update("Type to search…")
+            return
+
+        try:
+            rows = search_messages(self.conn, raw, limit=50)
+        except Exception as e:  # noqa: BLE001
+            results_list.clear()
+            status.update(f"Search error: {e}")
+            return
+
+        results_list.clear()
+        for row in rows:
+            results_list.append(SearchResultItem(row))
+
+        count = len(rows)
+        if count == 0:
+            status.update("No results")
+        else:
+            noun = "result" if count == 1 else "results"
+            status.update(
+                f"{count} {noun}" + (" (showing first 50)" if count >= 50 else "")
+            )
+
+    def on_key(self, event) -> None:
+        """Intercept nav / Escape keys while the Input holds focus.
+
+        Arrow keys and Ctrl+N/P aren't bound by Input so they bubble up
+        to here. Escape isn't bound by Input either. Enter IS bound by
+        Input (fires Submitted), so it's handled via on_input_submitted
+        below rather than here.
+        """
+        key = event.key
+        if key == "escape":
+            event.stop()
+            event.prevent_default()
+            self.dismiss(None)
+        elif key in ("down", "ctrl+n"):
+            event.stop()
+            event.prevent_default()
+            self._move_selection(1)
+        elif key in ("up", "ctrl+p"):
+            event.stop()
+            event.prevent_default()
+            self._move_selection(-1)
+
+    def action_open_result(self) -> None:
+        """Enter → open the highlighted result.
+
+        Fires via the screen-level priority Enter binding. As a safety
+        net, ``on_input_submitted`` below catches the Input.Submitted
+        message too — either path lands at _open_selected.
+        """
+        self._open_selected()
+
+    def on_input_submitted(self, event) -> None:
+        """Safety net: if Input's own enter binding fires first, its
+        Submitted message bubbles up to here. Treat it the same as the
+        screen-level binding — dismiss with the highlighted row.
+        """
+        try:
+            if event.input.id != "search-input":
+                return
+        except AttributeError:
+            return
+        event.stop()
+        self._open_selected()
+
+    def _move_selection(self, delta: int) -> None:
+        lv = self.query_one("#search-results", ListView)
+        count = len(lv.children)
+        if count == 0:
+            return
+        if lv.index is None:
+            lv.index = 0 if delta > 0 else count - 1
+            return
+        new_idx = max(0, min(count - 1, lv.index + delta))
+        lv.index = new_idx
+
+    def _open_selected(self) -> None:
+        """Dismiss with (session_id, uuid) from the highlighted result.
+
+        Reads ``children[index]`` directly rather than ``highlighted_child``
+        because ``highlighted_child`` may not be synchronously up to date
+        after a programmatic ``index`` change — the reactive update lands
+        on the next message cycle, not before we're called.
+        """
+        lv = self.query_one("#search-results", ListView)
+        if not lv.children:
+            return
+        idx = lv.index if lv.index is not None else 0
+        if idx < 0 or idx >= len(lv.children):
+            idx = 0
+        item = lv.children[idx]
+        if isinstance(item, SearchResultItem):
+            row = item.result
+            self.dismiss((row["session_id"], row["uuid"]))
 
 
 class ClaudeSessions(App):
@@ -1002,7 +1489,7 @@ class ClaudeSessions(App):
         Binding("g", "copy_session_id", "Copy ID"),
         Binding("enter", "start_reply_or_send", "Reply/Send", show=True, priority=True),
         Binding("alt+enter", "insert_newline", "Newline", show=False),
-        Binding("/", "start_reply", "Reply", show=False),
+        Binding("/", "open_search", "Search"),
         Binding("escape", "cancel_reply", "Cancel", show=False),
         Binding("right", "focus_transcript", "Transcript", show=False),
         Binding("left", "focus_list", "Sessions", show=False),
@@ -1728,6 +2215,80 @@ class ClaudeSessions(App):
                     list_view.highlighted_child.session_data.get("session_id")
                 )
             text_area.focus()
+
+    def action_open_search(self) -> None:
+        """Open the real-time FTS5 search panel (task #14).
+
+        Skips when the reply input has focus so `/` types normally while
+        the user is composing a message. Dismissing with a selection
+        routes through `_jump_to_search_result` to switch sessions and
+        scroll to the source message.
+        """
+        if self._input_has_focus():
+            return
+        self.push_screen(SearchScreen(self.conn), self._on_search_dismissed)
+
+    def _on_search_dismissed(self, result) -> None:
+        """Dismiss callback: the user either selected a row or pressed Esc."""
+        if result is None:
+            return
+        try:
+            session_id, message_uuid = result
+        except (TypeError, ValueError):
+            return
+        self._jump_to_search_result(session_id, message_uuid)
+
+    def _jump_to_search_result(self, session_id: str, message_uuid: str) -> None:
+        """Switch to ``session_id`` and scroll its transcript to ``message_uuid``.
+
+        If the target session isn't currently in the sidebar (e.g. older
+        than ``--days`` or archived with view off), surface a toast
+        rather than silently no-op'ing.
+        """
+        list_view = self.query_one("#session-list", ListView)
+        transcript = self.query_one("#transcript-scroll", TranscriptView)
+
+        target_idx: int | None = None
+        for i, item in enumerate(list_view.children):
+            if (
+                isinstance(item, SessionItem)
+                and item.session_data.get("session_id") == session_id
+            ):
+                target_idx = i
+                break
+
+        if target_idx is None:
+            self.notify(
+                "Source session not in current view "
+                "(try increasing --days or toggling archive view)",
+                severity="warning",
+                timeout=6,
+            )
+            return
+
+        # Already on the target session: transcript is loaded, just scroll.
+        # Otherwise queue the scroll so it runs at the end of the load
+        # that the highlight change will trigger.
+        if list_view.index == target_idx:
+            transcript._pending_scroll_uuid = None
+            if not transcript._scroll_to_uuid(message_uuid):
+                self.notify("Message not found in loaded transcript", severity="warning")
+        else:
+            transcript.queue_scroll_to_uuid(message_uuid)
+            list_view.index = target_idx
+
+        list_view.focus()
+
+    def check_action(self, action: str, parameters):
+        """Disable the priority Enter binding while a modal is up.
+
+        Returning False here tells Textual the binding doesn't match, so
+        the key event passes through to the modal screen's own bindings
+        and widgets instead of being swallowed by this app-level handler.
+        """
+        if action == "start_reply_or_send" and len(self.screen_stack) > 1:
+            return False
+        return True
 
     def action_start_reply_or_send(self) -> None:
         """If in list/transcript, go to reply. If in reply, send message."""


### PR DESCRIPTION
## Summary
- Introduce shared `COMMAND_REGISTRY` covering app-level bindings and widget-local modes (session list, transcript, selection, reply, find, search). `ClaudeSessions.BINDINGS` is now derived from it.
- Add `HelpScreen` modal grouped by scope (opens on `?`, closes on Esc / `?` / `q`) with pretty-printed keys.
- Replace stock `Footer` with `ContextualFooter` that renders only scope-relevant hints and refreshes on focus / selection-mode / find-bar changes.
- Help trigger is `?` — deliberately not `H`, per ADR-017, to leave room for upcoming handoff shortcut work.

Implements ADR-017 (task #42).

## Test plan
- [x] `pytest tests/` — 70/70 pass
- [x] Headless Textual app boots, `?` pushes `HelpScreen`, Esc pops it
- [x] `ContextualFooter.render_for` produces scope-appropriate hints for global / session_list / selection / reply / find / transcript
- [ ] Manual TUI smoke: open app, press `?` to inspect overlay, confirm footer changes when toggling selection mode (`m`) and find bar (`Ctrl+F`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)