### PR TITLE
Add watch-mode loop on top of observer core (task #19)

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -112,8 +112,8 @@ _Observer-first architecture. Observer uses `claude -p --model haiku --permissio
 
   _(ADR-010, ADR-018, ADR-019)_
 
-- [ ] **19. Incremental observer processing (byte offset per session)** *(blocked by: #18)*
-  The incremental logic is built into task #18's Step 1-2 (read from `source_byte_offset`, not byte 0). This task covers the **watch mode** layer on top: after the initial extraction, continue monitoring the source JSONL for growth. When the file grows and the batch threshold is met again, re-run Steps 2-7. Uses `observation_state.source_byte_offset` as the cursor. On-demand mode: run once and exit. Background mode: loop with fsevents/polling. _(ADR-010, ADR-019)_
+- [x] **19. Incremental observer processing (byte offset per session)** *(blocked by: #18)*
+  **DONE.** `observer.watch_session()` is the watch-mode layer on top of `observe_session()`. Runs an initial catch-up extraction, then polls `source_path.stat().st_size` and re-invokes the observer whenever the file has grown past the recorded cursor. Polling is the ADR-015 fallback; the per-iteration `sleep_fn` is the swap point where task #34 can plug in fsevents/kqueue without breaking the contract. Failures are tallied and never raised, so transient Haiku errors don't kill the watcher. Tests in `tests/test_observer.py::TestWatchSession`. _(ADR-010, ADR-015, ADR-019)_
 
 - [ ] **34. Build background observer sidecar (`threadhop observe`)** *(blocked by: #18, #19)*
   Background process mode for the observer (ADR-015). `threadhop observe --session <id>` watches the session's JSONL via fsevents (macOS) with polling fallback. Batches new messages (~3-4 trigger extraction). Records PID in `observation_state.observer_pid`. Exits when Claude Code session ends or `--stop` is sent. _(ADR-015)_

--- a/observer.py
+++ b/observer.py
@@ -40,9 +40,10 @@ import json
 import shutil
 import sqlite3
 import subprocess
+import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import db
 import indexer
@@ -64,6 +65,13 @@ PROMPT_PATH = Path(__file__).resolve().parent / "prompts" / "observer.md"
 # first call of a session can pay an auth/warmup cost, and extremely large
 # chunks (first-time catch-up on a long transcript) take longer.
 DEFAULT_TIMEOUT_SEC = 180.0
+
+# Default poll cadence for the watch-mode loop. Haiku itself takes seconds
+# to respond, so sub-second polling buys nothing — 1.0s keeps the loop
+# responsive without burning CPU on stat() calls. Background sidecars that
+# care about lower latency can swap in fsevents/kqueue without changing the
+# public API (see ``watch_session``'s docstring).
+WATCH_POLL_INTERVAL_SEC = 1.0
 
 # Known observation types, in display order for the summary line.
 _TYPE_ORDER = ("decision", "todo", "done", "adr", "observation", "conflict")
@@ -483,3 +491,217 @@ def observe_session(
         "obs_path": str(obs_path),
         "message": _summary_message(turns, by_type),
     }
+
+
+# --- Watch mode -----------------------------------------------------------
+
+
+def _resolve_source_path(
+    conn: sqlite3.Connection,
+    session_id: str,
+    explicit: str | Path | None,
+) -> Path | None:
+    """Resolve the source JSONL path for ``session_id``.
+
+    Same precedence as ``observe_session``: explicit override → state row
+    → sessions row. Returns ``None`` if no path is known anywhere.
+    Centralised here so the watch loop can detect a missing source up
+    front rather than discovering it inside the first observer call.
+    """
+    if explicit is not None:
+        return Path(explicit)
+    state = db.get_observation_state(conn, session_id)
+    if state is not None and state["source_path"]:
+        return Path(state["source_path"])
+    sess = db.get_session(conn, session_id)
+    if sess is not None and sess.get("session_path"):
+        return Path(sess["session_path"])
+    return None
+
+
+def _current_offset(
+    conn: sqlite3.Connection,
+    session_id: str,
+    fallback: int = 0,
+) -> int:
+    """Return the observer's recorded byte offset for ``session_id``.
+
+    Falls back to ``fallback`` when no state row exists yet — this happens
+    on the very first iteration before observe_session has had a chance to
+    seed the row.
+    """
+    state = db.get_observation_state(conn, session_id)
+    if state is None:
+        return fallback
+    return int(state["source_byte_offset"])
+
+
+def watch_session(
+    conn: sqlite3.Connection,
+    session_id: str,
+    *,
+    source_path: str | Path | None = None,
+    batch_threshold: int = BATCH_THRESHOLD,
+    poll_interval_sec: float = WATCH_POLL_INTERVAL_SEC,
+    claude_bin: str = "claude",
+    timeout: float = DEFAULT_TIMEOUT_SEC,
+    prompt_path: Path | None = None,
+    should_stop: Callable[[], bool] | None = None,
+    max_iterations: int | None = None,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    on_result: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    """Loop ``observe_session`` over ``session_id`` until told to stop.
+
+    The on-demand path (``observe_session``) already handles the
+    incremental "read from ``source_byte_offset``" logic; this function
+    is the **watch-mode** layer that lives on top of it. After the
+    initial catch-up extraction, it monitors the source JSONL for growth
+    and re-invokes the observer whenever the file has grown past the
+    current cursor — gated by ``observe_session``'s own batch-threshold
+    check, so cheap "1 new turn" updates don't pay for a Haiku call.
+
+    The implementation polls ``Path.stat().st_size``. Polling is the
+    "fallback" half of the ADR-015 design ("fsevents on macOS, polling
+    fallback") — it's correct everywhere and adds zero deps. A future
+    background sidecar (task #34) can replace the wait step with kqueue
+    / fsevents for sub-second latency without changing this function's
+    contract: the only swap point is the per-iteration sleep, which is
+    already injectable via ``sleep_fn``.
+
+    Args:
+        conn: Open DB connection with the schema applied.
+        session_id: Claude Code session UUID to watch.
+        source_path: Override for the source JSONL path. Resolved from
+            the ``observation_state`` / ``sessions`` rows otherwise.
+        batch_threshold: Forwarded to each ``observe_session`` call.
+        poll_interval_sec: Seconds between size checks. Defaults to
+            ``WATCH_POLL_INTERVAL_SEC`` (1.0s).
+        claude_bin: Forwarded to ``observe_session``.
+        timeout: Forwarded to ``observe_session``.
+        prompt_path: Forwarded to ``observe_session``.
+        should_stop: Optional callable polled before every iteration.
+            Returning ``True`` exits the loop with status ``stopped``.
+            Background sidecars wire this to a SIGTERM-set flag.
+        max_iterations: Optional cap on iteration count after the
+            initial catch-up. Primarily for tests so they don't have to
+            rely on the stop callback to terminate.
+        sleep_fn: Injected sleep function. Tests pass a no-op so the
+            loop runs at full speed.
+        on_result: Optional callback invoked with the full result dict
+            of every ``observe_session`` call (catch-up included). Lets
+            sidecars stream summaries to the user without coupling this
+            function to a specific output format.
+
+    Returns:
+        A summary dict::
+
+            {
+              "status":     "stopped" | "source_gone" | "max_iterations",
+              "iterations": <int>,         # loop ticks past the catch-up
+              "extractions": <int>,        # observe_session "extracted" runs
+              "below_threshold_runs": <int>,
+              "failures":   <int>,         # observe_session "failed" runs
+              "last_result": <dict | None> # last observe_session() return
+            }
+
+        Never raises on expected failures — the loop swallows
+        ``observe_session`` failures (so transient Haiku errors don't
+        kill the watcher) and reports them via ``on_result`` and the
+        ``failures`` counter. The only fatal condition is the source
+        JSONL disappearing, which exits with ``status="source_gone"``.
+    """
+    resolved = _resolve_source_path(conn, session_id, source_path)
+    if resolved is None or not resolved.exists():
+        return {
+            "status": "source_gone",
+            "iterations": 0,
+            "extractions": 0,
+            "below_threshold_runs": 0,
+            "failures": 0,
+            "last_result": None,
+        }
+
+    extractions = 0
+    below_threshold_runs = 0
+    failures = 0
+    last_result: dict[str, Any] | None = None
+
+    def _run_once() -> dict[str, Any]:
+        """Invoke observe_session and tally the outcome."""
+        nonlocal extractions, below_threshold_runs, failures, last_result
+        result = observe_session(
+            conn,
+            session_id,
+            source_path=resolved,
+            batch_threshold=batch_threshold,
+            claude_bin=claude_bin,
+            timeout=timeout,
+            prompt_path=prompt_path,
+        )
+        last_result = result
+        status = result.get("status")
+        if status == "extracted":
+            extractions += 1
+        elif status == "below_threshold":
+            below_threshold_runs += 1
+        elif status == "failed":
+            failures += 1
+        if on_result is not None:
+            on_result(result)
+        return result
+
+    # --- Catch-up: always run once so the cursor is current before we
+    # start watching. observe_session() handles the "no new bytes" case
+    # itself (status="up_to_date"), so this is safe even if the file is
+    # already fully observed.
+    _run_once()
+
+    iterations = 0
+    while True:
+        if should_stop is not None and should_stop():
+            return {
+                "status": "stopped",
+                "iterations": iterations,
+                "extractions": extractions,
+                "below_threshold_runs": below_threshold_runs,
+                "failures": failures,
+                "last_result": last_result,
+            }
+        if max_iterations is not None and iterations >= max_iterations:
+            return {
+                "status": "max_iterations",
+                "iterations": iterations,
+                "extractions": extractions,
+                "below_threshold_runs": below_threshold_runs,
+                "failures": failures,
+                "last_result": last_result,
+            }
+
+        # Source JSONL gone (deleted, moved): exit cleanly. Truncation
+        # (file shrank but still exists) is observe_session's problem —
+        # it rewinds the cursor to 0 and re-reads, so the watcher just
+        # keeps going on the next growth event.
+        try:
+            size = resolved.stat().st_size
+        except FileNotFoundError:
+            return {
+                "status": "source_gone",
+                "iterations": iterations,
+                "extractions": extractions,
+                "below_threshold_runs": below_threshold_runs,
+                "failures": failures,
+                "last_result": last_result,
+            }
+
+        offset = _current_offset(conn, session_id)
+        # Any growth past the cursor is a candidate. observe_session
+        # itself decides whether the new bytes contain enough complete
+        # turns to warrant a Haiku call — when they don't, it returns
+        # below_threshold without advancing the offset, and we'll retry
+        # on the next growth event for free (no subprocess cost).
+        if size > offset:
+            _run_once()
+
+        sleep_fn(poll_interval_sec)
+        iterations += 1

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -514,3 +514,287 @@ class TestObserveSession:
         assert result["status"] == "extracted"
         # All 3 turns should be read (cursor rewound to 0).
         assert result["turns"] == 3
+
+
+# --- Watch-mode tests ------------------------------------------------------
+
+
+class _StopAfter:
+    """should_stop helper: returns False until called ``after`` times.
+
+    Using a class instead of a closure makes the call count inspectable
+    from the tests so we can assert how many polls actually happened.
+    """
+
+    def __init__(self, after: int) -> None:
+        self.after = after
+        self.calls = 0
+
+    def __call__(self) -> bool:
+        self.calls += 1
+        return self.calls > self.after
+
+
+class TestWatchSession:
+    """The watch loop is the layer on top of observe_session that polls
+    for source-file growth and re-invokes the observer. These tests
+    exercise the loop's branches with a no-op sleep and either a stop
+    callback or ``max_iterations`` to terminate deterministically.
+    """
+
+    def test_runs_initial_catch_up_then_stops(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        # 3 turns waiting at start — meets threshold for the catch-up run.
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "hi"),
+            _assistant_line("a1", "m1", "yo"),
+            _user_line("u2", "more"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+        claude = fake_claude([
+            {"type": "decision", "text": "x", "context": "",
+             "ts": "2026-04-17T10:00:00Z"},
+        ])
+
+        results: list[dict] = []
+        result = observer.watch_session(
+            conn, "sess-1",
+            claude_bin=str(claude),
+            should_stop=_StopAfter(0),  # exit before the first poll iteration
+            sleep_fn=lambda _: None,
+            on_result=results.append,
+        )
+
+        assert result["status"] == "stopped"
+        assert result["extractions"] == 1
+        assert result["iterations"] == 0
+        # The catch-up call propagated through on_result.
+        assert len(results) == 1
+        assert results[0]["status"] == "extracted"
+
+    def test_no_growth_means_observer_not_re_invoked(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        # Same shape as above. After the catch-up advances the cursor
+        # to EOF, no further growth occurs, so the loop should not call
+        # observe_session again no matter how many times it polls.
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "a"),
+            _assistant_line("a1", "m1", "b"),
+            _user_line("u2", "c"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+        claude = fake_claude([
+            {"type": "decision", "text": "x", "context": "",
+             "ts": "2026-04-17T10:00:00Z"},
+        ])
+
+        result = observer.watch_session(
+            conn, "sess-1",
+            claude_bin=str(claude),
+            max_iterations=5,
+            sleep_fn=lambda _: None,
+        )
+
+        assert result["status"] == "max_iterations"
+        # Only the catch-up extraction happened — no further calls.
+        assert result["extractions"] == 1
+        assert result["iterations"] == 5
+        # Observation file unchanged after catch-up.
+        obs_path = obs_dir / "sess-1.jsonl"
+        assert len(obs_path.read_text().strip().splitlines()) == 1
+
+    def test_growth_after_catch_up_triggers_extraction(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        # Catch-up consumes 3 turns; then before each poll we append
+        # more turns and confirm the loop re-extracts.
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "a"),
+            _assistant_line("a1", "m1", "b"),
+            _user_line("u2", "c"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        # Single fake claude — appends one canned line per invocation.
+        # Each call to observe_session triggers exactly one append.
+        claude = fake_claude([
+            {"type": "decision", "text": "x", "context": "",
+             "ts": "2026-04-17T10:00:00Z"},
+        ])
+
+        # The "growth driver" runs as our sleep_fn: every time the loop
+        # sleeps, we append 3 more turns to the source. That guarantees
+        # growth is visible on the very next size check.
+        appends_left = [2]
+
+        def grow_then_sleep(_):
+            if appends_left[0] <= 0:
+                return
+            appends_left[0] -= 1
+            with open(jsonl, "a") as f:
+                f.write(_user_line(f"u-extra-{appends_left[0]}", "q") + "\n")
+                f.write(_assistant_line(
+                    f"a-extra-{appends_left[0]}",
+                    f"m-extra-{appends_left[0]}", "a") + "\n")
+                f.write(_user_line(f"u-extra2-{appends_left[0]}", "q2") + "\n")
+
+        result = observer.watch_session(
+            conn, "sess-1",
+            claude_bin=str(claude),
+            max_iterations=3,
+            sleep_fn=grow_then_sleep,
+        )
+
+        assert result["status"] == "max_iterations"
+        # 1 catch-up + 2 growth-triggered runs = 3 total extractions.
+        assert result["extractions"] == 3
+
+    def test_below_threshold_growth_does_not_advance_cursor(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        """A 1-turn append after catch-up triggers an observe call but
+        observe_session returns 'below_threshold' without advancing the
+        cursor — and counts as below_threshold_runs in the summary.
+        """
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "a"),
+            _assistant_line("a1", "m1", "b"),
+            _user_line("u2", "c"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+        claude = fake_claude([
+            {"type": "decision", "text": "x", "context": "",
+             "ts": "2026-04-17T10:00:00Z"},
+        ])
+
+        # First sleep: append exactly one new turn (below the 3-turn
+        # threshold). All later sleeps are no-ops.
+        appended = [False]
+
+        def sleep_fn(_):
+            if appended[0]:
+                return
+            appended[0] = True
+            with open(jsonl, "a") as f:
+                f.write(_user_line("u-extra", "tiny") + "\n")
+
+        cursor_before_loop = jsonl.stat().st_size
+
+        result = observer.watch_session(
+            conn, "sess-1",
+            claude_bin=str(claude),
+            max_iterations=2,
+            sleep_fn=sleep_fn,
+        )
+
+        assert result["extractions"] == 1  # just the catch-up
+        assert result["below_threshold_runs"] == 1
+        # The state cursor stayed at the catch-up EOF — observe_session
+        # is not allowed to advance past bytes it didn't ship to Haiku.
+        state = db.get_observation_state(conn, "sess-1")
+        assert state is not None
+        assert state["source_byte_offset"] == cursor_before_loop
+
+    def test_source_disappears_returns_source_gone(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "a"),
+            _assistant_line("a1", "m1", "b"),
+            _user_line("u2", "c"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+        claude = fake_claude([
+            {"type": "decision", "text": "x", "context": "",
+             "ts": "2026-04-17T10:00:00Z"},
+        ])
+
+        deleted = [False]
+
+        def delete_then_sleep(_):
+            if deleted[0]:
+                return
+            deleted[0] = True
+            jsonl.unlink()
+
+        result = observer.watch_session(
+            conn, "sess-1",
+            claude_bin=str(claude),
+            max_iterations=10,
+            sleep_fn=delete_then_sleep,
+        )
+
+        assert result["status"] == "source_gone"
+        # The catch-up still ran before the file went away.
+        assert result["extractions"] == 1
+
+    def test_missing_source_skips_catch_up(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        # No sessions row, no state row — the watcher must not try to
+        # call observe_session at all (it would fail with no_source).
+        result = observer.watch_session(
+            conn, "ghost-sess",
+            claude_bin=str(fake_claude([])),
+            max_iterations=3,
+            sleep_fn=lambda _: None,
+        )
+        assert result["status"] == "source_gone"
+        assert result["extractions"] == 0
+        assert result["iterations"] == 0
+
+    def test_subprocess_failure_does_not_kill_the_loop(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        # Catch-up will fail (claude exits non-zero). The loop must
+        # keep going — failures are tallied, not raised.
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "a"),
+            _assistant_line("a1", "m1", "b"),
+            _user_line("u2", "c"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+        claude = fake_claude("#!/usr/bin/env bash\nexit 7\n")
+
+        result = observer.watch_session(
+            conn, "sess-1",
+            claude_bin=str(claude),
+            max_iterations=2,
+            sleep_fn=lambda _: None,
+        )
+
+        assert result["status"] == "max_iterations"
+        assert result["failures"] >= 1
+        assert result["extractions"] == 0
+
+    def test_should_stop_polled_each_iteration(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        # No real source — we just want to prove should_stop is consulted
+        # before max_iterations and exits cleanly.
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "a"),
+            _assistant_line("a1", "m1", "b"),
+            _user_line("u2", "c"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+        claude = fake_claude([
+            {"type": "decision", "text": "x", "context": "",
+             "ts": "2026-04-17T10:00:00Z"},
+        ])
+        stop = _StopAfter(3)
+
+        result = observer.watch_session(
+            conn, "sess-1",
+            claude_bin=str(claude),
+            should_stop=stop,
+            max_iterations=100,
+            sleep_fn=lambda _: None,
+        )
+
+        assert result["status"] == "stopped"
+        # Polled at the top of every iteration; exits on the 4th call.
+        assert stop.calls == 4
+        assert result["iterations"] == 3


### PR DESCRIPTION
## Summary
- New `observer.watch_session()` — the watch-mode layer on top of `observe_session()` from task #18. Runs an initial catch-up call, then polls `Path.stat().st_size` and re-invokes the observer whenever the source JSONL grows past the recorded `source_byte_offset`.
- Polling is the ADR-015 fallback. The per-iteration `sleep_fn` is the documented swap point where task #34's background sidecar can plug in fsevents/kqueue without changing the public API.
- Subprocess failures are tallied (not raised) so transient Haiku errors don't kill a long-lived watcher. The only fatal condition is the source JSONL disappearing → `status="source_gone"`.
- `docs/TASKS.md` task #19 marked `[x]`.

## Test plan
- [x] `python3 -m pytest tests/test_observer.py -v` — 25/25 (8 new in `TestWatchSession`)
- [x] `python3 -m pytest` — full suite 78/78
- [ ] Manual smoke: run `watch_session` against a live `~/.claude/projects/.../<id>.jsonl` and confirm extractions trigger as messages append (deferred to task #34 sidecar wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)