### PR TITLE
[codex] Implement threadhop todos CLI query

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**ThreadHop** is a single-file Textual TUI for browsing, searching, and carrying context across Claude Code session transcripts. macOS-only — uses `ps`/`lsof` for active session detection.
+**ThreadHop** is a Textual TUI plus CLI for browsing, searching, and carrying context across Claude Code session transcripts. macOS-only — uses `ps`/`lsof` for active session detection.
 
 The project is expanding from a transcript viewer into a cross-session context manager with SQLite FTS search, project memory, session tagging, and a skill plugin for handoff generation. See `docs/DESIGN-DECISIONS.md` for the full architecture.
 
@@ -16,13 +16,22 @@ The project is expanding from a transcript viewer into a cross-session context m
 
 # With filters
 ./threadhop --project myproject --days 7
+
+# CLI query mode
+./threadhop todos
+./threadhop todos --project myproject
 ```
 
 No build step. The script uses `uv run --script` with PEP 723 inline metadata. Only dependency: `textual>=0.89.0`.
 
 ## Architecture
 
-**Single file**: `threadhop` (~1,345 lines Python) — everything lives here.
+Core modules:
+- `threadhop` — executable entry point, TUI, argparse routing, CLI handlers
+- `db.py` — SQLite schema, migrations, session / observation-state helpers
+- `indexer.py` — transcript normalization and FTS ingestion
+- `observer.py` — on-demand observer orchestration over transcript byte ranges
+- `observation_queries.py` — CLI query helpers for reading per-session observation JSONL
 
 ### Key Classes
 
@@ -38,6 +47,7 @@ No build step. The script uses `uv run --script` with PEP 723 inline metadata. O
 2. **Active detection**: `_get_active_claude_sessions()` runs `ps -eo pid,args`, finds `claude` processes, resolves CWD via `lsof -a -d cwd -p <pid>`, matches to session IDs
 3. **Display**: `_update_session_list()` diffs old/new session lists — full rebuild on change, in-place spinner updates otherwise
 4. **Transcript**: `load_transcript()` parses full JSONL, strips `<system-reminder>` tags, abbreviates tool calls, mounts message widgets
+5. **Observation CLI**: `threadhop todos` silently runs observer catch-up for already-tracked sessions, then reads `~/.config/threadhop/observations/<session_id>.jsonl` and prints compact JSONL rows newest-first
 
 ### Session State
 
@@ -46,7 +56,7 @@ No build step. The script uses `uv run --script` with PEP 723 inline metadata. O
 
 ### Persistent Config
 
-`~/.config/threadhop/config.json` stores theme, custom session names, session order, and last-viewed timestamps (for unread detection). Will migrate to SQLite in Phase 1.
+`~/.config/threadhop/config.json` stores app-level settings like theme. Session metadata and observation state live in SQLite at `~/.config/threadhop/sessions.db`.
 
 ## Styling
 
@@ -66,8 +76,8 @@ Every message line has native fields useful for indexing:
 - `sessionId`, `timestamp`, `cwd`, `isSidechain`
 - Assistant messages: multiple lines share the same `message.id` (streaming chunks) — must be merged for search
 
-## Planned Architecture (not yet implemented)
+## In Progress
 
-- SQLite database at `~/.config/threadhop/sessions.db` for session metadata, FTS index, bookmarks, project memory
-- Skill plugin: `/threadhop:handoff <session_id>` for LLM-compressed session handoffs
-- See `docs/DESIGN-DECISIONS.md` for full schema and implementation plan
+- Observation-backed CLI queries are landing incrementally: `todos` is implemented, `decisions` / `observations` remain stubs
+- Skill plugin work such as `/threadhop:handoff <session_id>` still depends on the observer pipeline
+- See `docs/DESIGN-DECISIONS.md` for the detailed rollout plan

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -112,8 +112,8 @@ _Observer-first architecture. Observer uses `claude -p --model haiku --permissio
 
   _(ADR-010, ADR-018, ADR-019)_
 
-- [ ] **19. Incremental observer processing (byte offset per session)** *(blocked by: #18)*
-  The incremental logic is built into task #18's Step 1-2 (read from `source_byte_offset`, not byte 0). This task covers the **watch mode** layer on top: after the initial extraction, continue monitoring the source JSONL for growth. When the file grows and the batch threshold is met again, re-run Steps 2-7. Uses `observation_state.source_byte_offset` as the cursor. On-demand mode: run once and exit. Background mode: loop with fsevents/polling. _(ADR-010, ADR-019)_
+- [x] **19. Incremental observer processing (byte offset per session)** *(blocked by: #18)*
+  **DONE.** `observer.watch_session()` is the watch-mode layer on top of `observe_session()`. Runs an initial catch-up extraction, then polls `source_path.stat().st_size` and re-invokes the observer whenever the file has grown past the recorded cursor. Polling is the ADR-015 fallback; the per-iteration `sleep_fn` is the swap point where task #34 can plug in fsevents/kqueue without breaking the contract. Failures are tallied and never raised, so transient Haiku errors don't kill the watcher. Tests in `tests/test_observer.py::TestWatchSession`. _(ADR-010, ADR-015, ADR-019)_
 
 - [ ] **34. Build background observer sidecar (`threadhop observe`)** *(blocked by: #18, #19)*
   Background process mode for the observer (ADR-015). `threadhop observe --session <id>` watches the session's JSONL via fsevents (macOS) with polling fallback. Batches new messages (~3-4 trigger extraction). Records PID in `observation_state.observer_pid`. Exits when Claude Code session ends or `--stop` is sent. _(ADR-015)_

--- a/observation_queries.py
+++ b/observation_queries.py
@@ -1,0 +1,221 @@
+"""Helpers for observation-backed CLI queries.
+
+The query commands share the same shape:
+
+1. Run the on-demand observer for any already-tracked sessions so byte
+   offsets are current.
+2. Read per-session observation JSONL files from ``db.OBS_DIR``.
+3. Filter / normalize rows for grep- and jq-friendly CLI output.
+
+This module stays free of TUI dependencies so it can be unit-tested
+directly without importing the executable ``threadhop`` script.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, Iterable
+
+import db
+import observer
+
+
+def _session_rows_for_filter(
+    conn: sqlite3.Connection,
+    *,
+    project: str | None = None,
+    session_id: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return matching session rows for CLI filters.
+
+    ``--project`` keeps the existing CLI semantics: case-insensitive
+    substring match against ``sessions.project``.
+    """
+    clauses: list[str] = []
+    params: list[Any] = []
+
+    if session_id:
+        clauses.append("session_id = ?")
+        params.append(session_id)
+    if project:
+        clauses.append("LOWER(COALESCE(project, '')) LIKE ?")
+        params.append(f"%{project.lower()}%")
+
+    sql = "SELECT session_id, project FROM sessions"
+    if clauses:
+        sql += " WHERE " + " AND ".join(clauses)
+    return db.query_all(conn, sql, tuple(params))
+
+
+def _tracked_session_ids(
+    conn: sqlite3.Connection,
+    *,
+    project: str | None = None,
+    session_id: str | None = None,
+) -> list[str]:
+    """Return sessions with persisted observer state, optionally filtered."""
+    clauses: list[str] = []
+    params: list[Any] = []
+
+    if session_id:
+        clauses.append("os.session_id = ?")
+        params.append(session_id)
+    if project:
+        clauses.append("LOWER(COALESCE(s.project, '')) LIKE ?")
+        params.append(f"%{project.lower()}%")
+
+    sql = (
+        "SELECT os.session_id "
+        "FROM observation_state os "
+        "LEFT JOIN sessions s ON s.session_id = os.session_id"
+    )
+    if clauses:
+        sql += " WHERE " + " AND ".join(clauses)
+    rows = db.query_all(conn, sql, tuple(params))
+    return [row["session_id"] for row in rows]
+
+
+def refresh_unprocessed_observations(
+    conn: sqlite3.Connection,
+    *,
+    project: str | None = None,
+    session_id: str | None = None,
+    batch_threshold: int = observer.BATCH_THRESHOLD,
+) -> list[dict[str, Any]]:
+    """Run the observer once for matching already-tracked sessions.
+
+    Query commands are catch-up consumers of the observer. They should not
+    implicitly start observation for brand-new sessions with no prior
+    state, but they *should* keep existing observation files current.
+    """
+    results: list[dict[str, Any]] = []
+    for sid in _tracked_session_ids(conn, project=project, session_id=session_id):
+        result = observer.observe_session(
+            conn,
+            sid,
+            batch_threshold=batch_threshold,
+        )
+        result["session_id"] = sid
+        results.append(result)
+    return results
+
+
+def _observation_files(
+    conn: sqlite3.Connection,
+    *,
+    project: str | None = None,
+    session_id: str | None = None,
+) -> list[Path]:
+    """Return observation files to read for a query."""
+    if session_id:
+        path = db.OBS_DIR / f"{session_id}.jsonl"
+        return [path] if path.exists() else []
+
+    if project:
+        rows = _session_rows_for_filter(conn, project=project)
+        paths: list[Path] = []
+        for row in rows:
+            path = db.OBS_DIR / f"{row['session_id']}.jsonl"
+            if path.exists():
+                paths.append(path)
+        return paths
+
+    return sorted(db.OBS_DIR.glob("*.jsonl"))
+
+
+def _project_map(
+    conn: sqlite3.Connection,
+    session_ids: Iterable[str],
+) -> dict[str, str]:
+    session_ids = list(dict.fromkeys(session_ids))
+    if not session_ids:
+        return {}
+    placeholders = ",".join("?" for _ in session_ids)
+    rows = db.query_all(
+        conn,
+        (
+            "SELECT session_id, COALESCE(project, '') AS project "
+            f"FROM sessions WHERE session_id IN ({placeholders})"
+        ),
+        tuple(session_ids),
+    )
+    return {row["session_id"]: row["project"] for row in rows}
+
+
+def list_observation_entries(
+    conn: sqlite3.Connection,
+    *,
+    observation_type: str | None = None,
+    project: str | None = None,
+    session_id: str | None = None,
+) -> list[dict[str, str]]:
+    """Read observation JSONL files and return normalized entries.
+
+    Returned rows are sorted newest-first and shaped for CLI output:
+    ``project``, ``session``, ``timestamp``, ``text``, plus ``type`` for
+    callers that need it.
+    """
+    files = _observation_files(conn, project=project, session_id=session_id)
+    project_by_session = _project_map(
+        conn,
+        [path.stem for path in files],
+    )
+
+    entries: list[dict[str, Any]] = []
+    order = 0
+    for path in files:
+        sid = path.stem
+        try:
+            with path.open() as fh:
+                for raw_line in fh:
+                    line = raw_line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(entry, dict):
+                        continue
+                    if observation_type and entry.get("type") != observation_type:
+                        continue
+                    entries.append(
+                        {
+                            "project": project_by_session.get(sid, ""),
+                            "session": sid,
+                            "timestamp": str(entry.get("ts") or ""),
+                            "text": str(entry.get("text") or ""),
+                            "type": str(entry.get("type") or ""),
+                            "_order": order,
+                        }
+                    )
+                    order += 1
+        except OSError:
+            continue
+
+    entries.sort(
+        key=lambda row: (row["timestamp"], row["_order"]),
+        reverse=True,
+    )
+    for entry in entries:
+        entry.pop("_order", None)
+    return entries
+
+
+def format_entry_json(
+    entry: dict[str, str],
+    *,
+    include_type: bool = False,
+) -> str:
+    """Serialize an observation row as one compact JSON object."""
+    payload = {
+        "project": entry["project"],
+        "session": entry["session"],
+        "timestamp": entry["timestamp"],
+        "text": entry["text"],
+    }
+    if include_type:
+        payload["type"] = entry["type"]
+    return json.dumps(payload, separators=(",", ":"))

--- a/observer.py
+++ b/observer.py
@@ -40,9 +40,10 @@ import json
 import shutil
 import sqlite3
 import subprocess
+import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import db
 import indexer
@@ -64,6 +65,13 @@ PROMPT_PATH = Path(__file__).resolve().parent / "prompts" / "observer.md"
 # first call of a session can pay an auth/warmup cost, and extremely large
 # chunks (first-time catch-up on a long transcript) take longer.
 DEFAULT_TIMEOUT_SEC = 180.0
+
+# Default poll cadence for the watch-mode loop. Haiku itself takes seconds
+# to respond, so sub-second polling buys nothing — 1.0s keeps the loop
+# responsive without burning CPU on stat() calls. Background sidecars that
+# care about lower latency can swap in fsevents/kqueue without changing the
+# public API (see ``watch_session``'s docstring).
+WATCH_POLL_INTERVAL_SEC = 1.0
 
 # Known observation types, in display order for the summary line.
 _TYPE_ORDER = ("decision", "todo", "done", "adr", "observation", "conflict")
@@ -483,3 +491,217 @@ def observe_session(
         "obs_path": str(obs_path),
         "message": _summary_message(turns, by_type),
     }
+
+
+# --- Watch mode -----------------------------------------------------------
+
+
+def _resolve_source_path(
+    conn: sqlite3.Connection,
+    session_id: str,
+    explicit: str | Path | None,
+) -> Path | None:
+    """Resolve the source JSONL path for ``session_id``.
+
+    Same precedence as ``observe_session``: explicit override → state row
+    → sessions row. Returns ``None`` if no path is known anywhere.
+    Centralised here so the watch loop can detect a missing source up
+    front rather than discovering it inside the first observer call.
+    """
+    if explicit is not None:
+        return Path(explicit)
+    state = db.get_observation_state(conn, session_id)
+    if state is not None and state["source_path"]:
+        return Path(state["source_path"])
+    sess = db.get_session(conn, session_id)
+    if sess is not None and sess.get("session_path"):
+        return Path(sess["session_path"])
+    return None
+
+
+def _current_offset(
+    conn: sqlite3.Connection,
+    session_id: str,
+    fallback: int = 0,
+) -> int:
+    """Return the observer's recorded byte offset for ``session_id``.
+
+    Falls back to ``fallback`` when no state row exists yet — this happens
+    on the very first iteration before observe_session has had a chance to
+    seed the row.
+    """
+    state = db.get_observation_state(conn, session_id)
+    if state is None:
+        return fallback
+    return int(state["source_byte_offset"])
+
+
+def watch_session(
+    conn: sqlite3.Connection,
+    session_id: str,
+    *,
+    source_path: str | Path | None = None,
+    batch_threshold: int = BATCH_THRESHOLD,
+    poll_interval_sec: float = WATCH_POLL_INTERVAL_SEC,
+    claude_bin: str = "claude",
+    timeout: float = DEFAULT_TIMEOUT_SEC,
+    prompt_path: Path | None = None,
+    should_stop: Callable[[], bool] | None = None,
+    max_iterations: int | None = None,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    on_result: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    """Loop ``observe_session`` over ``session_id`` until told to stop.
+
+    The on-demand path (``observe_session``) already handles the
+    incremental "read from ``source_byte_offset``" logic; this function
+    is the **watch-mode** layer that lives on top of it. After the
+    initial catch-up extraction, it monitors the source JSONL for growth
+    and re-invokes the observer whenever the file has grown past the
+    current cursor — gated by ``observe_session``'s own batch-threshold
+    check, so cheap "1 new turn" updates don't pay for a Haiku call.
+
+    The implementation polls ``Path.stat().st_size``. Polling is the
+    "fallback" half of the ADR-015 design ("fsevents on macOS, polling
+    fallback") — it's correct everywhere and adds zero deps. A future
+    background sidecar (task #34) can replace the wait step with kqueue
+    / fsevents for sub-second latency without changing this function's
+    contract: the only swap point is the per-iteration sleep, which is
+    already injectable via ``sleep_fn``.
+
+    Args:
+        conn: Open DB connection with the schema applied.
+        session_id: Claude Code session UUID to watch.
+        source_path: Override for the source JSONL path. Resolved from
+            the ``observation_state`` / ``sessions`` rows otherwise.
+        batch_threshold: Forwarded to each ``observe_session`` call.
+        poll_interval_sec: Seconds between size checks. Defaults to
+            ``WATCH_POLL_INTERVAL_SEC`` (1.0s).
+        claude_bin: Forwarded to ``observe_session``.
+        timeout: Forwarded to ``observe_session``.
+        prompt_path: Forwarded to ``observe_session``.
+        should_stop: Optional callable polled before every iteration.
+            Returning ``True`` exits the loop with status ``stopped``.
+            Background sidecars wire this to a SIGTERM-set flag.
+        max_iterations: Optional cap on iteration count after the
+            initial catch-up. Primarily for tests so they don't have to
+            rely on the stop callback to terminate.
+        sleep_fn: Injected sleep function. Tests pass a no-op so the
+            loop runs at full speed.
+        on_result: Optional callback invoked with the full result dict
+            of every ``observe_session`` call (catch-up included). Lets
+            sidecars stream summaries to the user without coupling this
+            function to a specific output format.
+
+    Returns:
+        A summary dict::
+
+            {
+              "status":     "stopped" | "source_gone" | "max_iterations",
+              "iterations": <int>,         # loop ticks past the catch-up
+              "extractions": <int>,        # observe_session "extracted" runs
+              "below_threshold_runs": <int>,
+              "failures":   <int>,         # observe_session "failed" runs
+              "last_result": <dict | None> # last observe_session() return
+            }
+
+        Never raises on expected failures — the loop swallows
+        ``observe_session`` failures (so transient Haiku errors don't
+        kill the watcher) and reports them via ``on_result`` and the
+        ``failures`` counter. The only fatal condition is the source
+        JSONL disappearing, which exits with ``status="source_gone"``.
+    """
+    resolved = _resolve_source_path(conn, session_id, source_path)
+    if resolved is None or not resolved.exists():
+        return {
+            "status": "source_gone",
+            "iterations": 0,
+            "extractions": 0,
+            "below_threshold_runs": 0,
+            "failures": 0,
+            "last_result": None,
+        }
+
+    extractions = 0
+    below_threshold_runs = 0
+    failures = 0
+    last_result: dict[str, Any] | None = None
+
+    def _run_once() -> dict[str, Any]:
+        """Invoke observe_session and tally the outcome."""
+        nonlocal extractions, below_threshold_runs, failures, last_result
+        result = observe_session(
+            conn,
+            session_id,
+            source_path=resolved,
+            batch_threshold=batch_threshold,
+            claude_bin=claude_bin,
+            timeout=timeout,
+            prompt_path=prompt_path,
+        )
+        last_result = result
+        status = result.get("status")
+        if status == "extracted":
+            extractions += 1
+        elif status == "below_threshold":
+            below_threshold_runs += 1
+        elif status == "failed":
+            failures += 1
+        if on_result is not None:
+            on_result(result)
+        return result
+
+    # --- Catch-up: always run once so the cursor is current before we
+    # start watching. observe_session() handles the "no new bytes" case
+    # itself (status="up_to_date"), so this is safe even if the file is
+    # already fully observed.
+    _run_once()
+
+    iterations = 0
+    while True:
+        if should_stop is not None and should_stop():
+            return {
+                "status": "stopped",
+                "iterations": iterations,
+                "extractions": extractions,
+                "below_threshold_runs": below_threshold_runs,
+                "failures": failures,
+                "last_result": last_result,
+            }
+        if max_iterations is not None and iterations >= max_iterations:
+            return {
+                "status": "max_iterations",
+                "iterations": iterations,
+                "extractions": extractions,
+                "below_threshold_runs": below_threshold_runs,
+                "failures": failures,
+                "last_result": last_result,
+            }
+
+        # Source JSONL gone (deleted, moved): exit cleanly. Truncation
+        # (file shrank but still exists) is observe_session's problem —
+        # it rewinds the cursor to 0 and re-reads, so the watcher just
+        # keeps going on the next growth event.
+        try:
+            size = resolved.stat().st_size
+        except FileNotFoundError:
+            return {
+                "status": "source_gone",
+                "iterations": iterations,
+                "extractions": extractions,
+                "below_threshold_runs": below_threshold_runs,
+                "failures": failures,
+                "last_result": last_result,
+            }
+
+        offset = _current_offset(conn, session_id)
+        # Any growth past the cursor is a candidate. observe_session
+        # itself decides whether the new bytes contain enough complete
+        # turns to warrant a Haiku call — when they don't, it returns
+        # below_threshold without advancing the offset, and we'll retry
+        # on the next growth event for free (no subprocess cost).
+        if size > offset:
+            _run_once()
+
+        sleep_fn(poll_interval_sec)
+        iterations += 1

--- a/tests/test_observation_queries.py
+++ b/tests/test_observation_queries.py
@@ -1,0 +1,190 @@
+"""Tests for observation-backed CLI query helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import db
+import observation_queries
+
+
+@pytest.fixture
+def obs_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect observation files into the test tempdir."""
+    d = tmp_path / "observations"
+    d.mkdir()
+    monkeypatch.setattr(db, "OBS_DIR", d)
+    return d
+
+
+def _write_obs(obs_dir: Path, session_id: str, entries: list[dict]) -> Path:
+    path = obs_dir / f"{session_id}.jsonl"
+    path.write_text("".join(json.dumps(entry) + "\n" for entry in entries))
+    return path
+
+
+def _seed_session(conn, session_id: str, project: str | None = None) -> None:
+    session_path = f"/tmp/{session_id}.jsonl"
+    db.upsert_session(conn, session_id, session_path, project=project)
+
+
+class TestRefreshUnprocessedObservations:
+    def test_project_filter_only_catches_up_matching_tracked_sessions(
+        self,
+        conn,
+        obs_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        _seed_session(conn, "alpha-1", "atlas")
+        _seed_session(conn, "beta-1", "billing")
+        db.upsert_observation_state(
+            conn,
+            "alpha-1",
+            "/tmp/alpha-1.jsonl",
+            str(obs_dir / "alpha-1.jsonl"),
+        )
+        db.upsert_observation_state(
+            conn,
+            "beta-1",
+            "/tmp/beta-1.jsonl",
+            str(obs_dir / "beta-1.jsonl"),
+        )
+
+        calls: list[str] = []
+
+        def fake_observe_session(conn_, session_id, *, batch_threshold, **_kwargs):
+            calls.append(session_id)
+            return {
+                "status": "up_to_date",
+                "message": f"{session_id} caught up",
+                "batch_threshold": batch_threshold,
+            }
+
+        monkeypatch.setattr(
+            observation_queries.observer,
+            "observe_session",
+            fake_observe_session,
+        )
+
+        results = observation_queries.refresh_unprocessed_observations(
+            conn,
+            project="atl",
+        )
+
+        assert calls == ["alpha-1"]
+        assert [result["session_id"] for result in results] == ["alpha-1"]
+
+
+class TestListObservationEntries:
+    def test_reads_all_files_and_sorts_newest_first(self, conn, obs_dir: Path):
+        _seed_session(conn, "sess-a", "atlas")
+        _seed_session(conn, "sess-b", "billing")
+        _write_obs(
+            obs_dir,
+            "sess-a",
+            [
+                {
+                    "type": "todo",
+                    "text": "first todo",
+                    "ts": "2026-04-17T10:00:00Z",
+                },
+                {
+                    "type": "decision",
+                    "text": "ignore me",
+                    "ts": "2026-04-17T10:30:00Z",
+                },
+            ],
+        )
+        _write_obs(
+            obs_dir,
+            "sess-b",
+            [
+                {
+                    "type": "todo",
+                    "text": "newest todo",
+                    "ts": "2026-04-17T11:00:00Z",
+                },
+            ],
+        )
+        _write_obs(
+            obs_dir,
+            "sess-c",
+            [
+                {
+                    "type": "todo",
+                    "text": "unknown project",
+                    "ts": "2026-04-17T09:00:00Z",
+                },
+            ],
+        )
+
+        rows = observation_queries.list_observation_entries(
+            conn,
+            observation_type="todo",
+        )
+
+        assert [row["session"] for row in rows] == ["sess-b", "sess-a", "sess-c"]
+        assert rows[0]["project"] == "billing"
+        assert rows[1]["project"] == "atlas"
+        assert rows[2]["project"] == ""
+        assert [row["text"] for row in rows] == [
+            "newest todo",
+            "first todo",
+            "unknown project",
+        ]
+
+    def test_project_filter_reads_only_matching_session_files(self, conn, obs_dir: Path):
+        _seed_session(conn, "alpha-1", "atlas")
+        _seed_session(conn, "beta-1", "billing")
+        _write_obs(
+            obs_dir,
+            "alpha-1",
+            [{"type": "todo", "text": "atlas todo", "ts": "2026-04-17T10:00:00Z"}],
+        )
+        _write_obs(
+            obs_dir,
+            "beta-1",
+            [{"type": "todo", "text": "billing todo", "ts": "2026-04-17T11:00:00Z"}],
+        )
+        _write_obs(
+            obs_dir,
+            "rogue",
+            [{"type": "todo", "text": "rogue todo", "ts": "2026-04-17T12:00:00Z"}],
+        )
+
+        rows = observation_queries.list_observation_entries(
+            conn,
+            observation_type="todo",
+            project="atl",
+        )
+
+        assert rows == [
+            {
+                "project": "atlas",
+                "session": "alpha-1",
+                "timestamp": "2026-04-17T10:00:00Z",
+                "text": "atlas todo",
+                "type": "todo",
+            }
+        ]
+
+
+class TestFormatEntryJson:
+    def test_emits_compact_json_with_required_fields(self):
+        line = observation_queries.format_entry_json(
+            {
+                "project": "atlas",
+                "session": "sess-1",
+                "timestamp": "2026-04-17T10:00:00Z",
+                "text": "Ship todos query",
+                "type": "todo",
+            }
+        )
+
+        assert line == (
+            '{"project":"atlas","session":"sess-1",'
+            '"timestamp":"2026-04-17T10:00:00Z","text":"Ship todos query"}'
+        )

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -514,3 +514,287 @@ class TestObserveSession:
         assert result["status"] == "extracted"
         # All 3 turns should be read (cursor rewound to 0).
         assert result["turns"] == 3
+
+
+# --- Watch-mode tests ------------------------------------------------------
+
+
+class _StopAfter:
+    """should_stop helper: returns False until called ``after`` times.
+
+    Using a class instead of a closure makes the call count inspectable
+    from the tests so we can assert how many polls actually happened.
+    """
+
+    def __init__(self, after: int) -> None:
+        self.after = after
+        self.calls = 0
+
+    def __call__(self) -> bool:
+        self.calls += 1
+        return self.calls > self.after
+
+
+class TestWatchSession:
+    """The watch loop is the layer on top of observe_session that polls
+    for source-file growth and re-invokes the observer. These tests
+    exercise the loop's branches with a no-op sleep and either a stop
+    callback or ``max_iterations`` to terminate deterministically.
+    """
+
+    def test_runs_initial_catch_up_then_stops(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        # 3 turns waiting at start — meets threshold for the catch-up run.
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "hi"),
+            _assistant_line("a1", "m1", "yo"),
+            _user_line("u2", "more"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+        claude = fake_claude([
+            {"type": "decision", "text": "x", "context": "",
+             "ts": "2026-04-17T10:00:00Z"},
+        ])
+
+        results: list[dict] = []
+        result = observer.watch_session(
+            conn, "sess-1",
+            claude_bin=str(claude),
+            should_stop=_StopAfter(0),  # exit before the first poll iteration
+            sleep_fn=lambda _: None,
+            on_result=results.append,
+        )
+
+        assert result["status"] == "stopped"
+        assert result["extractions"] == 1
+        assert result["iterations"] == 0
+        # The catch-up call propagated through on_result.
+        assert len(results) == 1
+        assert results[0]["status"] == "extracted"
+
+    def test_no_growth_means_observer_not_re_invoked(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        # Same shape as above. After the catch-up advances the cursor
+        # to EOF, no further growth occurs, so the loop should not call
+        # observe_session again no matter how many times it polls.
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "a"),
+            _assistant_line("a1", "m1", "b"),
+            _user_line("u2", "c"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+        claude = fake_claude([
+            {"type": "decision", "text": "x", "context": "",
+             "ts": "2026-04-17T10:00:00Z"},
+        ])
+
+        result = observer.watch_session(
+            conn, "sess-1",
+            claude_bin=str(claude),
+            max_iterations=5,
+            sleep_fn=lambda _: None,
+        )
+
+        assert result["status"] == "max_iterations"
+        # Only the catch-up extraction happened — no further calls.
+        assert result["extractions"] == 1
+        assert result["iterations"] == 5
+        # Observation file unchanged after catch-up.
+        obs_path = obs_dir / "sess-1.jsonl"
+        assert len(obs_path.read_text().strip().splitlines()) == 1
+
+    def test_growth_after_catch_up_triggers_extraction(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        # Catch-up consumes 3 turns; then before each poll we append
+        # more turns and confirm the loop re-extracts.
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "a"),
+            _assistant_line("a1", "m1", "b"),
+            _user_line("u2", "c"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        # Single fake claude — appends one canned line per invocation.
+        # Each call to observe_session triggers exactly one append.
+        claude = fake_claude([
+            {"type": "decision", "text": "x", "context": "",
+             "ts": "2026-04-17T10:00:00Z"},
+        ])
+
+        # The "growth driver" runs as our sleep_fn: every time the loop
+        # sleeps, we append 3 more turns to the source. That guarantees
+        # growth is visible on the very next size check.
+        appends_left = [2]
+
+        def grow_then_sleep(_):
+            if appends_left[0] <= 0:
+                return
+            appends_left[0] -= 1
+            with open(jsonl, "a") as f:
+                f.write(_user_line(f"u-extra-{appends_left[0]}", "q") + "\n")
+                f.write(_assistant_line(
+                    f"a-extra-{appends_left[0]}",
+                    f"m-extra-{appends_left[0]}", "a") + "\n")
+                f.write(_user_line(f"u-extra2-{appends_left[0]}", "q2") + "\n")
+
+        result = observer.watch_session(
+            conn, "sess-1",
+            claude_bin=str(claude),
+            max_iterations=3,
+            sleep_fn=grow_then_sleep,
+        )
+
+        assert result["status"] == "max_iterations"
+        # 1 catch-up + 2 growth-triggered runs = 3 total extractions.
+        assert result["extractions"] == 3
+
+    def test_below_threshold_growth_does_not_advance_cursor(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        """A 1-turn append after catch-up triggers an observe call but
+        observe_session returns 'below_threshold' without advancing the
+        cursor — and counts as below_threshold_runs in the summary.
+        """
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "a"),
+            _assistant_line("a1", "m1", "b"),
+            _user_line("u2", "c"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+        claude = fake_claude([
+            {"type": "decision", "text": "x", "context": "",
+             "ts": "2026-04-17T10:00:00Z"},
+        ])
+
+        # First sleep: append exactly one new turn (below the 3-turn
+        # threshold). All later sleeps are no-ops.
+        appended = [False]
+
+        def sleep_fn(_):
+            if appended[0]:
+                return
+            appended[0] = True
+            with open(jsonl, "a") as f:
+                f.write(_user_line("u-extra", "tiny") + "\n")
+
+        cursor_before_loop = jsonl.stat().st_size
+
+        result = observer.watch_session(
+            conn, "sess-1",
+            claude_bin=str(claude),
+            max_iterations=2,
+            sleep_fn=sleep_fn,
+        )
+
+        assert result["extractions"] == 1  # just the catch-up
+        assert result["below_threshold_runs"] == 1
+        # The state cursor stayed at the catch-up EOF — observe_session
+        # is not allowed to advance past bytes it didn't ship to Haiku.
+        state = db.get_observation_state(conn, "sess-1")
+        assert state is not None
+        assert state["source_byte_offset"] == cursor_before_loop
+
+    def test_source_disappears_returns_source_gone(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "a"),
+            _assistant_line("a1", "m1", "b"),
+            _user_line("u2", "c"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+        claude = fake_claude([
+            {"type": "decision", "text": "x", "context": "",
+             "ts": "2026-04-17T10:00:00Z"},
+        ])
+
+        deleted = [False]
+
+        def delete_then_sleep(_):
+            if deleted[0]:
+                return
+            deleted[0] = True
+            jsonl.unlink()
+
+        result = observer.watch_session(
+            conn, "sess-1",
+            claude_bin=str(claude),
+            max_iterations=10,
+            sleep_fn=delete_then_sleep,
+        )
+
+        assert result["status"] == "source_gone"
+        # The catch-up still ran before the file went away.
+        assert result["extractions"] == 1
+
+    def test_missing_source_skips_catch_up(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        # No sessions row, no state row — the watcher must not try to
+        # call observe_session at all (it would fail with no_source).
+        result = observer.watch_session(
+            conn, "ghost-sess",
+            claude_bin=str(fake_claude([])),
+            max_iterations=3,
+            sleep_fn=lambda _: None,
+        )
+        assert result["status"] == "source_gone"
+        assert result["extractions"] == 0
+        assert result["iterations"] == 0
+
+    def test_subprocess_failure_does_not_kill_the_loop(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        # Catch-up will fail (claude exits non-zero). The loop must
+        # keep going — failures are tallied, not raised.
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "a"),
+            _assistant_line("a1", "m1", "b"),
+            _user_line("u2", "c"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+        claude = fake_claude("#!/usr/bin/env bash\nexit 7\n")
+
+        result = observer.watch_session(
+            conn, "sess-1",
+            claude_bin=str(claude),
+            max_iterations=2,
+            sleep_fn=lambda _: None,
+        )
+
+        assert result["status"] == "max_iterations"
+        assert result["failures"] >= 1
+        assert result["extractions"] == 0
+
+    def test_should_stop_polled_each_iteration(
+        self, tmp_path, conn, obs_dir, fake_claude
+    ):
+        # No real source — we just want to prove should_stop is consulted
+        # before max_iterations and exits cleanly.
+        jsonl = _write_session(tmp_path, "sess-1", [
+            _user_line("u1", "a"),
+            _assistant_line("a1", "m1", "b"),
+            _user_line("u2", "c"),
+        ])
+        _seed_session_row(conn, "sess-1", jsonl)
+        claude = fake_claude([
+            {"type": "decision", "text": "x", "context": "",
+             "ts": "2026-04-17T10:00:00Z"},
+        ])
+        stop = _StopAfter(3)
+
+        result = observer.watch_session(
+            conn, "sess-1",
+            claude_bin=str(claude),
+            should_stop=stop,
+            max_iterations=100,
+            sleep_fn=lambda _: None,
+        )
+
+        assert result["status"] == "stopped"
+        # Polled at the top of every iteration; exits on the 4th call.
+        assert stop.calls == 4
+        assert result["iterations"] == 3

--- a/threadhop
+++ b/threadhop
@@ -13,6 +13,7 @@ import re
 import sqlite3
 import subprocess
 import sys
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -24,7 +25,7 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
-from textual.widgets import Footer, Header, Input, ListItem, ListView, Static, TextArea
+from textual.widgets import Header, Input, ListItem, ListView, Static, TextArea
 from textual.worker import Worker
 
 # Local package: SQLite DB module (init, migrations, session helpers).
@@ -146,6 +147,227 @@ STATUS_CYCLE: list[str] = [s for s in STATUS_ORDER if s != "archived"]
 
 # Regex to strip <system-reminder>...</system-reminder> blocks from text
 SYSTEM_REMINDER_RE = re.compile(r"<system-reminder>.*?</system-reminder>", re.DOTALL)
+
+
+# --- Command metadata registry (ADR-017, task #42) ---
+#
+# One source of truth for app-level bindings, widget-local keys, the
+# contextual footer, and the help overlay. Any new command lands here
+# and automatically becomes discoverable everywhere.
+#
+# Scopes group commands by where they're reachable. Widget-local
+# handlers (TranscriptView selection mode, FindBar, SearchScreen) own
+# their behaviour — the registry just records the metadata so the rest
+# of the UI can surface it.
+
+SCOPE_GLOBAL = "global"
+SCOPE_SESSION_LIST = "session_list"
+SCOPE_TRANSCRIPT = "transcript"
+SCOPE_SELECTION = "selection"
+SCOPE_REPLY = "reply"
+SCOPE_FIND = "find"
+SCOPE_SEARCH = "search"
+
+SCOPE_ORDER: list[str] = [
+    SCOPE_GLOBAL,
+    SCOPE_SESSION_LIST,
+    SCOPE_TRANSCRIPT,
+    SCOPE_SELECTION,
+    SCOPE_REPLY,
+    SCOPE_FIND,
+    SCOPE_SEARCH,
+]
+
+SCOPE_LABELS: dict[str, str] = {
+    SCOPE_GLOBAL: "Global",
+    SCOPE_SESSION_LIST: "Session list",
+    SCOPE_TRANSCRIPT: "Transcript",
+    SCOPE_SELECTION: "Selection mode",
+    SCOPE_REPLY: "Reply input",
+    SCOPE_FIND: "Find bar",
+    SCOPE_SEARCH: "Search modal",
+}
+
+# Pretty-print Textual key strings for the help overlay and footer.
+# Lookup is exact-match first, then falls back to capitalizing the raw
+# string so unknown keys still show up reasonably.
+_KEY_DISPLAY: dict[str, str] = {
+    "up": "↑",
+    "down": "↓",
+    "left": "←",
+    "right": "→",
+    "enter": "Enter",
+    "escape": "Esc",
+    "pageup": "PgUp",
+    "pagedown": "PgDn",
+    "home": "Home",
+    "end": "End",
+    "space": "Space",
+    "tab": "Tab",
+    "left_square_bracket": "[",
+    "right_square_bracket": "]",
+    "shift+up": "⇧↑",
+    "shift+down": "⇧↓",
+    "alt+enter": "⌥Enter",
+    "alt+j": "⌥j",
+    "alt+k": "⌥k",
+    "ctrl+f": "^F",
+    "ctrl+n": "^N",
+    "ctrl+p": "^P",
+}
+
+
+def format_key(key: str) -> str:
+    return _KEY_DISPLAY.get(key, key)
+
+
+@dataclass(frozen=True)
+class Command:
+    """One row of the command registry.
+
+    ``keys`` holds Textual-valid key names (``"ctrl+f"``, ``"shift+down"``,
+    ``"left_square_bracket"``) — prettification for display happens in
+    ``format_key``. When ``action`` is set the command is wired as an
+    App-level ``Binding``; otherwise the command is widget-local and the
+    registry entry exists purely for discoverability (footer, help
+    overlay).
+    """
+
+    keys: tuple[str, ...]
+    description: str
+    scope: str
+    action: str | None = None
+    priority: bool = False
+    # Footer commands are the minimal contextual hint row — only the
+    # highest-value bindings for each scope are marked ``footer=True``.
+    footer: bool = False
+
+
+COMMAND_REGISTRY: list[Command] = [
+    # --- Global ---
+    Command(("?",), "Help", SCOPE_GLOBAL, "open_help", footer=True),
+    Command(("q",), "Quit", SCOPE_GLOBAL, "maybe_quit", footer=True),
+    Command(("r",), "Refresh sessions", SCOPE_GLOBAL, "maybe_refresh"),
+    Command(("t",), "Next theme", SCOPE_GLOBAL, "toggle_theme_next"),
+    Command(("T",), "Previous theme", SCOPE_GLOBAL, "toggle_theme_prev"),
+    Command(("/",), "Search all sessions", SCOPE_GLOBAL, "open_search", footer=True),
+    Command(("ctrl+f",), "Find in transcript", SCOPE_GLOBAL, "open_find", footer=True),
+    Command(("left_square_bracket",), "Shrink sidebar", SCOPE_GLOBAL, "shrink_sidebar"),
+    Command(("right_square_bracket",), "Grow sidebar", SCOPE_GLOBAL, "grow_sidebar"),
+
+    # --- Session list ---
+    Command(("j",), "Next session", SCOPE_SESSION_LIST, "cursor_down", footer=True),
+    Command(("k",), "Previous session", SCOPE_SESSION_LIST, "cursor_up", footer=True),
+    Command(("l", "right"), "Focus transcript", SCOPE_SESSION_LIST, "focus_transcript"),
+    Command(
+        ("enter",), "Reply to session", SCOPE_SESSION_LIST,
+        "start_reply_or_send", priority=True, footer=True,
+    ),
+    Command(("n",), "Rename session", SCOPE_SESSION_LIST, "rename_session", footer=True),
+    Command(("g",), "Copy resume command", SCOPE_SESSION_LIST, "copy_session_id"),
+    Command(("s",), "Cycle status forward", SCOPE_SESSION_LIST, "cycle_status_forward"),
+    Command(("S",), "Cycle status backward", SCOPE_SESSION_LIST, "cycle_status_backward"),
+    Command(("a",), "Archive session", SCOPE_SESSION_LIST, "archive_session"),
+    Command(("A",), "Toggle archived view", SCOPE_SESSION_LIST, "toggle_archive_view"),
+    Command(
+        ("J", "shift+down"), "Move session down",
+        SCOPE_SESSION_LIST, "move_session_down",
+    ),
+    Command(
+        ("K", "shift+up"), "Move session up",
+        SCOPE_SESSION_LIST, "move_session_up",
+    ),
+
+    # --- Transcript ---
+    Command(("h", "left"), "Focus session list", SCOPE_TRANSCRIPT, "focus_list"),
+    Command(
+        ("pageup",), "Scroll page up", SCOPE_TRANSCRIPT,
+        "scroll_transcript_up", priority=True,
+    ),
+    Command(
+        ("pagedown",), "Scroll page down", SCOPE_TRANSCRIPT,
+        "scroll_transcript_down", priority=True,
+    ),
+    Command(
+        ("home",), "Scroll to top", SCOPE_TRANSCRIPT,
+        "scroll_transcript_home", priority=True,
+    ),
+    Command(
+        ("end",), "Scroll to bottom", SCOPE_TRANSCRIPT,
+        "scroll_transcript_end", priority=True,
+    ),
+    Command(("m",), "Enter selection mode", SCOPE_TRANSCRIPT, footer=True),
+
+    # --- Selection mode (widget-local; TranscriptView.on_key) ---
+    Command(("j", "down"), "Next message", SCOPE_SELECTION, footer=True),
+    Command(("k", "up"), "Previous message", SCOPE_SELECTION, footer=True),
+    Command(("v",), "Toggle range select", SCOPE_SELECTION, footer=True),
+    Command(("y",), "Copy selection", SCOPE_SELECTION, footer=True),
+    Command(("e",), "Export to /tmp", SCOPE_SELECTION, footer=True),
+    Command(("m", "escape"), "Exit selection", SCOPE_SELECTION, footer=True),
+
+    # --- Reply input ---
+    Command(
+        ("enter",), "Send message", SCOPE_REPLY,
+        "start_reply_or_send", priority=True, footer=True,
+    ),
+    Command(("alt+enter",), "Newline", SCOPE_REPLY, "insert_newline", footer=True),
+    Command(("escape",), "Cancel / return to list", SCOPE_REPLY, "cancel_reply", footer=True),
+    Command(("alt+j",), "Nav sessions while replying", SCOPE_REPLY, "nav_down_from_reply"),
+    Command(("alt+k",), "Nav sessions while replying", SCOPE_REPLY, "nav_up_from_reply"),
+
+    # --- Find bar (widget-local; FindBar.on_key + Input.Submitted) ---
+    Command(("enter",), "Next match", SCOPE_FIND, footer=True),
+    Command(("down",), "Next match", SCOPE_FIND, footer=True),
+    Command(("up",), "Previous match", SCOPE_FIND, footer=True),
+    Command(("N",), "Previous match (app-wide)", SCOPE_FIND, "find_prev"),
+    Command(("escape",), "Close find", SCOPE_FIND, footer=True),
+
+    # --- Search modal (widget-local; SearchScreen.on_key) ---
+    Command(("up", "down", "ctrl+n", "ctrl+p"), "Navigate results", SCOPE_SEARCH, footer=True),
+    Command(("enter",), "Open result", SCOPE_SEARCH, footer=True),
+    Command(("escape",), "Close search", SCOPE_SEARCH, footer=True),
+]
+
+
+def commands_for_scope(scope: str) -> list[Command]:
+    return [c for c in COMMAND_REGISTRY if c.scope == scope]
+
+
+def format_command_keys(cmd: Command) -> str:
+    """Render a command's keys as a slash-separated list for display."""
+    return "/".join(format_key(k) for k in cmd.keys)
+
+
+def app_bindings_from_registry() -> list[Binding]:
+    """Derive App-level ``Binding`` entries from the registry.
+
+    Every Command with an ``action`` is bound at the App level. The
+    scope field is advisory for display — app bindings fire globally,
+    but each action already gates itself on focus / mode state (see
+    e.g. ``_input_has_focus`` in action handlers). Widget-local keys
+    (selection mode, find bar, search modal) are deliberately skipped
+    because their widgets handle the key in ``on_key`` and stop the
+    event before it reaches an app binding.
+    """
+    bindings: list[Binding] = []
+    for cmd in COMMAND_REGISTRY:
+        if cmd.action is None:
+            continue
+        for key in cmd.keys:
+            bindings.append(
+                Binding(
+                    key,
+                    cmd.action,
+                    cmd.description,
+                    show=False,
+                    priority=cmd.priority,
+                )
+            )
+    # Escape on the reply input action is the app-level cancel_reply;
+    # it doubles as "close find bar" when the bar is up (see
+    # action_cancel_reply). Registered via the SCOPE_REPLY entry above.
+    return bindings
 
 
 def format_age(timestamp: float) -> str:
@@ -384,6 +606,11 @@ class TranscriptView(VerticalScroll):
         self._selected_index = len(messages) - 1
         self._update_selection(messages)
         self.app.notify("Selection mode: j/k move, v range, y copy, e export, m/Esc exit")
+        # Nudge the contextual footer — selection mode has its own scope.
+        try:
+            self.app.refresh_footer()
+        except Exception:
+            pass
 
     def _exit_selection_mode(self):
         self._range_mode = False
@@ -392,6 +619,10 @@ class TranscriptView(VerticalScroll):
         self._selection_mode = False
         self._selected_index = -1
         self.border_title = "Transcript"
+        try:
+            self.app.refresh_footer()
+        except Exception:
+            pass
 
     def _enter_range_mode(self):
         self._range_mode = True
@@ -1686,6 +1917,167 @@ class SearchScreen(ModalScreen):
         self.dismiss((row["session_id"], row["uuid"], terms))
 
 
+class HelpScreen(ModalScreen):
+    """Full-app help overlay grouped by scope (ADR-017, task #42).
+
+    Mirrors the search modal layout so the two discoverability surfaces
+    feel consistent. Reads entirely from ``COMMAND_REGISTRY`` — anything
+    new added there appears here automatically.
+    """
+
+    BINDINGS = [
+        Binding("escape", "close", "Close", priority=True),
+        Binding("?", "close", "Close", priority=True),
+        Binding("q", "close", "Close", priority=True),
+    ]
+
+    CSS = """
+    HelpScreen {
+        layout: vertical;
+        align: center top;
+        background: $background 70%;
+    }
+
+    #help-container {
+        width: 90%;
+        max-width: 120;
+        height: 85%;
+        margin-top: 1;
+        background: $surface;
+        border: thick $accent;
+        layout: vertical;
+    }
+
+    #help-title {
+        height: 1;
+        padding: 0 1;
+        background: $boost;
+        color: $text;
+        text-style: bold;
+    }
+
+    #help-body {
+        height: 1fr;
+        padding: 1 2;
+    }
+
+    #help-hint {
+        height: 1;
+        padding: 0 1;
+        color: $text-muted;
+        background: $boost;
+        text-style: italic;
+    }
+
+    .help-scope {
+        margin-top: 1;
+        text-style: bold;
+        color: $accent;
+    }
+
+    .help-scope:first-of-type {
+        margin-top: 0;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="help-container") as container:
+            container.border_title = "Help — keys grouped by context"
+            yield Static("ThreadHop commands", id="help-title")
+            yield VerticalScroll(id="help-body")
+            yield Static(
+                "Esc / ? / q close • keys are grouped by where they're live",
+                id="help-hint",
+            )
+
+    def on_mount(self) -> None:
+        body = self.query_one("#help-body", VerticalScroll)
+        for scope in SCOPE_ORDER:
+            commands = commands_for_scope(scope)
+            if not commands:
+                continue
+            body.mount(Static(SCOPE_LABELS[scope], classes="help-scope"))
+            # Width of the keys column is computed per-scope so shorter
+            # sections don't pay for a long key name in another scope.
+            key_width = max(len(format_command_keys(c)) for c in commands)
+            key_width = max(key_width, 6)
+            for cmd in commands:
+                keys = format_command_keys(cmd).ljust(key_width)
+                body.mount(Static(f"  {keys}   {cmd.description}"))
+
+    def action_close(self) -> None:
+        self.dismiss(None)
+
+
+class ContextualFooter(Static):
+    """Single-line footer that shows scope-relevant hints from the registry.
+
+    The stock ``Footer`` widget lists every visible binding at once, which
+    turns into noise once the app has focus-aware and mode-specific
+    commands. Instead we read ``COMMAND_REGISTRY`` and render only
+    commands whose scope matches the caller-supplied context, preferring
+    those marked ``footer=True``.
+    """
+
+    DEFAULT_CSS = """
+    ContextualFooter {
+        dock: bottom;
+        height: 1;
+        background: $boost;
+        color: $text-muted;
+        padding: 0 1;
+    }
+    ContextualFooter > .footer-sep {
+        color: $text-disabled;
+    }
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__("", *args, **kwargs)
+        self._last_scopes: tuple[str, ...] = ()
+
+    def render_for(self, scopes: list[str]) -> None:
+        """Rebuild the footer content for the given list of active scopes.
+
+        Scopes are evaluated in the order passed — the registry entries
+        for later scopes win when a key appears in multiple (e.g. Enter
+        is Reply/Send globally but Send in the reply scope).
+        """
+        scope_tuple = tuple(scopes)
+        if scope_tuple == self._last_scopes:
+            # Footer already reflects the right context — skip the rebuild.
+            return
+        self._last_scopes = scope_tuple
+
+        # Keep the help shortcut pinned on the far left so it stays
+        # discoverable regardless of current focus.
+        parts: list[str] = []
+        seen_keys: set[tuple[str, ...]] = set()
+
+        def add(cmd: Command) -> None:
+            if cmd.keys in seen_keys:
+                return
+            seen_keys.add(cmd.keys)
+            parts.append(f"[b]{format_command_keys(cmd)}[/b] {cmd.description}")
+
+        # Global "?" first, so it's always in the same spot.
+        for cmd in commands_for_scope(SCOPE_GLOBAL):
+            if cmd.keys == ("?",):
+                add(cmd)
+                break
+
+        for scope in scopes:
+            for cmd in commands_for_scope(scope):
+                if cmd.footer and cmd.keys != ("?",):
+                    add(cmd)
+
+        if not parts:
+            self.update("")
+            return
+        sep = "  [dim]·[/dim]  "
+        self.update(sep.join(parts))
+
+
 class FindBar(Horizontal):
     """Persistent Ctrl+F-style find bar shown above the transcript.
 
@@ -1943,44 +2335,10 @@ class ClaudeSessions(App):
     }
     """
 
-    BINDINGS = [
-        Binding("q", "maybe_quit", "Quit"),
-        Binding("r", "maybe_refresh", "Refresh"),
-        Binding("t", "toggle_theme_next", "Theme"),
-        Binding("T", "toggle_theme_prev", "Theme Prev", show=False),
-        Binding("n", "rename_session", "Rename"),
-        Binding("g", "copy_session_id", "Copy ID"),
-        Binding("enter", "start_reply_or_send", "Reply/Send", show=True, priority=True),
-        Binding("alt+enter", "insert_newline", "Newline", show=False),
-        Binding("/", "open_search", "Search"),
-        Binding("ctrl+f", "open_find", "Find"),
-        Binding("N", "find_prev", "Prev match", show=False),
-        Binding("escape", "cancel_reply", "Cancel", show=False),
-        Binding("right", "focus_transcript", "Transcript", show=False),
-        Binding("left", "focus_list", "Sessions", show=False),
-        Binding("l", "focus_transcript", "Transcript", show=False),
-        Binding("h", "focus_list", "Sessions", show=False),
-        Binding("j", "cursor_down", "Down", show=False),
-        Binding("k", "cursor_up", "Up", show=False),
-        Binding("J", "move_session_down", "Move Down", show=False),
-        Binding("K", "move_session_up", "Move Up", show=False),
-        Binding("shift+down", "move_session_down", "Move Down", show=False),
-        Binding("shift+up", "move_session_up", "Move Up", show=False),
-        Binding("alt+j", "nav_down_from_reply", "Nav Down", show=False),
-        Binding("alt+k", "nav_up_from_reply", "Nav Up", show=False),
-        Binding("a", "archive_session", "Archive", show=False),
-        Binding("A", "toggle_archive_view", "Show Archived", show=False),
-        Binding("pageup", "scroll_transcript_up", "PgUp", show=False, priority=True),
-        Binding(
-            "pagedown", "scroll_transcript_down", "PgDn", show=False, priority=True
-        ),
-        Binding("home", "scroll_transcript_home", "Top", show=False, priority=True),
-        Binding("end", "scroll_transcript_end", "Bottom", show=False, priority=True),
-        Binding("s", "cycle_status_forward", "Status", show=False),
-        Binding("S", "cycle_status_backward", "Status Back", show=False),
-        Binding("left_square_bracket", "shrink_sidebar", "Narrow", show=False),
-        Binding("right_square_bracket", "grow_sidebar", "Widen", show=False),
-    ]
+    # Bindings come from the shared command registry (ADR-017). Add new
+    # App-level commands to COMMAND_REGISTRY above, not here — footer and
+    # help overlay both read from the same list.
+    BINDINGS = app_bindings_from_registry()
 
     SIDEBAR_MIN = 20
     SIDEBAR_MAX = 60
@@ -2036,7 +2394,7 @@ class ClaudeSessions(App):
             id="transcript-column",
         )
         yield Vertical(TextArea(id="reply-input"), id="input-container")
-        yield Footer()
+        yield ContextualFooter(id="contextual-footer")
 
     def on_mount(self) -> None:
         # Apply persisted sidebar width (defaults to CSS value of 36).
@@ -2059,6 +2417,11 @@ class ClaudeSessions(App):
         self.set_interval(REFRESH_INTERVAL, self.auto_refresh_background)
         self._spinner_frame = 0
         self.set_interval(SPINNER_INTERVAL, self.animate_spinners)
+        # Prime the contextual footer now that all widgets are mounted
+        # and the sidebar has focus. on_descendant_focus also covers
+        # this, but calling refresh_footer directly makes startup
+        # deterministic in tests that don't emit focus events.
+        self.refresh_footer()
 
     def update_titles(self) -> None:
         filter_info = ""
@@ -2703,6 +3066,75 @@ class ClaudeSessions(App):
         bar = self._find_bar()
         return bool(bar and bar.display)
 
+    def _current_scopes(self) -> list[str]:
+        """Resolve which registry scopes are live right now.
+
+        Ordered from outer to inner (``global`` first, most-specific
+        last) so the contextual footer and any downstream consumer
+        can give precedence to the innermost scope when a key appears
+        in more than one.
+        """
+        scopes = [SCOPE_GLOBAL]
+        focused = self.focused
+
+        # Selection mode is inside the transcript but displaces its
+        # regular bindings, so it's surfaced as its own scope first.
+        try:
+            transcript = self.query_one("#transcript-scroll", TranscriptView)
+        except Exception:
+            transcript = None
+        in_selection = bool(transcript and transcript._selection_mode)
+
+        # Find bar is modeless — it can be up while focus is elsewhere.
+        # Surface it as its own scope whenever it's visible.
+        if self._find_is_active():
+            scopes.append(SCOPE_FIND)
+
+        if focused is not None:
+            fid = getattr(focused, "id", None)
+            if fid == "reply-input":
+                scopes.append(SCOPE_REPLY)
+            elif fid == "session-list":
+                scopes.append(SCOPE_SESSION_LIST)
+            elif fid == "find-input":
+                # Already covered by SCOPE_FIND above.
+                pass
+            elif transcript is not None and focused is transcript:
+                scopes.append(SCOPE_SELECTION if in_selection else SCOPE_TRANSCRIPT)
+
+        if in_selection and SCOPE_SELECTION not in scopes:
+            scopes.append(SCOPE_SELECTION)
+        return scopes
+
+    def refresh_footer(self) -> None:
+        """Re-render the contextual footer for the current scope stack.
+
+        Called whenever focus moves, selection mode toggles, or the
+        find bar opens/closes — the footer picks up the new scope set
+        and redraws. No-ops if the footer hasn't mounted yet.
+        """
+        try:
+            footer = self.query_one("#contextual-footer", ContextualFooter)
+        except Exception:
+            return
+        footer.render_for(self._current_scopes())
+
+    def on_descendant_focus(self, event) -> None:
+        self.refresh_footer()
+
+    def on_descendant_blur(self, event) -> None:
+        self.refresh_footer()
+
+    def action_open_help(self) -> None:
+        """Show the context-aware help overlay.
+
+        Skips when an input widget has focus so `?` still types
+        normally while composing a reply or a search query.
+        """
+        if self._input_has_focus():
+            return
+        self.push_screen(HelpScreen())
+
     def action_maybe_quit(self) -> None:
         if not self._input_has_focus():
             self.exit()
@@ -2756,6 +3188,7 @@ class ClaudeSessions(App):
         existing = (input_widget.value or "").strip()
         if existing:
             self._run_find(input_widget.value)
+        self.refresh_footer()
 
     def action_find_next(self) -> None:
         if not self._find_is_active():
@@ -2813,6 +3246,7 @@ class ClaudeSessions(App):
             self.query_one("#session-list", ListView).focus()
         except Exception:
             pass
+        self.refresh_footer()
 
     def on_input_changed(self, event) -> None:
         """Debounce keystrokes in the find bar into a single highlight pass."""

--- a/threadhop
+++ b/threadhop
@@ -33,6 +33,7 @@ from textual.worker import Worker
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import db  # noqa: E402
 import indexer  # noqa: E402
+import observation_queries  # noqa: E402
 import observer  # noqa: E402
 
 
@@ -4161,6 +4162,36 @@ def cmd_observe(args) -> int:
     return 0
 
 
+def cmd_todos(args) -> int:
+    """List open TODO observations as compact JSONL."""
+    conn = db.init_db()
+    try:
+        results = observation_queries.refresh_unprocessed_observations(
+            conn,
+            project=args.project,
+            session_id=args.session,
+        )
+        for result in results:
+            if result.get("status") == "failed":
+                print(
+                    "threadhop todos: observer failed for session "
+                    f"{result['session_id']}: {result.get('message', 'unknown error')}",
+                    file=sys.stderr,
+                )
+        entries = observation_queries.list_observation_entries(
+            conn,
+            observation_type="todo",
+            project=args.project,
+            session_id=args.session,
+        )
+    finally:
+        conn.close()
+
+    for entry in entries:
+        print(observation_queries.format_entry_json(entry))
+    return 0
+
+
 def main():
     parser = build_parser()
     args = parser.parse_args()
@@ -4188,6 +4219,8 @@ def main():
             conn.close()
         print(f"Tagged session {args.session} as {args.status}")
         return 0
+    if args.command == "todos":
+        return cmd_todos(args)
     if args.command == "observe":
         return cmd_observe(args)
     return _cli_stub(args.command)


### PR DESCRIPTION
## What changed
Implemented `threadhop todos [--project]` so the CLI now runs observer catch-up for tracked sessions, reads per-session observation files, filters `type == "todo"`, and prints grep/jq-friendly JSON lines newest-first.

## Why
This closes the task for querying open TODO observations from the observer pipeline without opening the TUI.

## Validation
Ran `python3 -m pytest tests/test_observation_queries.py tests/test_observer.py -q` and a CLI smoke test against a temporary `HOME`.
