### PR TITLE
Implement threadhop observations CLI query (#22)

### DIFF
--- a/tests/test_cli_observations.py
+++ b/tests/test_cli_observations.py
@@ -1,0 +1,80 @@
+"""CLI tests for ``threadhop observations``."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import db
+
+
+ROOT = Path(__file__).resolve().parent.parent
+THREADHOP = ROOT / "threadhop"
+
+
+def _home_dirs(home: Path) -> tuple[Path, Path]:
+    cfg = home / ".config" / "threadhop"
+    obs = cfg / "observations"
+    obs.mkdir(parents=True, exist_ok=True)
+    return cfg / "sessions.db", obs
+
+
+def _run_threadhop(home: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    return subprocess.run(
+        [str(THREADHOP), *args],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_observations_dumps_raw_jsonl_newest_first(tmp_path: Path):
+    home = tmp_path / "home"
+    db_path, obs_dir = _home_dirs(home)
+    db.init_db(db_path).close()
+
+    older = '{"type":"todo","text":"wire CLI","context":"","ts":"2026-04-17T09:00:00Z"}'
+    newest = '{"type":"decision","text":"read per-session files","context":"ADR-019","ts":"2026-04-17T11:00:00Z"}'
+    middle = '{"type":"observation","text":"observer is core","context":"ADR-010","ts":"2026-04-17T10:00:00Z"}'
+
+    (obs_dir / "alpha.jsonl").write_text(f"{older}\n{newest}\n")
+    (obs_dir / "beta.jsonl").write_text(f"{middle}\n")
+
+    result = _run_threadhop(home, "observations")
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert result.stdout.splitlines() == [newest, middle, older]
+
+
+def test_observations_project_filter_uses_sqlite_session_mapping(tmp_path: Path):
+    home = tmp_path / "home"
+    db_path, obs_dir = _home_dirs(home)
+    conn = db.init_db(db_path)
+    try:
+        db.upsert_session(
+            conn, "sess-alpha", "/missing/alpha.jsonl",
+            project="atlas",
+        )
+        db.upsert_session(
+            conn, "sess-beta", "/missing/beta.jsonl",
+            project="zephyr",
+        )
+    finally:
+        conn.close()
+
+    atlas_line = '{"type":"decision","text":"use sqlite","context":"atlas","ts":"2026-04-17T10:00:00Z"}'
+    zephyr_line = '{"type":"decision","text":"use postgres","context":"zephyr","ts":"2026-04-17T11:00:00Z"}'
+    (obs_dir / "sess-alpha.jsonl").write_text(f"{atlas_line}\n")
+    (obs_dir / "sess-beta.jsonl").write_text(f"{zephyr_line}\n")
+
+    result = _run_threadhop(home, "observations", "--project", "atl")
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert result.stdout.splitlines() == [atlas_line]

--- a/threadhop
+++ b/threadhop
@@ -3964,6 +3964,148 @@ def _cli_stub(command):
     return 0
 
 
+def _ensure_cli_session_row(
+    conn: sqlite3.Connection,
+    session_id: str,
+) -> dict | None:
+    """Return the session row for ``session_id``, seeding it from disk if needed."""
+    row = db.get_session(conn, session_id)
+    if row is not None:
+        return row
+    session_path = find_session_path(session_id)
+    if session_path is None:
+        return None
+    db.upsert_session(
+        conn, session_id, str(session_path),
+        project=session_path.parent.name,
+    )
+    return db.get_session(conn, session_id)
+
+
+def _query_cli_sessions(
+    conn: sqlite3.Connection,
+    *,
+    project: str | None = None,
+    session_id: str | None = None,
+) -> list[dict]:
+    """Resolve the sessions targeted by a CLI query.
+
+    Project filtering intentionally goes through SQLite's ``sessions`` table
+    (ADR-019) rather than inferring the project from observation filenames.
+    """
+    if session_id:
+        row = _ensure_cli_session_row(conn, session_id)
+        return [row] if row is not None else []
+
+    sql = (
+        "SELECT session_id, session_path, project, modified_at "
+        "FROM sessions"
+    )
+    params: list[str] = []
+    if project:
+        sql += " WHERE project LIKE ?"
+        params.append(f"%{project}%")
+    sql += " ORDER BY modified_at IS NULL, modified_at DESC, session_id"
+    return db.query_all(conn, sql, tuple(params))
+
+
+def _obs_path_for_session(
+    conn: sqlite3.Connection,
+    session_id: str,
+) -> Path:
+    """Return the canonical observation-file path for ``session_id``."""
+    state = db.get_observation_state(conn, session_id)
+    if state is not None and state.get("obs_path"):
+        return Path(state["obs_path"])
+    return db.OBS_DIR / f"{session_id}.jsonl"
+
+
+def _catch_up_cli_observations(
+    conn: sqlite3.Connection,
+    sessions: list[dict],
+) -> list[str]:
+    """Run the observer once per targeted session, collecting hard failures."""
+    errors: list[str] = []
+    for row in sessions:
+        sid = row["session_id"]
+        result = observer.observe_session(conn, sid)
+        if result.get("status") == "failed":
+            errors.append(
+                f"{sid}: {result.get('message') or result.get('error') or 'observer failed'}"
+            )
+    return errors
+
+
+def _sessions_with_observation_files(
+    conn: sqlite3.Connection,
+    sessions: list[dict],
+) -> tuple[list[dict], list[Path]]:
+    """Filter ``sessions`` down to rows that already participate in observations."""
+    filtered_sessions: list[dict] = []
+    obs_paths: list[Path] = []
+    for row in sessions:
+        obs_path = _obs_path_for_session(conn, row["session_id"])
+        state = db.get_observation_state(conn, row["session_id"])
+        if not obs_path.exists() and state is None:
+            continue
+        filtered_sessions.append(row)
+        obs_paths.append(obs_path)
+    return filtered_sessions, obs_paths
+
+
+def _load_observation_lines(
+    conn: sqlite3.Connection,
+    *,
+    project: str | None = None,
+    session_id: str | None = None,
+) -> tuple[list[str], list[str]]:
+    """Read observation JSONL lines, newest-first, preserving raw line text."""
+    errors: list[str] = []
+    if session_id:
+        sessions = _query_cli_sessions(
+            conn, project=project, session_id=session_id,
+        )
+        errors.extend(_catch_up_cli_observations(conn, sessions))
+        obs_paths = [_obs_path_for_session(conn, row["session_id"]) for row in sessions]
+    elif project:
+        sessions = _query_cli_sessions(conn, project=project)
+        sessions, obs_paths = _sessions_with_observation_files(conn, sessions)
+        errors.extend(_catch_up_cli_observations(conn, sessions))
+    else:
+        obs_paths = sorted(db.OBS_DIR.glob("*.jsonl"))
+        session_rows: list[dict] = []
+        for obs_path in obs_paths:
+            row = db.get_session(conn, obs_path.stem)
+            if row is not None:
+                session_rows.append(row)
+        errors.extend(_catch_up_cli_observations(conn, session_rows))
+
+    ranked: list[tuple[str, int, str]] = []
+    seq = 0
+    for obs_path in obs_paths:
+        if not obs_path.exists():
+            continue
+        try:
+            with open(obs_path) as f:
+                for line_no, raw_line in enumerate(f, start=1):
+                    raw = raw_line.rstrip("\n")
+                    if not raw.strip():
+                        continue
+                    try:
+                        entry = json.loads(raw)
+                    except (json.JSONDecodeError, ValueError) as e:
+                        errors.append(f"{obs_path}:{line_no}: invalid JSON: {e}")
+                        continue
+                    ts = entry.get("ts")
+                    ranked.append((ts if isinstance(ts, str) else "", seq, raw))
+                    seq += 1
+        except OSError as e:
+            errors.append(f"{obs_path}: {e}")
+
+    ranked.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    return [raw for _ts, _seq, raw in ranked], errors
+
+
 def _resolve_cli_session(args) -> int:
     """Populate args.session via auto-detection when omitted.
 
@@ -4081,8 +4223,12 @@ def build_parser():
     subparsers.add_parser(
         "observations",
         parents=[shared],
-        help="List all memory entries (todos, decisions, observations)",
-        description="List everything in the memory ledger. Use --project/--session to filter.",
+        help="Dump observations JSONL, newest first",
+        description=(
+            "Dump all observation entries as raw JSON lines, newest first. "
+            "Reads per-session files under ~/.config/threadhop/observations/ "
+            "and uses SQLite session metadata for --project filtering."
+        ),
     )
 
     observe_p = subparsers.add_parser(
@@ -4161,6 +4307,25 @@ def cmd_observe(args) -> int:
     return 0
 
 
+def cmd_observations(args) -> int:
+    """Dump raw observation JSONL lines, newest first."""
+    conn = db.init_db()
+    try:
+        lines, errors = _load_observation_lines(
+            conn,
+            project=args.project,
+            session_id=args.session,
+        )
+    finally:
+        conn.close()
+
+    for raw in lines:
+        print(raw)
+    for err in errors:
+        print(f"threadhop observations: {err}", file=sys.stderr)
+    return 0
+
+
 def main():
     parser = build_parser()
     args = parser.parse_args()
@@ -4190,6 +4355,8 @@ def main():
         return 0
     if args.command == "observe":
         return cmd_observe(args)
+    if args.command == "observations":
+        return cmd_observations(args)
     return _cli_stub(args.command)
 
 


### PR DESCRIPTION
Implements #22.

## What
- Adds `threadhop observations [--project <name>]`.
- Dumps observation entries newest first.
- Reads per-session files from `~/.config/threadhop/observations/*.jsonl`.
- Uses the SQLite session-to-project mapping for `--project`.
- Preserves grep/jq-friendly output by printing one raw JSON object per line.

## Implementation
- Added CLI helpers to resolve target sessions from `--session` or `--project`.
- Reused the observer core to catch up targeted sessions before reading output.
- Read per-session observation files and sorted entries globally by `ts` descending.
- Parsed each line only for ordering; stdout still emits the original JSONL line unchanged.
- Routed malformed JSON / file-read issues to stderr so stdout stays pipe-friendly.

## Decision Tree
1. `--session <id>`: resolve or seed that session row, catch it up, then dump that session's observation file.
2. `--project <name>`: select matching sessions from SQLite, keep sessions that already participate in observations, catch them up, then dump their files.
3. No filter: scan `~/.config/threadhop/observations/*.jsonl`, catch up sessions that have DB rows, then dump everything.

## Test Plan
- [x] `python3 -m pytest tests/test_cli_observations.py -q`
- [x] Verified unfiltered output is newest-first across multiple per-session files
- [x] Verified `--project` filtering uses SQLite session mapping rather than filename inference

Generated with Codex