### PR TITLE
docs: add PERFORMANCE.md + UI-IMPROVEMENTS.md, schedule perf tasks #50–#53

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,288 @@
+# ThreadHop — Performance Design
+
+Design decisions for the four near-term performance initiatives. Extracted
+from the TUI redesign exploration on 2026-04-19 — the broader catalogue
+of UI / UX ideas lives in [UI-IMPROVEMENTS.md](UI-IMPROVEMENTS.md);
+these four are the ones scheduled for work.
+
+ADR numbering continues the global sequence from
+[DESIGN-DECISIONS.md](DESIGN-DECISIONS.md) so task references stay
+unambiguous.
+
+Status: **Design complete, implementation not started.**
+
+---
+
+## Table of Contents
+
+- [Ordering & Rationale](#ordering--rationale)
+- [ADR-023: Event-driven session discovery via fsevents](#adr-023-event-driven-session-discovery-via-fsevents)
+- [ADR-024: Defer transcript parse until focus with lazy tail load](#adr-024-defer-transcript-parse-until-focus-with-lazy-tail-load)
+- [ADR-025: Row-window virtualisation of TranscriptView](#adr-025-row-window-virtualisation-of-transcriptview)
+- [ADR-026: Arrow/Parquet-backed DataTable via textual-fastdatatable](#adr-026-arrowparquet-backed-datatable-via-textual-fastdatatable)
+
+---
+
+## Ordering & Rationale
+
+Two of the four are **backend / data-layer** changes that land alongside
+the indexer and observer work in Phase 2. The other two are
+**rendering-layer** changes that land after the observer ships and the
+cross-session query surfaces (#14, #20, #21, #22, #45) expose tables
+large enough to matter.
+
+| # | ADR | Layer | Phase | Depends on |
+|---|-----|-------|-------|-----------|
+| 50 | ADR-023 | Backend — discovery | Phase 2 | #1 (SQLite), #8 (indexer) |
+| 51 | ADR-024 | Backend — parse | Phase 2 | #8 (indexer) |
+| 52 | ADR-025 | Rendering — transcript | Phase 7 | #51 |
+| 53 | ADR-026 | Rendering — tables | Phase 7 | #14 (search) |
+
+Backend-first because the rendering work assumes fresh, lazily-parsed
+data. Virtualising a widget whose data source still does a synchronous
+full-file parse just moves the stutter.
+
+---
+
+## ADR-023: Event-driven session discovery via fsevents
+
+**Context:** `_gather_session_data()` runs in a background worker every
+5 seconds. It scans `~/.claude/projects/**/*.jsonl`, reads the first 100
+lines of each file for metadata, and rebuilds the session list. The
+work is O(sessions) whether anything changed or not. Worst case the UI
+lags up to 5 s behind Claude Code actually writing a message. Related
+pieces already in flight: task #9 (incremental FTS indexing by byte
+offset) and task #34 (observer sidecar watching a single file via
+fsevents).
+
+**Decision:** Replace the 5 s poll with a single `watchdog` observer
+rooted at `~/.claude/projects`. On file-system events
+(`FileModifiedEvent`, `FileCreatedEvent`, `FileDeletedEvent`), dispatch
+a Textual `post_message` that the UI handles to update just the
+affected session row. Polling is retained only as a cold-start path
+(initial discovery on app launch).
+
+**Rationale:**
+- macOS `fsevents` (and Linux `inotify`) give sub-100 ms latency — the
+  UI feels as live as Claude Code itself
+- CPU at idle drops to zero — no more 5-second wake-ups
+- The checkpoint logic task #9 already needs (per-file byte offset) is
+  the right shape for incremental work triggered by events rather than
+  polling
+- `watchdog` transparently abstracts fsevents / kqueue / inotify, so
+  the macOS-only concern only affects which event backend we pin at
+  install time
+- Existing session-detection (`ps` / `lsof` for active `claude`
+  processes) stays on its own cadence — that's a different signal
+
+**Rejected:**
+- Keeping the 5 s poll and only cutting the per-file work. Still burns
+  a wakeup; still has up-to-5-second lag; doesn't fix the idle CPU cost
+  enough to justify staying on polling
+- Inlining fsevents handling into the observer sidecar (task #34).
+  That covers a single observed session; this ADR is about the
+  **global** session-list refresh the TUI runs whether or not any
+  observer is attached
+
+**Implementation sketch:**
+- Add `watchdog` to the `uv run --script` PEP 723 dependency block
+- New module `fs_watch.py`: wraps `watchdog.observers.Observer`, emits
+  typed Textual messages (`SessionFileChanged`, `SessionFileCreated`,
+  `SessionFileDeleted`) on the UI thread
+- `ClaudeSessions.on_mount()` starts the observer; `on_unmount()`
+  stops it
+- `_gather_session_data()` retained only for first-boot discovery;
+  per-session state is updated by message handlers
+- Incremental parse: each event carries a path → look up
+  `index_state.byte_offset` → `seek()` → parse only the tail → update
+  metadata + FTS row. Always parse up to the last `\n` (guard against
+  partial flushes)
+
+**Cost:** Small. New dependency (`watchdog` is well-known). Main
+engineering is the partial-line guard and making sure the event stream
+and the cold-start scan don't race.
+
+**Reference idea:** [UI-IMPROVEMENTS.md — Performance Patterns](UI-IMPROVEMENTS.md#performance-patterns)
+("Incremental re-index on fsevents"). Inspiration: lnav's byte-offset
+checkpointing — [lnav performance](https://docs.lnav.org/en/latest/performance.html).
+
+---
+
+## ADR-024: Defer transcript parse until focus with lazy tail load
+
+**Context:** `load_transcript()` opens the selected session's JSONL,
+parses every line, and synchronously mounts a `UserMessage` /
+`AssistantMessage` / `ToolMessage` widget for each. For a 50 MB session
+this blocks the UI for visible seconds. The app already does a cheap
+version of this on discovery (only reading the first 100 lines for
+metadata), but the full parse on selection is the actual felt-latency
+cost.
+
+**Decision:** Keep discovery cheap (unchanged). On session focus, read
+the **tail** of the file first (~64 KB), parse backwards from EOF,
+mount the visible range immediately, then stream earlier messages in
+from a background worker. Cache parsed message lists per session in an
+LRU; invalidate when ADR-023 fires a file-change event for that
+session.
+
+**Rationale:**
+- Users almost always want the most recent messages when they open a
+  session — the tail-first read delivers those in tens of milliseconds
+  regardless of file size
+- The background fill keeps "scroll up to older messages" working
+  without blocking the initial paint
+- The LRU makes session-hopping feel instant after the first visit —
+  paired with ADR-025's virtualisation this eliminates the "opening a
+  big session hangs the TUI" failure mode
+- Piggybacks on ADR-023's event stream for cache invalidation
+
+**Rejected:**
+- Pre-parsing all sessions in the background on startup. Wastes
+  memory on sessions the user never opens and moves the cost rather
+  than removing it
+- Mounting widgets lazily *inside* `TranscriptView` without changing
+  the parse model. The parse itself is the hot path — widget mount is
+  a separate concern handled by ADR-025
+
+**Implementation sketch:**
+- Refactor `load_transcript()` to return an async iterator of message
+  dicts rather than a list
+- New helper `parse_tail(path, max_bytes=65536) -> list[dict]`: opens
+  the file, seeks to `max(0, filesize - max_bytes)`, advances to the
+  next `\n`, parses from there to EOF
+- Spawn a `@work` background task that parses the remaining head (byte
+  0 → tail-start) and yields message dicts as they resolve
+- `TranscriptCache` — simple LRU keyed by `session_id`, value is
+  `list[dict]`. Invalidated by `SessionFileChanged` messages from
+  ADR-023
+- `TranscriptView.load(session_id)` consumes the iterator and renders
+  as messages arrive (today: mount each; after ADR-025: update the
+  virtual window)
+
+**Cost:** Medium. Mostly a refactor of `load_transcript` into an async
+pipeline and teaching `TranscriptView` to accept incremental appends.
+Low risk because the render logic itself doesn't change.
+
+**Reference idea:** [UI-IMPROVEMENTS.md — Performance Patterns](UI-IMPROVEMENTS.md#performance-patterns)
+("Defer heavy parse until focus"). Inspiration: k9s's resource-detail
+fetch-on-drill-in pattern.
+
+---
+
+## ADR-025: Row-window virtualisation of TranscriptView
+
+**Context:** Today `TranscriptView` mounts one widget per message. A
+4-hour session with 3k messages produces 3k live widgets — each with
+CSS, event handlers, and layout cost. Textual re-computes layout for
+all of them on resize, theme change, and some scroll events. This is
+the dominant cost for long sessions even after ADR-024 makes the
+initial parse fast, because the widget mount loop has its own
+bottleneck.
+
+**Decision:** Replace the current `VerticalScroll`-of-all-messages
+with a custom virtual-scroll container that mounts only the **visible
+range + a small overscan buffer**. As the user scrolls, recycle widget
+instances — the same N widgets get their content swapped rather than
+new mounts.
+
+**Rationale:**
+- Rendering cost becomes constant in the session's length — a
+  3k-message transcript behaves identically to a 100-message one
+- Jump-to-message (e.g., from search results in #14, or timeline
+  scrubbing if ever built) becomes O(1) instead of O(N) mounts
+- Idiomatic in modern TUIs: Textual's own `DataTable` virtualises the
+  same way, ratatui lists do it natively, TanStack Virtual is the
+  web-world equivalent. We aren't inventing anything novel
+- Enables the density toggle (UI-IMPROVEMENTS.md pattern #6) cleanly
+  — compact rows and expanded rows both fit the same virtual-row API
+
+**Rejected:**
+- Using Textual's `DataTable` as-is to render messages. Message
+  bodies aren't tabular — they have varying heights, inline markdown,
+  selection state. `DataTable` is the wrong shape
+- Fixing this with Textual's `OptionList`. Similar mismatch — no
+  per-row-widget escape hatch, limited styling
+- Deferring mount until scroll (lazy-append). Still ends up with N
+  widgets when the user reaches the bottom, which is the common case
+
+**Implementation sketch:**
+- New widget `VirtualTranscript(ScrollView)`:
+  - Holds the parsed message list as plain data (not widgets)
+  - Maintains a small widget pool (`UserMessage`, `AssistantMessage`,
+    `ToolMessage` instances) — one pool per message type
+  - On `scroll` / `resize`, computes visible index range +
+    ±OVERSCAN_ROWS buffer, pulls widgets from the pool, applies
+    message data, mounts at the correct y-offset
+  - Recycles widgets that fall out of range back into their pool
+- Start with **fixed row height** (measured once per message type) +
+  overflow ellipsis. Variable-height support lands in a follow-up —
+  the density toggle handles most of the tall-message cases by letting
+  the user collapse them
+- Expand-on-focus: when a row receives focus, it can grow to full
+  height and the container recomputes offsets below
+
+**Cost:** Non-trivial. Not a library drop-in — this is a custom
+scroll container. Budget a focused week. Single biggest performance
+win in the roadmap.
+
+**Reference idea:** [UI-IMPROVEMENTS.md — Performance Patterns](UI-IMPROVEMENTS.md#performance-patterns)
+("Row-window virtualisation for the transcript"). Inspiration: Textual
+`DataTable` internals, ratatui lists, TanStack Virtual (web).
+
+---
+
+## ADR-026: Arrow/Parquet-backed DataTable via textual-fastdatatable
+
+**Context:** Textual's stock `DataTable` keeps every row as Python
+objects in memory. Fine at a few hundred rows, painful past a few
+thousand. ThreadHop's session list is small, but the cross-session
+query surfaces landing in Phase 3 (tasks #20 `todos`, #21 `decisions`,
+#22 `observations`, #45 `conflicts`, and the observation CLI queries
+generally) and the full-text search results in task #14 will routinely
+produce 10k–300k rows once real usage accumulates.
+
+**Decision:** Adopt
+[`textual-fastdatatable`](https://github.com/tconbeer/textual-fastdatatable)
+as a drop-in replacement for `DataTable` at every data-heavy surface —
+search results, cross-session query output, and (later) any Phase 3
+CLI view ported into the TUI. Keep the stock `DataTable` for trivial
+tabular surfaces where the row count is bounded (settings panes, help
+overlay listings).
+
+**Rationale:**
+- Arrow's columnar layout means memory and sort/filter scale with the
+  *projection size*, not the raw row count — idiomatic for FTS hits
+  and cross-session aggregates
+- SQLite → Arrow is a one-call conversion via `pyarrow.Table.from_pydict`
+  on `fetchall()` output, so query pipelines stay straightforward
+- The library is a direct `DataTable` API match — cutover is mostly
+  import changes
+- Parquet support means we can later materialise expensive queries
+  (e.g., trigram-augmented search results in task #32) as on-disk
+  tables the TUI reads lazily
+
+**Rejected:**
+- Staying on Textual's `DataTable` and paging queries manually. Moves
+  complexity into every call site; doesn't fix sort/filter perf
+- Building our own Arrow-backed table widget. The library already
+  exists, is maintained, and matches the API we want
+
+**Implementation sketch:**
+- Add `pyarrow` and `textual-fastdatatable` to the PEP 723 dependency
+  block (note: `pyarrow` is a ~50 MB wheel — acceptable for a local
+  dev tool)
+- Swap imports at every heavy surface (search panel, `todos` /
+  `decisions` / `observations` / `conflicts` views when they come to
+  the TUI). Light surfaces keep `DataTable`
+- Query helpers in `db.py` grow a `fetch_arrow()` sibling to
+  `fetch_all()` for callers that want Arrow straight out of SQLite
+- Verify macOS wheels cover both Intel and Apple Silicon (they do as
+  of `pyarrow` 13+)
+
+**Cost:** Small — dependency weight and a straightforward API swap.
+Main risk is the wheel size; mitigated by the fact that this is a
+local dev tool, not a shipped binary.
+
+**Reference idea:** [UI-IMPROVEMENTS.md — Performance Patterns](UI-IMPROVEMENTS.md#performance-patterns)
+("Arrow/Parquet-backed DataTable"). Library:
+[textual-fastdatatable](https://github.com/tconbeer/textual-fastdatatable).

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,6 +1,7 @@
 # ThreadHop — Implementation Task List
 
-Extracted from [DESIGN-DECISIONS.md](DESIGN-DECISIONS.md). Last reconciled 2026-04-17.
+Extracted from [DESIGN-DECISIONS.md](DESIGN-DECISIONS.md) and
+[PERFORMANCE.md](PERFORMANCE.md). Last reconciled 2026-04-19.
 
 ---
 
@@ -56,6 +57,12 @@ _Enables instant search and cross-session context sharing. All TUI features._
 
 - [ ] **42. Context-aware help overlay + command metadata registry**
   Add a full-app discoverability surface modeled on the search modal, but for commands instead of FTS results. Keep the footer minimal/contextual rather than trying to show every keybinding all the time. Define a shared command metadata registry that covers both app-level bindings and widget-local modes (session list, transcript, selection mode, reply input, search/find), and use it to drive the help overlay plus footer hints from one source of truth. The implementation should leave the final help trigger key open and must not assume `H`, since handoff shortcut work is still in flux. _(ADR-017)_
+
+- [ ] **50. Event-driven session discovery via fsevents** *(blocked by: #1, #8; supersedes polling in `_gather_session_data()`)*
+  Replace the 5 s poll with a `watchdog` observer rooted at `~/.claude/projects`. Dispatch typed Textual messages (`SessionFileChanged`, `SessionFileCreated`, `SessionFileDeleted`) on file-system events and update just the affected session row incrementally — seek to the stored byte offset, parse only the tail, update metadata + FTS. Retain polling only for cold-start discovery. Distinct from task #34 (single-session observer sidecar): this is the global session-list refresh path. Add `watchdog` to the PEP 723 dependency block. _(ADR-023, PERFORMANCE.md)_
+
+- [ ] **51. Defer transcript parse until focus with lazy tail load** *(blocked by: #8; prereq for: #52)*
+  Refactor `load_transcript()` into an async pipeline. On session focus, read ~64 KB from the tail, parse backwards from EOF, paint the visible range immediately, then stream earlier messages from a `@work` background task. Add a `TranscriptCache` LRU keyed by `session_id`, invalidated by `SessionFileChanged` events from #50. Discovery-side parse stays cheap (first 100 lines only, unchanged). _(ADR-024, PERFORMANCE.md)_
 
 - [ ] **33. Data model hardening: CHECK constraints + Pydantic schemas** *(blocked by: #1; prereq for: #8)*
   Add a migration introducing `CHECK (status IN ('active','in_progress','in_review','done','archived'))` on the `sessions` table so the enum is enforced at the DB layer, not just the app. Design Pydantic models as the validation boundary for JSONL transcript parsing — user/assistant messages, `tool_use` blocks, `tool_result` blocks — so the indexer in #8 folds over typed instances instead of raw dicts and malformed lines fail loudly. Use `Literal` types for enums (session status, message role, memory `type`). Define `Session`, `Message`, `Bookmark`, `MemoryEntry` shapes alongside their table migrations so the Python types and SQL schemas evolve together. Add `pydantic` to the script's PEP 723 dependency block. _(ADR-001, ADR-003, ADR-004)_
@@ -210,62 +217,13 @@ process — not independent. Uses `reflector_entry_offset` for incremental proce
 
 ---
 
-## Dependency Graph (critical path)
+## Phase 7: Rendering Performance
+_Scheduled after the observer ships and cross-session query surfaces
+(#14, #20-22, #45) expose enough rows to matter. Backend perf (#50,
+#51) lands in Phase 2 — rendering perf lands here._
 
-```
-#1 SQLite DB ──┬──> #2 Migration ──> #7 Tests
-               ├──> #3 Status ──┬──> #4 Keybinds (s/S)  ─────────┐
-               │                └──> #5 Archive (a/A)            │
-               ├──> #33 Data models ──> #8 Indexer ──> #9 Incremental ──> #14 Search │ ──> #32 Fuzzy
-               ├──> #44 observation_state table ──┐
-               │                                   ├──> #46 TUI obs indicator
-               │                                   ├──> #47 Transcript header
-               │                                   └──> (prereq for #18, #35)
-               │
-               │  #43 Observer prompt (independent)
-               │         ↓
-               │  #8 Indexer + #43 + #44 ──> #18 Observer core ──> #19 Incremental
-               │                                                    ├──> #20 todos
-               │                                                    ├──> #21 decisions
-               │                                                    ├──> #22 observations
-               │                                                    ├──> #45 conflicts CLI
-               │                                                    ├──> #29 Annotation detection
-               │                                                    ├──> #30 Memory rendering
-               │                                                    ├──> #34 Background observer ──> #35 Stop/resume lifecycle
-               │                                                    │                            ├──> #48 TUI obs keybindings (o/O)
-               │                                                    │                            └──> #36 Observer-triggered reflector (also needs #31)
-               │                                                    └──> #49 Reflector prompt ──> #31 Reflector core ──> #38 TUI notification
-               │                                                                                                     └──> #39 Condensation
-               ├──> #27 Bookmarks (also needs #10)
-               └──> #28 Memory ledger ──┬──> #29 Annotation detection
-                                        └──> #30 Memory rendering
+- [ ] **52. Row-window virtualisation of TranscriptView** *(blocked by: #51)*
+  Replace the `VerticalScroll`-of-all-messages with a custom virtual-scroll container (`VirtualTranscript(ScrollView)`) that mounts only the visible range + overscan buffer and recycles widget instances from per-type pools (`UserMessage`, `AssistantMessage`, `ToolMessage`). Start with fixed row height + overflow ellipsis; expand-on-focus handles tall messages. Single biggest rendering-perf win — makes long sessions render in constant cost. _(ADR-025, PERFORMANCE.md)_
 
-#6 Sidebar resize (independent)
-
-#42 Help overlay + command registry (independent)
-
-#10 Selection ──┬──> #11 Range select
-                ├──> #12 Clipboard copy ──> #25 /threadhop:context (also needs #23)
-                ├──> #13 Temp export
-                └──> #27 Bookmarks (also needs #1)
-
-#15 Subcommand routing ──> #16 tag CLI ──> #17 Auto-detect session
-                                        └──> #24 /threadhop:tag skill (also needs #23)
-
-#23 Skill packaging research ──┬──> #24 /threadhop:tag
-                                ├──> #25 /threadhop:context
-                                ├──> #26 /threadhop:handoff (runs observer first, then formats)
-                                ├──> #40 /threadhop:observe (also needs #34)
-                                └──> #41 /threadhop:insights (reads unified per-session file)
-
-Entry points for session tagging (ADR-013): #4 (TUI) · #16 (CLI) · #24 (skill) — all write to the same sessions table.
-
-Observer as core function (ADR-018): #43 prompt + #44 state table → #18 core → used by #34 (background), #26 (handoff), #20-22,45 (CLI queries), #40 (skill)
-
-Reflector as observer companion (ADR-022): #49 prompt → #31 core → triggered by #34 observer (when entry_count - reflector_entry_offset ≥ 5)
-  Reflector input: decisions from observation files (not raw transcripts). Output: type:"conflict" entries in same JSONL.
-
-Observer-reflector unified output (ADR-020): #18 observer + #31 reflector both append to observations/<session_id>.jsonl
-
-TUI observation surface (ADR-021): #44 → #46 indicator + #47 header + #48 keybindings (o/O)
-```
+- [ ] **53. Migrate data-heavy DataTables to textual-fastdatatable** *(blocked by: #14; also benefits #20, #21, #22, #45 if those land in the TUI)*
+  Swap Textual's `DataTable` for [`textual-fastdatatable`](https://github.com/tconbeer/textual-fastdatatable) at every heavy surface — search results panel, cross-session query views, observation browsers. Light surfaces (settings, help) keep the stock `DataTable`. Add `pyarrow` + `textual-fastdatatable` to the PEP 723 deps. Add `db.fetch_arrow()` helper for SQLite → Arrow conversion so query pipelines can feed the table directly. _(ADR-026, PERFORMANCE.md)_

--- a/docs/UI-IMPROVEMENTS.md
+++ b/docs/UI-IMPROVEMENTS.md
@@ -1,0 +1,223 @@
+# ThreadHop — UI / UX Improvement Ideas
+
+Captured from a design exploration on 2026-04-19. Survey of modern TUI
+patterns (agentic CLIs, transcript/log viewers, dashboard TUIs, Charm /
+ratatui aesthetics) to inform a radical next-gen redesign.
+
+Status: **Ideas only — not scheduled.** Pull items into `TASKS.md` when
+promoted.
+
+---
+
+## Table of Contents
+
+- [Borrowable Patterns (12)](#borrowable-patterns-12)
+- [Aesthetic Moves Worth Stealing](#aesthetic-moves-worth-stealing)
+- [Performance Patterns](#performance-patterns)
+- [Three-Thing vNext](#three-thing-vnext)
+- [Sources](#sources)
+
+---
+
+## Borrowable Patterns (12)
+
+### 1. Transient menus (Magit)
+
+Prefix key → floating popup of grouped commands **with togglable flags**
+before you fire. Not a palette — a stateful command-builder. Maps
+naturally to `handoff --include-sidechains --from=<uuid>`.
+**Textual difficulty:** Medium (`ModalScreen` + grid; the infix flag
+state is the hard bit).
+
+### 2. Hotlist / activity strip (WeeChat)
+
+One-line strip showing only sessions that changed since last look,
+coloured by urgency. `Alt+A` cycles. Replaces the 36-col sidebar when
+you have 20+ sessions.
+**Easy.**
+
+### 3. SQL-over-transcripts ad-hoc view (lnav)
+
+Press `;` → SQL prompt queries JSONL as virtual tables. Example:
+`SELECT sessionId, count(*) FROM tool_call WHERE tool='Bash' AND ts > today()-7`.
+Already have SQLite + FTS; mostly schema work.
+**Medium.**
+
+### 4. Threaded message tree pane (NeoMutt)
+
+Collapsible ASCII tree in a left gutter mirroring the transcript.
+Sidechains render as `├─ subagent(researcher): …` under their parent.
+Different from a full DAG — it is a gutter, not a canvas.
+**Medium.**
+
+### 5. Timeline rail with live-preview filter (lnav 0.14)
+
+Top/bottom strip that is both scrubber and filter. Drag handles →
+matching lines dim in-place before you commit. "Show only user messages
+3–5 pm."
+**Medium.**
+
+### 6. Density toggle (Crush)
+
+One binding flips the entire UI between verbose and one-line-compact.
+Crush ships `compact_mode`. 10× scrolling speed-up.
+**Easy.**
+
+### 7. btop-style toggleable regions
+
+Overview screen with N panels, digit keys `1`–`5` hide/show each.
+Sparkline-per-project, open TODOs, blocked-on-user sessions.
+**Easy–medium.**
+
+### 8. Zoomable time-series sparkline (zenith)
+
+`+`/`-` zooms time axis above the transcript. Click-scrub ties sparkline
+position to transcript scroll. See the 3-hour gap or 40-tool-call burst.
+**Medium.**
+
+### 9. Chrome-style session tabs (opencode proposal)
+
+Persistent top tabs with per-tab status (spinner / attention / error /
+done). Preserves scroll position unlike list selection. Hybrid with #2:
+tabs for pinned, hotlist for the long tail.
+**Easy.**
+
+### 10. Subagent split panel (opencode proposal)
+
+When a session has sidechains, peel them into a right-side panel —
+"what is the subagent doing now." Currently they are inlined and
+visually indistinguishable.
+**Medium.**
+
+### 11. Regex-capture-groups-as-columns (lnav)
+
+User types a regex with named captures → lnav materialises it as a SQL
+table. For ThreadHop: `TODO: (?<task>.+)`,
+`` ```(?<lang>\w+)\n(?<code>.+?)``` ``. Save, reuse, query across
+sessions. More powerful than tags.
+**Medium.**
+
+### 12. Discoverability popup (Helix / which-key)
+
+Press `space` → floating menu of every valid next binding,
+context-aware. Replaces the static help overlay (ADR-017) with a
+keyboard tutor that teaches as you use it. The command registry already
+has the data.
+**Easy.**
+
+---
+
+## Aesthetic Moves Worth Stealing
+
+- **Glamour-rendered markdown** for assistant messages (Textual 5's
+  `Markdown` widget). Real code-fence syntax highlighting.
+- **Single accent gradient** (Crush charmtone) instead of per-message
+  background tints. Less palette sprawl.
+- **Nerd Font glyphs** for density —  /  /  / . Gate behind a
+  setting.
+- **Chrome reduction** (Helix) — kill borders, use 1-px dividers +
+  background tint.
+- **Contextual bottom key-hint bar** (k9s, Crush) that shrinks as focus
+  changes.
+- **Kitty graphics protocol** for real line charts + inline avatars on
+  iTerm2 / Kitty / WezTerm / Ghostty. Textual cannot render inline
+  raster — shell out to `kitty +kitten icat`. Unicode fallback required.
+- **Turn on Textual smooth pixel scrolling** (2.0+). Near-zero-code
+  perceptual win.
+
+---
+
+## Performance Patterns
+
+- **SQLite virtual tables over raw JSONL** (lnav). Index by byte offset
+  + timestamp; do not ingest row-per-message. See
+  https://docs.lnav.org/en/latest/performance.html.
+- **Arrow / Parquet-backed DataTable** via
+  [`textual-fastdatatable`](https://github.com/tconbeer/textual-fastdatatable).
+  Drop-in, loads 300k rows instantly.
+- **Row-window virtualisation for the transcript.** Mount only visible
+  range + buffer, reuse widgets. Current `VerticalScroll` mounts
+  everything — the single biggest perf win for long sessions.
+- **Incremental re-index on fsevents** — parse only the bytes after the
+  last checkpoint.
+- **Defer heavy parse until focus** (k9s). Session list stays cheap;
+  full JSONL loads only on selection.
+- **Cap indexer CPU** (btop) at a fixed fraction. A laggy TUI is more
+  noticeable than slightly-slower search.
+
+---
+
+## Three-Thing vNext
+
+Minimum set that delivers the biggest felt improvement:
+
+1. Virtualise transcript rendering + turn on Textual smooth scroll.
+2. Replace the sidebar with Chrome tabs (#9) + WeeChat hotlist (#2).
+3. Add the `:` SQL prompt over a JSONL virtual table (#3) — unlocks #5,
+   #8, #11 almost for free.
+
+## The Hot Take
+
+ThreadHop vNext is **lnav for AI transcripts**: single scroll surface
+warpable with a `:` SQL prompt, a scrubbable / filterable timeline rail
+up top, a collapsible thread-tree in the left gutter (not a separate
+DAG), a Magit-style transient menu for `handoff` / `tag` / `fork` with
+their flags, and a hotlist strip + Chrome tabs for multi-session
+presence without a permanent 36-col sidebar. Storage: virtual tables
+over JSONL — never re-parse on launch. Trade-off: the most beautiful
+version assumes Kitty / iTerm2 / WezTerm; Unicode fallbacks required.
+If aesthetics truly dominate, the honest answer is a Bubble Tea rewrite
+in Go — but ~90% of the functional ideas ship in Textual today.
+
+---
+
+## Sources
+
+Agentic CLI / TUI:
+- [Crush (Charm)](https://github.com/charmbracelet/crush),
+  [TUI arch](https://deepwiki.com/charmbracelet/crush/5.1-tui-architecture),
+  [Styling](https://deepwiki.com/charmbracelet/crush/5.8-styling-system)
+- [OpenCode TUI docs](https://opencode.ai/docs/tui/),
+  [multi-session tabs](https://github.com/anomalyco/opencode/issues/16047),
+  [subagent panel](https://github.com/anomalyco/opencode/issues/15223)
+- [Codex CLI](https://developers.openai.com/codex/cli/features),
+  [DeepWiki](https://deepwiki.com/openai/codex/4-developer-guide)
+- [Claude Code statusline](https://code.claude.com/docs/en/statusline)
+- [Aider commands](https://aider.chat/docs/usage/commands.html)
+- [pi-tool-display](https://github.com/MasuRii/pi-tool-display)
+
+Log / transcript viewers:
+- [lnav features](https://lnav.org/features),
+  [performance](https://docs.lnav.org/en/latest/performance.html),
+  [UI](https://docs.lnav.org/en/latest/ui.html)
+- [jless](https://jless.io/), [fx](https://fx.wtf/)
+- [NeoMutt](https://neomutt.org/guide/),
+  [Aerc](https://blog.sergeantbiggs.net/posts/aerc-a-well-crafted-tui-for-email/)
+- [WeeChat guide](https://weechat.org/files/doc/devel/weechat_user.en.html)
+- [tut](https://github.com/RasmusLindroth/tut)
+
+Dashboard / monitor:
+- [btop review](https://www.both.org/?p=9668)
+- [k9s overview](https://www.x-cmd.com/install/k9s/)
+- [lazygit keybindings](https://github.com/jesseduffield/lazygit/blob/master/docs/keybindings/Keybindings_en.md)
+- [tig manual](https://jonas.github.io/tig/doc/manual.html)
+- [zenith](https://terminaltrove.com/zenith/)
+
+Editor patterns:
+- [Helix Way](https://dev.to/rajasegar/the-helix-way-36mh)
+- [which-key / wf.nvim](https://github.com/Cassin01/wf.nvim)
+- [Telescope](https://github.com/nvim-telescope/telescope.nvim)
+- [Magit Transient](https://github.com/magit/transient)
+
+Rendering / aesthetics:
+- [Lipgloss](https://github.com/charmbracelet/lipgloss),
+  [Glamour](https://github.com/charmbracelet/glamour)
+- [Kitty graphics protocol](https://sw.kovidgoyal.net/kitty/graphics-protocol/),
+  [rasterm](https://github.com/BourgeoisBear/rasterm),
+  [term-image](https://pypi.org/project/term-image/)
+- [Textual smooth scroll](https://textual.textualize.io/blog/2025/02/16/smoother-scrolling-in-the-terminal-mdash-a-feature-decades-in-the-making/),
+  [Sparkline](https://textual.textualize.io/widgets/sparkline/),
+  [Markdown](https://textual.textualize.io/widgets/markdown/)
+- [textual-fastdatatable](https://github.com/tconbeer/textual-fastdatatable)
+- [awesome-ratatui](https://github.com/ratatui/awesome-ratatui),
+  [awesome-tuis](https://github.com/rothgar/awesome-tuis)


### PR DESCRIPTION
## Summary

- New **`docs/PERFORMANCE.md`** — design spec with ADR-023 through ADR-026 for the four near-term performance initiatives. Follows the same shape as `DESIGN-DECISIONS.md` (Context / Decision / Rationale / Rejected / Implementation sketch / Cost). Global ADR numbering continues from ADR-022 so task references stay unambiguous.
- New **`docs/UI-IMPROVEMENTS.md`** — catalogue of the wider TUI-redesign research: 12 borrowable patterns (transient menus, hotlist strip, lnav-style SQL-over-transcripts, thread tree, timeline filter rail, density toggle, etc.), aesthetic moves, performance patterns, and a "three-thing vNext" summary. Source of ideas; items get promoted into `TASKS.md` as they're scheduled.
- **`docs/TASKS.md`** updates:
  - Header now references both `DESIGN-DECISIONS.md` and `PERFORMANCE.md`.
  - **Phase 2** grows two backend-perf tasks: **#50** (event-driven session discovery via fsevents, ADR-023) and **#51** (defer transcript parse until focus + lazy tail, ADR-024).
  - **New Phase 7 — Rendering Performance**: **#52** (row-window virtualisation of `TranscriptView`, ADR-025) and **#53** (Arrow/Parquet-backed `DataTable` via `textual-fastdatatable`, ADR-026).
  - Dependency graph section removed — per-task `(blocked by: ...)` annotations already cover ordering for sequential work.

## Task plan

- [ ] Skim `docs/PERFORMANCE.md` — ADR-023 through ADR-026 for design correctness
- [ ] Skim `docs/UI-IMPROVEMENTS.md` — sanity-check the 12-pattern catalogue and source list
- [ ] Confirm task placement in `docs/TASKS.md` — #50/#51 in Phase 2, #52/#53 in new Phase 7
- [ ] Confirm it's OK that the dependency-graph section is gone
- [ ] Sign off that these ADRs can land under the `docs/adr` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)