### PR TITLE
Handle stale observer stop lifecycle

### DIFF
--- a/tests/test_cli_observe.py
+++ b/tests/test_cli_observe.py
@@ -154,3 +154,129 @@ def test_stop_all_observers_reports_live_and_stale_counts(
     out = capsys.readouterr().out
     assert "Sent SIGTERM to 1 observer(s)." in out
     assert "Corrected 1 stale observer PID(s)." in out
+
+
+def test_refresh_observer_state_returns_none_when_row_missing(
+    conn, threadhop_ns: dict
+):
+    assert threadhop_ns["_refresh_observer_state"](conn, "ghost-session") is None
+
+
+def test_refresh_observer_state_leaves_live_running_state_untouched(
+    conn, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, threadhop_ns: dict
+):
+    _seed_observation_state(
+        conn,
+        tmp_path,
+        "sess-1",
+        observer_pid=4242,
+        status="running",
+    )
+    monkeypatch.setattr(threadhop_ns["observer"], "_pid_is_alive", lambda pid: True)
+
+    state = threadhop_ns["_refresh_observer_state"](conn, "sess-1")
+
+    assert state is not None
+    assert state["status"] == "running"
+    assert state["observer_pid"] == 4242
+
+
+def test_refresh_observer_state_ignores_already_stopped_row(
+    conn, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, threadhop_ns: dict
+):
+    _seed_observation_state(
+        conn,
+        tmp_path,
+        "sess-1",
+        observer_pid=None,
+        status="stopped",
+    )
+    # Should not even need to consult _pid_is_alive — crash it to prove that.
+    def boom(_pid):
+        raise AssertionError("_pid_is_alive should not be called for non-running rows")
+
+    monkeypatch.setattr(threadhop_ns["observer"], "_pid_is_alive", boom)
+
+    state = threadhop_ns["_refresh_observer_state"](conn, "sess-1")
+
+    assert state is not None
+    assert state["status"] == "stopped"
+    assert state["observer_pid"] is None
+
+
+def test_stop_observer_session_noop_when_no_state_row(
+    conn,
+    capsys: pytest.CaptureFixture[str],
+    threadhop_ns: dict,
+):
+    rc = threadhop_ns["_stop_observer_session"](conn, "ghost-session")
+
+    assert rc == 0
+    assert "Observer is not running for session ghost-session." in capsys.readouterr().out
+
+
+def test_stop_observer_session_noop_when_state_has_no_pid(
+    conn,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    threadhop_ns: dict,
+):
+    _seed_observation_state(
+        conn,
+        tmp_path,
+        "sess-1",
+        observer_pid=None,
+        status="idle",
+    )
+
+    rc = threadhop_ns["_stop_observer_session"](conn, "sess-1")
+
+    assert rc == 0
+    assert "Observer is not running for session sess-1." in capsys.readouterr().out
+
+
+def test_stop_observer_session_handles_kill_race_when_process_disappears(
+    conn,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    threadhop_ns: dict,
+):
+    """Pre-check sees a live PID, but the process exits before ``os.kill`` —
+    the legacy ``ProcessLookupError`` fallback must still correct the row."""
+    _seed_observation_state(
+        conn,
+        tmp_path,
+        "sess-1",
+        observer_pid=4242,
+        status="running",
+    )
+    monkeypatch.setattr(threadhop_ns["observer"], "_pid_is_alive", lambda pid: True)
+
+    def racing_kill(pid: int, signum: int) -> None:
+        raise ProcessLookupError
+
+    monkeypatch.setattr(threadhop_ns["os"], "kill", racing_kill)
+
+    rc = threadhop_ns["_stop_observer_session"](conn, "sess-1")
+
+    state = db.get_observation_state(conn, "sess-1")
+    assert rc == 0
+    assert state is not None
+    assert state["status"] == "stopped"
+    assert state["observer_pid"] is None
+    assert (
+        "Observer PID 4242 for session sess-1 was stale; state corrected to stopped."
+        in capsys.readouterr().out
+    )
+
+
+def test_stop_all_observers_reports_when_none_running(
+    conn,
+    capsys: pytest.CaptureFixture[str],
+    threadhop_ns: dict,
+):
+    rc = threadhop_ns["_stop_all_observers"](conn)
+
+    assert rc == 0
+    assert "No running observers." in capsys.readouterr().out

--- a/tests/test_cli_observe.py
+++ b/tests/test_cli_observe.py
@@ -1,0 +1,156 @@
+"""CLI helper tests for ``threadhop observe`` lifecycle management."""
+
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+import pytest
+
+import db
+
+
+ROOT = Path(__file__).resolve().parent.parent
+THREADHOP = ROOT / "threadhop"
+
+
+@pytest.fixture
+def threadhop_ns() -> dict:
+    """Load the CLI script as a module namespace without executing main()."""
+    return runpy.run_path(str(THREADHOP))
+
+
+def _seed_observation_state(conn, tmp_path: Path, session_id: str, **kwargs) -> None:
+    source_path = tmp_path / f"{session_id}.jsonl"
+    source_path.write_text("")
+    obs_dir = tmp_path / "observations"
+    obs_dir.mkdir(exist_ok=True)
+    obs_path = obs_dir / f"{session_id}.jsonl"
+    db.upsert_session(conn, session_id, str(source_path), project="test-project")
+    db.upsert_observation_state(
+        conn,
+        session_id,
+        str(source_path),
+        str(obs_path),
+        **kwargs,
+    )
+
+
+def test_refresh_observer_state_marks_stale_pid_stopped(
+    conn, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, threadhop_ns: dict
+):
+    _seed_observation_state(
+        conn,
+        tmp_path,
+        "sess-1",
+        observer_pid=4242,
+        status="running",
+    )
+    monkeypatch.setattr(threadhop_ns["observer"], "_pid_is_alive", lambda pid: False)
+
+    state = threadhop_ns["_refresh_observer_state"](conn, "sess-1")
+
+    assert state is not None
+    assert state["status"] == "stopped"
+    assert state["observer_pid"] is None
+
+
+def test_stop_observer_session_sends_sigterm_to_live_pid(
+    conn,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    threadhop_ns: dict,
+):
+    _seed_observation_state(
+        conn,
+        tmp_path,
+        "sess-1",
+        observer_pid=4242,
+        status="running",
+    )
+    monkeypatch.setattr(threadhop_ns["observer"], "_pid_is_alive", lambda pid: True)
+    sent: list[tuple[int, int]] = []
+
+    def fake_kill(pid: int, signum: int) -> None:
+        sent.append((pid, signum))
+
+    monkeypatch.setattr(threadhop_ns["os"], "kill", fake_kill)
+
+    rc = threadhop_ns["_stop_observer_session"](conn, "sess-1")
+
+    assert rc == 0
+    assert sent == [(4242, threadhop_ns["signal"].SIGTERM)]
+    assert "Sent SIGTERM to observer for session sess-1 (pid 4242)." in capsys.readouterr().out
+
+
+def test_stop_observer_session_reports_stale_pid_correction(
+    conn,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    threadhop_ns: dict,
+):
+    _seed_observation_state(
+        conn,
+        tmp_path,
+        "sess-1",
+        observer_pid=4242,
+        status="running",
+    )
+    monkeypatch.setattr(threadhop_ns["observer"], "_pid_is_alive", lambda pid: False)
+
+    rc = threadhop_ns["_stop_observer_session"](conn, "sess-1")
+
+    state = db.get_observation_state(conn, "sess-1")
+    assert rc == 0
+    assert state is not None
+    assert state["status"] == "stopped"
+    assert state["observer_pid"] is None
+    assert (
+        "Observer PID 4242 for session sess-1 was stale; state corrected to stopped."
+        in capsys.readouterr().out
+    )
+
+
+def test_stop_all_observers_reports_live_and_stale_counts(
+    conn,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    threadhop_ns: dict,
+):
+    _seed_observation_state(
+        conn,
+        tmp_path,
+        "sess-live",
+        observer_pid=1111,
+        status="running",
+    )
+    _seed_observation_state(
+        conn,
+        tmp_path,
+        "sess-stale",
+        observer_pid=2222,
+        status="running",
+    )
+    sent: list[tuple[int, int]] = []
+
+    def fake_kill(pid: int, signum: int) -> None:
+        if pid == 2222:
+            raise ProcessLookupError
+        sent.append((pid, signum))
+
+    monkeypatch.setattr(threadhop_ns["os"], "kill", fake_kill)
+
+    rc = threadhop_ns["_stop_all_observers"](conn)
+
+    stale_state = db.get_observation_state(conn, "sess-stale")
+    assert rc == 0
+    assert sent == [(1111, threadhop_ns["signal"].SIGTERM)]
+    assert stale_state is not None
+    assert stale_state["status"] == "stopped"
+    assert stale_state["observer_pid"] is None
+    out = capsys.readouterr().out
+    assert "Sent SIGTERM to 1 observer(s)." in out
+    assert "Corrected 1 stale observer PID(s)." in out

--- a/threadhop
+++ b/threadhop
@@ -4375,6 +4375,17 @@ def _print_observer_result(result: dict, *, prefix: str = "observer") -> None:
 
 
 def _stop_observer_session(conn, session_id: str) -> int:
+    state = db.get_observation_state(conn, session_id)
+    if state is not None and state.get("status") == "running":
+        pid = state.get("observer_pid")
+        if pid is not None and not observer._pid_is_alive(int(pid)):
+            db.set_observer_stopped(conn, session_id)
+            print(
+                f"Observer PID {pid} for session {session_id} was stale; "
+                "state corrected to stopped."
+            )
+            return 0
+
     state = _refresh_observer_state(conn, session_id)
     if state is None or state.get("observer_pid") is None:
         print(f"Observer is not running for session {session_id}.")


### PR DESCRIPTION
## Summary

- `threadhop observe --stop` now reports a precise "stale PID; state corrected to stopped" message when the DB has `status=running` but the recorded PID is already dead — previously this path fell through to the generic "Observer is not running" after silently correcting the row, which read as a lie about a real state change.
- The fix adds a pre-check in `_stop_observer_session` that inspects the row *before* `_refresh_observer_state` normalises it, so the correction surfaces in CLI output. The legacy `ProcessLookupError` fallback stays in place for the kill-time race.
- Locks the stop/resume surface down with 11 focused tests in a new `tests/test_cli_observe.py` — no behavioural change to `--stop-all`, observer core, or watch-mode.

## Notes for review

- The second `state = _refresh_observer_state(...)` call after the pre-check is intentional: the pre-check short-circuits the stale case, and the refresh still runs for the live-PID path so we never re-read a torn row.
- `_stop_all_observers` deliberately still relies on `os.kill → ProcessLookupError` to tally stale PIDs — it already emitted a distinct "Corrected N stale observer PID(s)" line, so no UX gap there.
- Tests load the CLI script via `runpy.run_path` (mirrors task #17's `_resolve_cli_session` pattern) so the script-style `threadhop` entry point stays testable without packaging.
- Monkeypatching `observer._pid_is_alive` + `os.kill` through the loaded namespace keeps the fake surface tiny — no real signals sent during tests.

## Test plan

- [x] `uv run --with pytest --with rich --with textual --with watchdog --with pydantic python -m pytest -q` — **106 pass** (99 pre-branch + 7 new `test_cli_observe.py` assertions beyond the 4 originally in the Codex patch)
- [x] `uv run … python -m pytest tests/test_cli_observe.py -v` — all 11 pass
- [x] Live SIGTERM dispatch covered (`test_stop_observer_session_sends_sigterm_to_live_pid`)
- [x] Stale-PID correction covered (`test_stop_observer_session_reports_stale_pid_correction`)
- [x] Kill-time race covered (`test_stop_observer_session_handles_kill_race_when_process_disappears`) — the legacy `ProcessLookupError` fallback stays reachable and still corrects the row
- [x] No-state + null-PID "not running" paths covered
- [x] `_refresh_observer_state` no-op branches covered (null row, live PID, already-stopped row — the last asserts `_pid_is_alive` isn't even consulted)
- [x] `_stop_all_observers` empty + mixed live/stale paths covered
- [ ] Manual: start a real observer (`./threadhop observe --session <id>`), `kill -9` the child, then `./threadhop observe --session <id> --stop` — confirm the stale-PID correction message prints

## Follow-ups

- None from this PR. Task #32 (observer watch-loop adaptive backoff + Claude lifecycle awareness) is the next lifecycle item and is tracked independently in `docs/TASKS.md`.

## References

- ADR-018, ADR-019 — observer sidecar + `observation_state` lifecycle
- PR #36 — the original background observer sidecar that introduced `observer_pid` tracking
- `observer._pid_is_alive` — the shared liveness check reused by both the pre-check and the watch-loop
