### PR TITLE
Add bookmarks: pin messages + browse via modal (task #18)

### DIFF
--- a/db.py
+++ b/db.py
@@ -40,7 +40,7 @@ DB_PATH = DB_DIR / "sessions.db"
 # --- Schema version ---
 # Each migration N in MIGRATIONS moves the DB from version N to N+1.
 # The DB's current version lives in PRAGMA user_version.
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 
 # --- Migrations -----------------------------------------------------------
@@ -349,6 +349,40 @@ def _migration_006_sessions_status_check(conn: sqlite3.Connection) -> None:
         )
 
 
+def _migration_007_bookmarks(conn: sqlite3.Connection) -> None:
+    """Task #18: bookmarks table.
+
+    Users pin messages for later recall via `space` in selection mode.
+    One bookmark per message (UNIQUE on ``message_uuid``) so the keybind
+    is a pure toggle. ``FK … ON DELETE CASCADE`` keeps the table free
+    of orphan rows if a message is ever reindexed out from under a pin.
+
+    ``tags`` is a JSON-encoded array of strings, mirroring the
+    :class:`models.Bookmark` shape declared for this table in
+    ``models.py`` (task #24's model/schema lockstep rule). The tag
+    *editor UX* is deferred — tracked separately — so the column exists
+    but only ``label`` has a TUI surface in this migration's companion
+    commit.
+    """
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS bookmarks (
+            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            message_uuid TEXT NOT NULL UNIQUE,
+            label        TEXT,
+            tags         TEXT NOT NULL DEFAULT '[]',
+            created_at   REAL NOT NULL,
+            FOREIGN KEY (message_uuid) REFERENCES messages(uuid)
+                ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_bookmarks_created_at "
+        "ON bookmarks(created_at)"
+    )
+
+
 # Ordered list; MIGRATIONS[i] moves schema from version i to i+1.
 MIGRATIONS: list = [
     _migration_001_initial,
@@ -357,6 +391,7 @@ MIGRATIONS: list = [
     _migration_004_observation_state,
     _migration_005_conflict_reviews,
     _migration_006_sessions_status_check,
+    _migration_007_bookmarks,
 ]
 
 assert len(MIGRATIONS) == SCHEMA_VERSION, (
@@ -1288,3 +1323,147 @@ def mark_conflict_reviewed(
             reviewed_at if reviewed_at is not None else datetime.now().timestamp(),
         ),
     )
+
+
+# --- Bookmarks ------------------------------------------------------------
+# Users pin messages via `space` in selection mode; the browser modal
+# reads back via ``list_bookmarks``. Timestamps are Unix epoch floats to
+# match ``sessions.modified_at`` and the rest of the time columns here.
+#
+# ``tags`` is stored as a JSON-encoded array to match ``models.Bookmark``
+# (task #24's lockstep rule). Helpers decode to ``list[str]`` on read so
+# callers never see the raw JSON.
+
+
+def _decode_bookmark_tags(row: dict | None) -> dict | None:
+    """Decode ``row['tags']`` from JSON to a list. Mutates ``row`` in place
+    and returns it; ``None`` passes through."""
+    if row is None:
+        return None
+    raw = row.get("tags")
+    if isinstance(raw, str):
+        try:
+            decoded = json.loads(raw) if raw else []
+        except json.JSONDecodeError:
+            decoded = []
+        row["tags"] = decoded if isinstance(decoded, list) else []
+    elif raw is None:
+        row["tags"] = []
+    return row
+
+
+def get_bookmark(
+    conn: sqlite3.Connection, message_uuid: str
+) -> dict | None:
+    """Return the bookmark row for ``message_uuid`` or None."""
+    row = query_one(
+        conn,
+        "SELECT id, message_uuid, label, tags, created_at FROM bookmarks "
+        "WHERE message_uuid = ?",
+        (message_uuid,),
+    )
+    return _decode_bookmark_tags(row)
+
+
+def toggle_bookmark(
+    conn: sqlite3.Connection,
+    message_uuid: str,
+    created_at: float | None = None,
+) -> dict | None:
+    """Toggle a bookmark on ``message_uuid``.
+
+    Returns the new bookmark dict on create, or ``None`` on delete so
+    callers can show the right toast ("Bookmarked" vs "Removed"). New
+    rows start with an empty tag list — tag editing is a follow-up to
+    this feature, but the column exists so the schema matches
+    :class:`models.Bookmark`.
+    """
+    existing = get_bookmark(conn, message_uuid)
+    if existing is not None:
+        conn.execute("DELETE FROM bookmarks WHERE id = ?", (existing["id"],))
+        return None
+    ts = created_at if created_at is not None else datetime.now().timestamp()
+    cur = conn.execute(
+        "INSERT INTO bookmarks (message_uuid, label, tags, created_at) "
+        "VALUES (?, NULL, '[]', ?)",
+        (message_uuid, ts),
+    )
+    return {
+        "id": cur.lastrowid,
+        "message_uuid": message_uuid,
+        "label": None,
+        "tags": [],
+        "created_at": ts,
+    }
+
+
+def set_bookmark_label(
+    conn: sqlite3.Connection,
+    bookmark_id: int,
+    label: str | None,
+) -> None:
+    """Update a bookmark's label. Empty strings collapse to NULL."""
+    clean = label.strip() if label else ""
+    conn.execute(
+        "UPDATE bookmarks SET label = ? WHERE id = ?",
+        (clean or None, bookmark_id),
+    )
+
+
+def delete_bookmark(conn: sqlite3.Connection, bookmark_id: int) -> None:
+    """Remove a bookmark by row id. No-op if the row doesn't exist."""
+    conn.execute("DELETE FROM bookmarks WHERE id = ?", (bookmark_id,))
+
+
+def list_bookmarks(
+    conn: sqlite3.Connection,
+    query: str | None = None,
+    limit: int = 500,
+) -> list[dict]:
+    """Return bookmarks joined with message + session metadata, newest first.
+
+    ``query`` is an optional case-insensitive substring filter applied
+    across the label, the message body, and the session's project /
+    custom name — mirrors the single filter input in the browser modal.
+    """
+    sql = (
+        "SELECT b.id, b.message_uuid, b.label, b.tags, b.created_at, "
+        "       m.session_id, m.role, m.text, m.timestamp, "
+        "       s.custom_name, s.project "
+        "FROM bookmarks b "
+        "JOIN messages m ON m.uuid = b.message_uuid "
+        "LEFT JOIN sessions s ON s.session_id = m.session_id "
+    )
+    params: tuple = ()
+    if query:
+        sql += (
+            "WHERE b.label LIKE ? OR m.text LIKE ? "
+            "OR s.custom_name LIKE ? OR s.project LIKE ? "
+        )
+        like = f"%{query}%"
+        params = (like, like, like, like)
+    sql += "ORDER BY b.created_at DESC LIMIT ?"
+    params = params + (limit,)
+    rows = query_all(conn, sql, params)
+    for row in rows:
+        _decode_bookmark_tags(row)
+    return rows
+
+
+def get_bookmarked_uuids(
+    conn: sqlite3.Connection,
+    session_id: str | None = None,
+) -> set[str]:
+    """Return the set of bookmarked message UUIDs, optionally scoped
+    to one session. Used by the transcript view to tag pinned widgets
+    when rendering."""
+    if session_id is not None:
+        rows = conn.execute(
+            "SELECT b.message_uuid FROM bookmarks b "
+            "JOIN messages m ON m.uuid = b.message_uuid "
+            "WHERE m.session_id = ?",
+            (session_id,),
+        ).fetchall()
+    else:
+        rows = conn.execute("SELECT message_uuid FROM bookmarks").fetchall()
+    return {r[0] for r in rows}

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -1,0 +1,194 @@
+"""Tests for the bookmarks helpers in db.py (task #18).
+
+Focuses on the contract the TUI relies on:
+  - toggle is idempotent per-uuid (space keybind flips a single state)
+  - label round-trips, blanks collapse to NULL
+  - list_bookmarks returns newest-first with the joined metadata the
+    browser modal renders (session / project / timestamp / role / text)
+  - filter matches against label, message text, project, custom_name
+  - cascade delete removes orphan bookmarks when messages disappear
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+import db
+
+
+def _seed_session(conn: sqlite3.Connection, session_id: str, **over):
+    row = {
+        "session_id": session_id,
+        "session_path": f"/tmp/{session_id}.jsonl",
+        "project": "-Users-alice-work",
+        "custom_name": None,
+        "created_at": 1000.0,
+        "modified_at": 1000.0,
+    }
+    row.update(over)
+    conn.execute(
+        "INSERT INTO sessions(session_id, session_path, project, "
+        "custom_name, created_at, modified_at) VALUES (?,?,?,?,?,?)",
+        (row["session_id"], row["session_path"], row["project"],
+         row["custom_name"], row["created_at"], row["modified_at"]),
+    )
+
+
+def _seed_message(conn, uuid, session_id, role="user", text="hello",
+                  timestamp="2026-04-19T00:00:00Z"):
+    conn.execute(
+        "INSERT INTO messages(uuid, session_id, role, text, timestamp) "
+        "VALUES (?,?,?,?,?)",
+        (uuid, session_id, role, text, timestamp),
+    )
+
+
+def test_toggle_creates_then_removes(conn):
+    _seed_session(conn, "s1")
+    _seed_message(conn, "u1", "s1")
+
+    first = db.toggle_bookmark(conn, "u1", created_at=500.0)
+    assert first is not None
+    assert first["message_uuid"] == "u1"
+    assert first["label"] is None
+    # Tags column lives in the schema to match models.Bookmark even
+    # though the editor UI is deferred — new rows default to [].
+    assert first["tags"] == []
+
+    second = db.toggle_bookmark(conn, "u1")
+    assert second is None  # removed
+    assert db.get_bookmark(conn, "u1") is None
+
+
+def test_label_round_trip(conn):
+    _seed_session(conn, "s1")
+    _seed_message(conn, "u1", "s1")
+    row = db.toggle_bookmark(conn, "u1")
+
+    db.set_bookmark_label(conn, row["id"], "  important  ")
+    assert db.get_bookmark(conn, "u1")["label"] == "important"
+
+    # Empty / whitespace collapses to NULL — the browser treats empty
+    # submissions as "clear" without a separate code path.
+    db.set_bookmark_label(conn, row["id"], "   ")
+    assert db.get_bookmark(conn, "u1")["label"] is None
+
+    db.set_bookmark_label(conn, row["id"], None)
+    assert db.get_bookmark(conn, "u1")["label"] is None
+
+
+def test_list_newest_first_with_joined_metadata(conn):
+    _seed_session(conn, "s1", custom_name="project-one", project="proj1")
+    _seed_session(conn, "s2", custom_name="project-two", project="proj2")
+    _seed_message(conn, "u1", "s1", role="user", text="first question")
+    _seed_message(conn, "u2", "s2", role="assistant", text="second answer")
+
+    db.toggle_bookmark(conn, "u1", created_at=1000.0)
+    db.toggle_bookmark(conn, "u2", created_at=2000.0)
+
+    rows = db.list_bookmarks(conn)
+    assert [r["message_uuid"] for r in rows] == ["u2", "u1"]
+    assert rows[0]["role"] == "assistant"
+    assert rows[0]["custom_name"] == "project-two"
+    assert rows[0]["project"] == "proj2"
+    assert rows[0]["text"] == "second answer"
+    assert rows[1]["session_id"] == "s1"
+
+
+@pytest.mark.parametrize(
+    "query,expected",
+    [
+        ("important", {"u1"}),         # matches label
+        ("SECOND", {"u2"}),            # case-insensitive, matches text
+        ("project-two", {"u2"}),       # matches custom_name
+        ("proj1", {"u1"}),             # matches project
+        ("nope", set()),
+    ],
+)
+def test_filter_matches_label_text_and_session(conn, query, expected):
+    _seed_session(conn, "s1", custom_name="project-one", project="proj1")
+    _seed_session(conn, "s2", custom_name="project-two", project="proj2")
+    _seed_message(conn, "u1", "s1", text="first question")
+    _seed_message(conn, "u2", "s2", text="second answer")
+
+    b1 = db.toggle_bookmark(conn, "u1")
+    db.toggle_bookmark(conn, "u2")
+    db.set_bookmark_label(conn, b1["id"], "important note")
+
+    got = {r["message_uuid"] for r in db.list_bookmarks(conn, query=query)}
+    assert got == expected
+
+
+def test_cascade_delete_on_message_removal(conn):
+    _seed_session(conn, "s1")
+    _seed_message(conn, "u1", "s1")
+    _seed_message(conn, "u2", "s1")
+    db.toggle_bookmark(conn, "u1")
+    db.toggle_bookmark(conn, "u2")
+
+    assert db.get_bookmarked_uuids(conn) == {"u1", "u2"}
+
+    conn.execute("DELETE FROM messages WHERE uuid = ?", ("u1",))
+    assert db.get_bookmarked_uuids(conn) == {"u2"}
+
+
+def test_get_bookmarked_uuids_scoped(conn):
+    _seed_session(conn, "s1")
+    _seed_session(conn, "s2")
+    _seed_message(conn, "u1", "s1")
+    _seed_message(conn, "u2", "s2")
+    db.toggle_bookmark(conn, "u1")
+    db.toggle_bookmark(conn, "u2")
+
+    assert db.get_bookmarked_uuids(conn, "s1") == {"u1"}
+    assert db.get_bookmarked_uuids(conn, "s2") == {"u2"}
+    assert db.get_bookmarked_uuids(conn) == {"u1", "u2"}
+
+
+def test_delete_bookmark_removes_row(conn):
+    _seed_session(conn, "s1")
+    _seed_message(conn, "u1", "s1")
+    row = db.toggle_bookmark(conn, "u1")
+
+    db.delete_bookmark(conn, row["id"])
+    assert db.get_bookmark(conn, "u1") is None
+
+
+def test_unique_constraint_rejects_duplicate_inserts(conn):
+    """toggle_bookmark is the only public insert path and handles the
+    toggle semantics. Any attempt to insert a second row for the same
+    message_uuid directly should still be rejected at the DB layer."""
+    _seed_session(conn, "s1")
+    _seed_message(conn, "u1", "s1")
+    db.toggle_bookmark(conn, "u1")
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO bookmarks (message_uuid, label, tags, created_at) "
+            "VALUES (?, NULL, '[]', ?)",
+            ("u1", 1.0),
+        )
+
+
+def test_tags_column_round_trips_json(conn):
+    """The tags column exists to match models.Bookmark; no public setter
+    ships in this task but direct writes + the get/list helpers should
+    round-trip the JSON payload correctly for the follow-up UI work."""
+    _seed_session(conn, "s1")
+    _seed_message(conn, "u1", "s1")
+    row = db.toggle_bookmark(conn, "u1")
+
+    conn.execute(
+        "UPDATE bookmarks SET tags = ? WHERE id = ?",
+        ('["bug", "decision"]', row["id"]),
+    )
+    assert db.get_bookmark(conn, "u1")["tags"] == ["bug", "decision"]
+
+    # Corrupt JSON must not crash the reader — decode failures fall back
+    # to an empty list so the browser keeps rendering the row.
+    conn.execute(
+        "UPDATE bookmarks SET tags = ? WHERE id = ?",
+        ("not json", row["id"]),
+    )
+    assert db.get_bookmark(conn, "u1")["tags"] == []

--- a/threadhop
+++ b/threadhop
@@ -173,6 +173,7 @@ SCOPE_SELECTION = "selection"
 SCOPE_REPLY = "reply"
 SCOPE_FIND = "find"
 SCOPE_SEARCH = "search"
+SCOPE_BOOKMARKS = "bookmarks"
 
 SCOPE_ORDER: list[str] = [
     SCOPE_GLOBAL,
@@ -182,6 +183,7 @@ SCOPE_ORDER: list[str] = [
     SCOPE_REPLY,
     SCOPE_FIND,
     SCOPE_SEARCH,
+    SCOPE_BOOKMARKS,
 ]
 
 SCOPE_LABELS: dict[str, str] = {
@@ -192,6 +194,7 @@ SCOPE_LABELS: dict[str, str] = {
     SCOPE_REPLY: "Reply input",
     SCOPE_FIND: "Find bar",
     SCOPE_SEARCH: "Search modal",
+    SCOPE_BOOKMARKS: "Bookmarks modal",
 }
 
 # Pretty-print Textual key strings for the help overlay and footer.
@@ -258,6 +261,7 @@ COMMAND_REGISTRY: list[Command] = [
     Command(("T",), "Previous theme", SCOPE_GLOBAL, "toggle_theme_prev"),
     Command(("/",), "Search all sessions", SCOPE_GLOBAL, "open_search", footer=True),
     Command(("ctrl+f",), "Find in transcript", SCOPE_GLOBAL, "open_find", footer=True),
+    Command(("b",), "Browse bookmarks", SCOPE_GLOBAL, "open_bookmarks", footer=True),
     Command(("left_square_bracket",), "Shrink sidebar", SCOPE_GLOBAL, "shrink_sidebar"),
     Command(("right_square_bracket",), "Grow sidebar", SCOPE_GLOBAL, "grow_sidebar"),
 
@@ -310,6 +314,8 @@ COMMAND_REGISTRY: list[Command] = [
     Command(("v",), "Toggle range select", SCOPE_SELECTION, footer=True),
     Command(("y",), "Copy selection", SCOPE_SELECTION, footer=True),
     Command(("e",), "Export to /tmp", SCOPE_SELECTION, footer=True),
+    Command(("space",), "Toggle bookmark", SCOPE_SELECTION, footer=True),
+    Command(("L",), "Label bookmark", SCOPE_SELECTION),
     Command(("m", "escape"), "Exit selection", SCOPE_SELECTION, footer=True),
 
     # --- Reply input ---
@@ -333,6 +339,13 @@ COMMAND_REGISTRY: list[Command] = [
     Command(("up", "down", "ctrl+n", "ctrl+p"), "Navigate results", SCOPE_SEARCH, footer=True),
     Command(("enter",), "Open result", SCOPE_SEARCH, footer=True),
     Command(("escape",), "Close search", SCOPE_SEARCH, footer=True),
+
+    # --- Bookmark browser modal (widget-local; BookmarkBrowserScreen.on_key) ---
+    Command(("up", "down", "ctrl+n", "ctrl+p"), "Navigate bookmarks", SCOPE_BOOKMARKS, footer=True),
+    Command(("enter",), "Jump to message", SCOPE_BOOKMARKS, footer=True),
+    Command(("L",), "Edit label", SCOPE_BOOKMARKS, footer=True),
+    Command(("d",), "Delete bookmark", SCOPE_BOOKMARKS, footer=True),
+    Command(("escape",), "Close", SCOPE_BOOKMARKS, footer=True),
 ]
 
 
@@ -595,6 +608,14 @@ class TranscriptView(VerticalScroll):
                 self._export_selection()
                 event.stop()
                 event.prevent_default()
+            elif event.key == "space":
+                self.app.bookmark_toggle_selection()
+                event.stop()
+                event.prevent_default()
+            elif event.key == "L":
+                self.app.bookmark_prompt_label()
+                event.stop()
+                event.prevent_default()
             elif event.key == "escape":
                 if self._range_mode:
                     self._exit_range_mode()
@@ -611,7 +632,10 @@ class TranscriptView(VerticalScroll):
         # Start at the last message — recent context is usually what you want
         self._selected_index = len(messages) - 1
         self._update_selection(messages)
-        self.app.notify("Selection mode: j/k move, v range, y copy, e export, m/Esc exit")
+        self.app.notify(
+            "Selection mode: j/k move, v range, y copy, e export, "
+            "space bookmark, L label, m/Esc exit"
+        )
         # Nudge the contextual footer — selection mode has its own scope.
         try:
             self.app.refresh_footer()
@@ -706,7 +730,7 @@ class TranscriptView(VerticalScroll):
                 f"({pos}/{total}) (j/k extend, v/Esc cancel)"
             )
         else:
-            self.border_title = f"Transcript ── SELECT {pos}/{total} (j/k move, v range, y/e copy/export, m/Esc exit)"
+            self.border_title = f"Transcript ── SELECT {pos}/{total} (j/k move, v range, y/e copy/export, space bookmark, L label, m/Esc exit)"
 
     def _clear_selection(self):
         for widget in self._get_message_widgets():
@@ -1923,6 +1947,401 @@ class SearchScreen(ModalScreen):
         self.dismiss((row["session_id"], row["uuid"], terms))
 
 
+class BookmarkItem(ListItem):
+    """One row in the bookmark browser.
+
+    Layout mirrors SearchResultItem so the two modals feel like siblings:
+    label / role marker + snippet, then session · project · timestamp.
+    Bookmarks without a label fall back to the message role marker alone.
+    """
+
+    def __init__(self, row: dict):
+        self.row = row
+        super().__init__()
+
+    def compose(self) -> ComposeResult:
+        role = self.row.get("role", "")
+        role_icon = "▶" if role == "user" else "●"
+        role_style = "bold cyan" if role == "user" else "bold green"
+        label = (self.row.get("label") or "").strip()
+
+        first_line = Text()
+        first_line.append("★ ", style="bold yellow")
+        if label:
+            first_line.append(label, style="bold")
+            first_line.append("  ", style="dim")
+        first_line.append(f"{role_icon} ", style=role_style)
+        # Trim the stored text to a single-line snippet — the full body
+        # is reachable via Enter → jump.
+        raw_text = (self.row.get("text") or "").strip().replace("\n", " ")
+        snippet = raw_text[:160] + ("…" if len(raw_text) > 160 else "")
+        first_line.append(snippet)
+
+        session_name = (
+            self.row.get("custom_name")
+            or self.row.get("project")
+            or (self.row.get("session_id", "") or "")[:8]
+        )
+        project = self.row.get("project") or ""
+        ts_raw = self.row.get("timestamp") or ""
+        ts_str = ts_raw[:16]
+        try:
+            dt = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+            ts_str = dt.strftime("%Y-%m-%d %H:%M")
+        except (ValueError, AttributeError):
+            pass
+
+        meta = Text()
+        meta.append("  ", style="dim")
+        meta.append(str(session_name), style="bold")
+        if project and project != session_name:
+            meta.append("  ·  ", style="dim")
+            meta.append(str(project), style="cyan")
+        meta.append("  ·  ", style="dim")
+        meta.append(ts_str, style="dim")
+
+        yield Static(Group(first_line, meta), classes="bookmark-item")
+
+
+class BookmarkBrowserScreen(ModalScreen):
+    """Modal bookmark browser (task #18).
+
+    Shares the SearchScreen layout — filter Input on top, ListView of
+    results, status + hint lines at the bottom — so keyboard muscle
+    memory carries over. Filter runs case-insensitive substring matches
+    over label / message body / project / custom name via
+    ``db.list_bookmarks``.
+
+    Dismiss payload:
+      - ``(session_id, message_uuid)`` when the user hits Enter on a row
+      - ``None`` on Escape
+
+    The caller routes the payload through ``_jump_to_search_result``
+    which handles all three cases (same session, sidebar session,
+    cross-project/out-of-view session).
+    """
+
+    DEBOUNCE_SECONDS = 0.08
+
+    BINDINGS = [
+        Binding("enter", "open_result", "Open", priority=True, show=False),
+    ]
+
+    CSS = """
+    BookmarkBrowserScreen {
+        layout: vertical;
+        align: center top;
+        background: $background 70%;
+    }
+
+    #bookmark-container {
+        width: 90%;
+        max-width: 140;
+        height: 85%;
+        margin-top: 1;
+        background: $surface;
+        border: thick $accent;
+        layout: vertical;
+    }
+
+    #bookmark-input {
+        margin: 0;
+        border: none;
+        background: $boost;
+    }
+
+    #bookmark-input:focus {
+        background: $boost;
+    }
+
+    #bookmark-results {
+        height: 1fr;
+        background: $surface;
+    }
+
+    #bookmark-status {
+        height: 1;
+        padding: 0 1;
+        color: $text-muted;
+        background: $boost;
+    }
+
+    #bookmark-help {
+        height: 1;
+        padding: 0 1;
+        color: $text-muted;
+        background: $boost;
+        text-style: italic;
+    }
+
+    .bookmark-item {
+        padding: 0 1;
+    }
+
+    BookmarkItem {
+        padding: 0;
+    }
+    """
+
+    def __init__(self, conn: sqlite3.Connection):
+        super().__init__()
+        self.conn = conn
+        self._filter_timer = None
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="bookmark-container") as container:
+            container.border_title = "Bookmarks"
+            yield Input(
+                placeholder="Filter bookmarks by label, text, or session…",
+                id="bookmark-input",
+            )
+            yield Static("", id="bookmark-status")
+            yield ListView(id="bookmark-results")
+            yield Static(
+                "↑/↓ navigate • Enter jump • L label • d delete • Esc close",
+                id="bookmark-help",
+            )
+
+    def on_mount(self) -> None:
+        self._refresh_results("")
+        self.query_one("#bookmark-input", Input).focus()
+
+    def on_input_changed(self, event) -> None:
+        try:
+            if event.input.id != "bookmark-input":
+                return
+        except AttributeError:
+            return
+        if self._filter_timer is not None:
+            try:
+                self._filter_timer.stop()
+            except Exception:
+                pass
+        value = event.value
+        self._filter_timer = self.set_timer(
+            self.DEBOUNCE_SECONDS, lambda v=value: self._refresh_results(v)
+        )
+
+    def _refresh_results(self, raw_query: str) -> None:
+        """Reload the results list from the DB. Preserves cursor position
+        when possible so in-place edits (label / delete) don't jump the
+        user back to the top."""
+        results_list = self.query_one("#bookmark-results", ListView)
+        status = self.query_one("#bookmark-status", Static)
+
+        prev_idx = results_list.index
+        results_list.clear()
+
+        query = raw_query.strip() or None
+        try:
+            rows = db.list_bookmarks(self.conn, query=query, limit=200)
+        except Exception as e:  # noqa: BLE001
+            status.update(f"Bookmark query error: {e}")
+            return
+
+        for row in rows:
+            results_list.append(BookmarkItem(row))
+
+        count = len(rows)
+        if count == 0:
+            status.update("No bookmarks" if query is None else "No bookmarks match")
+        else:
+            noun = "bookmark" if count == 1 else "bookmarks"
+            status.update(
+                f"{count} {noun}" + (" (showing first 200)" if count >= 200 else "")
+            )
+
+        # Restore cursor if still in range — otherwise clamp.
+        if count:
+            if prev_idx is None:
+                results_list.index = 0
+            else:
+                results_list.index = min(prev_idx, count - 1)
+
+    def on_key(self, event) -> None:
+        key = event.key
+        if key == "escape":
+            event.stop()
+            event.prevent_default()
+            self.dismiss(None)
+        elif key in ("down", "ctrl+n"):
+            event.stop()
+            event.prevent_default()
+            self._move_selection(1)
+        elif key in ("up", "ctrl+p"):
+            event.stop()
+            event.prevent_default()
+            self._move_selection(-1)
+        elif key == "L":
+            event.stop()
+            event.prevent_default()
+            self._edit_label_selected()
+        elif key == "d":
+            event.stop()
+            event.prevent_default()
+            self._delete_selected()
+
+    def action_open_result(self) -> None:
+        self._open_selected()
+
+    def on_input_submitted(self, event) -> None:
+        try:
+            if event.input.id != "bookmark-input":
+                return
+        except AttributeError:
+            return
+        event.stop()
+        self._open_selected()
+
+    def _move_selection(self, delta: int) -> None:
+        lv = self.query_one("#bookmark-results", ListView)
+        count = len(lv.children)
+        if count == 0:
+            return
+        if lv.index is None:
+            lv.index = 0 if delta > 0 else count - 1
+            return
+        lv.index = max(0, min(count - 1, lv.index + delta))
+
+    def _current_row(self) -> dict | None:
+        lv = self.query_one("#bookmark-results", ListView)
+        if not lv.children:
+            return None
+        idx = lv.index if lv.index is not None else 0
+        if idx < 0 or idx >= len(lv.children):
+            idx = 0
+        item = lv.children[idx]
+        if not isinstance(item, BookmarkItem):
+            return None
+        return item.row
+
+    def _open_selected(self) -> None:
+        row = self._current_row()
+        if row is None:
+            return
+        self.dismiss((row["session_id"], row["message_uuid"]))
+
+    def _edit_label_selected(self) -> None:
+        row = self._current_row()
+        if row is None:
+            return
+        bookmark_id = row["id"]
+        current = row.get("label") or ""
+
+        def _apply(new_label: str | None) -> None:
+            if new_label is None:
+                return
+            try:
+                db.set_bookmark_label(self.conn, bookmark_id, new_label)
+            except Exception as e:  # noqa: BLE001
+                self.app.notify(f"Label update failed: {e}", severity="error")
+                return
+            # Refresh in place so the edited label renders immediately.
+            raw = self.query_one("#bookmark-input", Input).value or ""
+            self._refresh_results(raw)
+            shown = new_label.strip() or "(no label)"
+            self.app.notify(f"Label: {shown}")
+
+        self.app.push_screen(LabelPromptScreen(current), _apply)
+
+    def _delete_selected(self) -> None:
+        row = self._current_row()
+        if row is None:
+            return
+        try:
+            db.delete_bookmark(self.conn, row["id"])
+        except Exception as e:  # noqa: BLE001
+            self.app.notify(f"Delete failed: {e}", severity="error")
+            return
+        raw = self.query_one("#bookmark-input", Input).value or ""
+        self._refresh_results(raw)
+        self.app.notify("Bookmark removed")
+
+
+class LabelPromptScreen(ModalScreen):
+    """Tiny modal that captures a single line of text.
+
+    Used both when setting a label from selection mode and when editing
+    one from the browser. Returns the submitted string on Enter, or
+    ``None`` on Escape — caller decides whether an empty submission
+    means "clear" (bookmark browser does that via set_bookmark_label's
+    blank-collapses-to-NULL behaviour).
+    """
+
+    BINDINGS = [
+        Binding("enter", "submit", "Save", priority=True, show=False),
+        Binding("escape", "cancel", "Cancel", priority=True, show=False),
+    ]
+
+    CSS = """
+    LabelPromptScreen {
+        layout: vertical;
+        align: center middle;
+        background: $background 70%;
+    }
+
+    #label-container {
+        width: 70;
+        max-width: 90%;
+        height: auto;
+        background: $surface;
+        border: thick $accent;
+        padding: 1 2;
+        layout: vertical;
+    }
+
+    #label-title {
+        height: 1;
+        text-style: bold;
+        color: $text;
+    }
+
+    #label-input {
+        margin-top: 1;
+    }
+
+    #label-hint {
+        height: 1;
+        margin-top: 1;
+        color: $text-muted;
+        text-style: italic;
+    }
+    """
+
+    def __init__(self, initial: str = ""):
+        super().__init__()
+        self._initial = initial
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="label-container"):
+            yield Static("Bookmark label", id="label-title")
+            yield Input(
+                value=self._initial,
+                placeholder="Label (blank = clear)",
+                id="label-input",
+            )
+            yield Static("Enter to save • Esc to cancel", id="label-hint")
+
+    def on_mount(self) -> None:
+        self.query_one("#label-input", Input).focus()
+
+    def action_submit(self) -> None:
+        value = self.query_one("#label-input", Input).value or ""
+        self.dismiss(value)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    def on_input_submitted(self, event) -> None:
+        try:
+            if event.input.id != "label-input":
+                return
+        except AttributeError:
+            return
+        event.stop()
+        self.action_submit()
+
+
 class HelpScreen(ModalScreen):
     """Full-app help overlay grouped by scope (ADR-017, task #42).
 
@@ -3121,6 +3540,104 @@ class ClaudeSessions(App):
         if self._input_has_focus():
             return
         self.push_screen(SearchScreen(self.conn), self._on_search_dismissed)
+
+    def action_open_bookmarks(self) -> None:
+        """Open the bookmark browser modal (task #18).
+
+        Skips while a text input holds focus so `b` still types when the
+        user is composing a reply / filtering search. Dismiss payload is
+        ``(session_id, message_uuid)``; we reuse the search jump path so
+        bookmarks in out-of-sidebar sessions load just like search hits.
+        """
+        if self._input_has_focus():
+            return
+        self.push_screen(
+            BookmarkBrowserScreen(self.conn),
+            self._on_bookmark_dismissed,
+        )
+
+    def _on_bookmark_dismissed(self, result) -> None:
+        """Route a bookmark pick through the same jump path as search
+        results. ``None`` means the user hit Escape without picking."""
+        if result is None:
+            return
+        try:
+            session_id, message_uuid = result
+        except (TypeError, ValueError):
+            return
+        self._jump_to_search_result(session_id, message_uuid, search_terms=None)
+
+    def bookmark_toggle_selection(self) -> None:
+        """Selection-mode `space`: toggle a bookmark on each selected
+        message. Messages without a stored uuid (rare — synthetic or
+        pre-index) are silently skipped; the rest flip independently so
+        a range with mixed state ends up consistent with the user's
+        intent per message."""
+        transcript = self.query_one("#transcript-scroll", TranscriptView)
+        selected = transcript.get_selected_messages()
+        if not selected:
+            return
+        created = 0
+        removed = 0
+        skipped = 0
+        with db.transaction(self.conn):
+            for widget in selected:
+                uuid = getattr(widget, "_uuid", None)
+                if not uuid:
+                    skipped += 1
+                    continue
+                result = db.toggle_bookmark(self.conn, uuid)
+                if result is None:
+                    removed += 1
+                else:
+                    created += 1
+        parts = []
+        if created:
+            parts.append(f"{created} bookmarked")
+        if removed:
+            parts.append(f"{removed} removed")
+        if skipped and not parts:
+            parts.append(f"{skipped} skipped (no uuid)")
+        self.notify(", ".join(parts) if parts else "No bookmarks changed")
+
+    def bookmark_prompt_label(self) -> None:
+        """Selection-mode `L`: prompt for a label on the (single) focused
+        message. For range selections we label the cursor message only —
+        bulk labeling is an anti-pattern for a short free-text field."""
+        transcript = self.query_one("#transcript-scroll", TranscriptView)
+        messages = transcript._get_message_widgets()
+        if not transcript._selection_mode or not messages:
+            return
+        idx = transcript._selected_index
+        if idx < 0 or idx >= len(messages):
+            return
+        widget = messages[idx]
+        uuid = getattr(widget, "_uuid", None)
+        if not uuid:
+            self.notify("Message has no uuid — cannot bookmark", severity="warning")
+            return
+
+        existing = db.get_bookmark(self.conn, uuid)
+        current = existing["label"] if existing and existing.get("label") else ""
+
+        def _apply(new_label: str | None) -> None:
+            if new_label is None:
+                return
+            # If the message isn't bookmarked yet, create one first so
+            # we have an id to label. This makes `L` on an unbookmarked
+            # message behave like "bookmark + label in one step".
+            row = db.get_bookmark(self.conn, uuid)
+            if row is None:
+                row = db.toggle_bookmark(self.conn, uuid)
+                if row is None:
+                    # Extremely unlikely — the toggle raced a delete.
+                    self.notify("Could not create bookmark", severity="error")
+                    return
+            db.set_bookmark_label(self.conn, row["id"], new_label)
+            shown = (new_label or "").strip() or "(no label)"
+            self.notify(f"Bookmark label: {shown}")
+
+        self.push_screen(LabelPromptScreen(current), _apply)
 
     def action_open_find(self) -> None:
         """Toggle the persistent in-transcript find bar.


### PR DESCRIPTION
## Summary

- Pin messages from selection mode (`space` toggle, `L` for optional label) and browse them in a modal (`b`) that mirrors the search panel — filter across label/text/project/session, Enter jumps via the existing `_jump_to_search_result` path so cross-project bookmarks work out of the box.
- Migration 007 adds a `bookmarks` table: `id` PK, `message_uuid` UNIQUE with FK + ON DELETE CASCADE to `messages`, `label`, `tags TEXT DEFAULT '[]'`, `created_at`. The `tags` column matches the existing `models.Bookmark` shape per task #24's model/schema lockstep rule; the tag editor UI is deferred (tracked in #42) so only `label` has a TUI surface here.

## Notes for review

- From the browser, `L` edits a label inline and `d` removes a bookmark; both refresh the list in place while preserving the cursor position so edits don't jump the user back to the top.
- `L` in selection mode on an unbookmarked message creates the bookmark first and then applies the label — a single-keybind "bookmark + label".
- Out-of-sidebar sessions (older than `--days`, cross-project) are picked up for free because the dismiss callback routes through `_jump_to_search_result`'s Case 3 path — same contract the search modal relies on.
- The browser uses the same SearchScreen ModalScreen layout, CSS structure, and debounce pattern so the two modals feel like siblings in the help overlay and footer.
- `_decode_bookmark_tags` tolerates corrupt / non-JSON payloads by falling back to an empty list so the browser keeps rendering rows even if a future direct write stores malformed data.

## Test plan

- [x] `pytest tests/` — 108 pass (95 existing + 13 new in `tests/test_bookmarks.py`): toggle idempotency, label round-trip + NULL collapse, newest-first ordering, substring filter across label/text/project/custom_name, cascade delete on message removal, UNIQUE enforcement, tags-column JSON round-trip + corrupt-payload fallback
- [ ] Manual: `space` toggles in single + range selection; notify shows correct "N bookmarked / M removed" breakdown
- [ ] Manual: `L` on unbookmarked message creates + labels in one step; `L` on bookmarked message edits existing label; blank label clears
- [ ] Manual: `b` opens browser; typing filters live; Enter jumps to a same-session bookmark, a different-sidebar-session bookmark, and an out-of-sidebar session bookmark
- [ ] Manual: `L` in browser edits label in place; `d` deletes and cursor stays in range; Esc closes

## Follow-ups

- #42 — tag editor UI + `set_bookmark_tags` helper (column exists in this PR per model lockstep, but no entry surface yet)

## References

- `docs/TASKS.md` task #18 — "Build bookmark system"
- `models.py` — `Bookmark` model (task #24)
- ADR-001 — SQLite as the source of truth for non-app state
- PR pattern: mirrors the SearchScreen modal (PR for task #14)