### PR TITLE
Phase 4: /threadhop:handoff skill + handoff orchestrator (task #26)

### DIFF
--- a/handoff.py
+++ b/handoff.py
@@ -1,0 +1,608 @@
+"""Handoff brief builder — task #26, ADR-012 / ADR-016 / ADR-018 / ADR-020.
+
+``/threadhop:handoff <session_id> [--full]`` produces a compressed brief
+that lets a new Claude Code session pick up where an older one left off.
+
+Per ADR-018, the observer is the core function — there is no separate
+"compress raw JSONL" path. This module orchestrates:
+
+  1. Run ``observer.observe_session`` on the target session. The observer
+     itself decides whether to read from byte 0 (first run) or resume
+     from the recorded ``source_byte_offset`` (catch-up on new bytes).
+     We drop its batch threshold to 1 — for handoff we want whatever is
+     extractable, even from a short tail.
+  2. Read the per-session observation file
+     (``~/.config/threadhop/observations/<session_id>.jsonl``). Per
+     ADR-020 this file is unified: observer entries AND reflector
+     ``type: "conflict"`` entries live together.
+  3. Format the entries:
+       * **direct** (short sets, no ``--full``) — pure Python markdown
+         grouped by type. No LLM call, deterministic.
+       * **polish** (large sets, no ``--full``) — Haiku sub-agent via
+         ``claude -p`` compresses/cleans the direct form.
+       * **full** (``--full``) — Haiku sub-agent plus the cleaned
+         transcript, emitting a comprehensive handoff with rationale
+         and verbatim excerpts.
+
+On any polish failure (missing prompt, timeout, non-zero exit) we fall
+back to the direct formatter so the caller still gets something useful.
+
+Public API::
+
+    build_handoff(conn, session_id, *, full=False, ...) -> dict
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+import subprocess
+from pathlib import Path
+from typing import Any, Callable
+
+import db
+import indexer
+import observer
+import reflector
+
+
+# --- Configuration --------------------------------------------------------
+
+# Above this observation count we prefer the Haiku polish pass even
+# without ``--full``. The direct formatter is fine for ~30-50 line briefs,
+# but once a session accumulates dozens of entries the output needs
+# compression, deduplication, and ordering judgement a template can't do.
+LARGE_SET_THRESHOLD = 40
+
+# Polish subprocess timeout. Longer than the observer's default because
+# ``--full`` passes the full cleaned transcript alongside observations,
+# which inflates the prompt considerably.
+DEFAULT_POLISH_TIMEOUT_SEC = 240.0
+
+# Observer batch threshold when invoked via handoff. The normal default
+# (3) is designed for watch mode where skipping "2 turn" chunks avoids
+# burning Haiku calls. Handoff is the user's last chance — run the
+# observer even on a short tail, but still return "up_to_date" when
+# nothing at all has been appended (turns == 0 path).
+HANDOFF_BATCH_THRESHOLD = 1
+
+# Location of the polish prompt. Bundled with the app alongside
+# ``prompts/observer.md`` and ``prompts/reflector.md``.
+POLISH_PROMPT_PATH = Path(__file__).resolve().parent / "prompts" / "handoff.md"
+
+# Observation types in display order. Mirrors observer.py's ``_TYPE_ORDER``
+# but reorders for a reader: decisions/ADRs first (the "what was chosen"),
+# then TODOs (what's left), then done (context), then observations, then
+# conflicts (warnings, intentionally last so they don't drown the brief).
+_TYPE_ORDER = ("decision", "adr", "todo", "done", "observation", "conflict")
+
+_TYPE_LABELS = {
+    "decision": "Decisions",
+    "adr": "ADRs",
+    "todo": "Open TODOs",
+    "done": "Completed",
+    "observation": "Observations",
+    "conflict": "Conflicts",
+}
+
+
+# --- Helpers --------------------------------------------------------------
+
+
+def _read_observations(obs_path: Path) -> list[dict]:
+    """Load all parseable JSONL entries from the observation file.
+
+    Malformed lines are silently skipped — the file is append-only
+    (ADR-020) so a half-written tail line on the first observer run
+    shouldn't abort the whole read.
+    """
+    if not obs_path or not obs_path.is_file():
+        return []
+    entries: list[dict] = []
+    with open(obs_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except (json.JSONDecodeError, ValueError):
+                continue
+    return entries
+
+
+def _group_by_type(entries: list[dict]) -> dict[str, list[dict]]:
+    """Bucket entries by their ``type`` field. Unknown types fall into
+    ``observation`` so nothing is silently dropped in the direct format.
+    """
+    groups: dict[str, list[dict]] = {}
+    for e in entries:
+        t = e.get("type") or "observation"
+        if not isinstance(t, str):
+            t = "observation"
+        groups.setdefault(t, []).append(e)
+    return groups
+
+
+def _format_brief_direct(
+    session_id: str,
+    session_meta: dict | None,
+    entries: list[dict],
+) -> str:
+    """Deterministic markdown brief — used for short sets with no ``--full``.
+
+    The shape intentionally mirrors what the polish prompt is asked to
+    produce so consumers of the brief don't have to care which path ran.
+    """
+    groups = _group_by_type(entries)
+    lines: list[str] = []
+
+    title = f"# Handoff — session {session_id[:12]}"
+    project = (session_meta or {}).get("project")
+    if project:
+        title += f" · project `{project}`"
+    lines.append(title)
+    lines.append("")
+    lines.append(
+        f"Based on {len(entries)} observation"
+        f"{'' if len(entries) == 1 else 's'} "
+        "extracted by the ThreadHop observer."
+    )
+    lines.append("")
+
+    for t in _TYPE_ORDER:
+        items = groups.get(t, [])
+        if not items:
+            continue
+        lines.append(f"## {_TYPE_LABELS[t]}")
+        for e in items:
+            lines.append(_bullet_for(t, e))
+        lines.append("")
+
+    # Defensive: catch any types the observer emitted that we don't know
+    # about yet. Better to surface them than hide them.
+    for t, items in groups.items():
+        if t in _TYPE_ORDER or not items:
+            continue
+        lines.append(f"## {t.title()}")
+        for e in items:
+            lines.append(_bullet_for(t, e))
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _bullet_for(type_name: str, entry: dict) -> str:
+    """One bullet line for a single observation entry.
+
+    Conflict entries get their linked session refs appended so the brief
+    isn't just "there is a conflict" — the reader can jump to the other
+    session if they want more detail.
+    """
+    text = (entry.get("text") or "").strip()
+    context = (entry.get("context") or "").strip()
+    bullet = f"- {text}" if text else "- (empty)"
+    if context:
+        bullet += f"  _({context})_"
+    if type_name == "conflict":
+        refs = entry.get("refs") or []
+        if isinstance(refs, list) and refs:
+            short = ", ".join(str(r)[:8] for r in refs)
+            bullet += f"  — refs: {short}"
+    return bullet
+
+
+def _invoke_polish(
+    prompt_template: str,
+    observations_jsonl: str,
+    transcript: str | None,
+    mode: str,
+    *,
+    claude_bin: str = "claude",
+    timeout: float = DEFAULT_POLISH_TIMEOUT_SEC,
+) -> tuple[str, dict[str, Any]]:
+    """Shell out to ``claude -p --model haiku`` to produce the polished brief.
+
+    ``mode`` is ``"polish"`` (observations-only compression) or ``"full"``
+    (observations + transcript, comprehensive output). The transcript is
+    only passed through for ``"full"``; ``"polish"`` deliberately leaves
+    the source transcript out so the sub-agent can't paraphrase beyond
+    what the observer already extracted.
+
+    Returns ``(brief_text, meta)``. ``brief_text`` is empty on failure;
+    ``meta`` carries ``error`` (and possibly ``stderr``) in that case so
+    the caller can message the user and fall back to direct formatting.
+    """
+    prompt_parts = [
+        prompt_template.rstrip(),
+        "",
+        "---",
+        "",
+        f"## Mode\n\n{mode}",
+        "",
+        "## Observations",
+        "",
+        "<observations>",
+        observations_jsonl.rstrip(),
+        "</observations>",
+    ]
+    if transcript is not None and mode == "full":
+        prompt_parts += [
+            "",
+            "## Cleaned transcript",
+            "",
+            "<transcript>",
+            transcript.rstrip(),
+            "</transcript>",
+        ]
+    prompt = "\n".join(prompt_parts)
+
+    if shutil.which(claude_bin) is None and not Path(claude_bin).exists():
+        return "", {"error": f"{claude_bin} not found on PATH"}
+
+    try:
+        proc = subprocess.run(
+            [
+                claude_bin, "-p", prompt,
+                "--model", "haiku",
+                "--permission-mode", "acceptEdits",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return "", {"error": f"polish timed out after {timeout}s"}
+    except OSError as e:
+        return "", {"error": f"polish could not start: {e}"}
+
+    if proc.returncode != 0:
+        return "", {
+            "error": f"polish exited {proc.returncode}",
+            "stderr": (proc.stderr or "").strip(),
+        }
+
+    out = (proc.stdout or "").strip()
+    if not out:
+        return "", {"error": "polish returned empty output"}
+    return out + "\n", {}
+
+
+def _resolve_source_path(
+    conn: sqlite3.Connection,
+    session_id: str,
+    explicit: str | Path | None,
+) -> Path | None:
+    """Same precedence as the observer's resolver: explicit → state → sessions.
+
+    Used for the ``--full`` transcript read, which happens *after* the
+    observer has already run, so any of the three levels may have been
+    populated. Returns ``None`` if no path is known — callers skip the
+    transcript step and the sub-agent works from observations alone.
+    """
+    if explicit is not None:
+        return Path(explicit)
+    state = db.get_observation_state(conn, session_id)
+    if state is not None and state["source_path"]:
+        return Path(state["source_path"])
+    sess = db.get_session(conn, session_id)
+    if sess is not None and sess.get("session_path"):
+        return Path(sess["session_path"])
+    return None
+
+
+def _rendered_transcript(
+    conn: sqlite3.Connection,
+    session_id: str,
+    source_path: str | Path | None,
+) -> str | None:
+    """Render the full source JSONL through the same pipeline the observer
+    and FTS index use (indexer.parse_byte_range + observer._format_transcript).
+
+    Guarantees the ``--full`` sub-agent reasons about the same view of the
+    conversation the user sees in the TUI. Returns ``None`` if the source
+    can't be located or read — the caller degrades to observations-only
+    polish in that case.
+    """
+    resolved = _resolve_source_path(conn, session_id, source_path)
+    if resolved is None or not resolved.exists():
+        return None
+    try:
+        raw = resolved.read_bytes()
+    except OSError:
+        return None
+    turns = indexer.parse_byte_range(raw, fallback_session_id=session_id)
+    if not turns:
+        return None
+    return observer._format_transcript(turns)
+
+
+# --- Main entry point -----------------------------------------------------
+
+
+def build_handoff(
+    conn: sqlite3.Connection,
+    session_id: str,
+    *,
+    source_path: str | Path | None = None,
+    full: bool = False,
+    large_set_threshold: int = LARGE_SET_THRESHOLD,
+    claude_bin: str = "claude",
+    timeout: float = DEFAULT_POLISH_TIMEOUT_SEC,
+    prompt_path: Path | None = None,
+    observer_prompt_path: Path | None = None,
+    observer_batch_threshold: int = HANDOFF_BATCH_THRESHOLD,
+    observer_timeout: float = observer.DEFAULT_TIMEOUT_SEC,
+    reflect_fn: Callable[..., dict[str, Any]] | None | str = "default",
+    reflector_prompt_path: Path | None = None,
+    reflector_timeout: float = reflector.DEFAULT_TIMEOUT_SEC,
+) -> dict[str, Any]:
+    """Produce a handoff brief for ``session_id``.
+
+    Orchestration — per ADR-018 the observer is the only path to
+    observations, so this always runs it first (which itself no-ops when
+    the cursor is at EOF and there's nothing new to extract).
+
+    Args:
+        conn: Open DB connection with the schema applied.
+        session_id: Claude Code session UUID to hand off.
+        source_path: Optional source JSONL override. Normally resolved
+            from ``observation_state`` / ``sessions`` rows by the observer.
+        full: If True, use the Haiku sub-agent in "full" mode — produces
+            a comprehensive handoff with rationale and transcript
+            excerpts. Always invokes Haiku regardless of set size.
+        large_set_threshold: If ``len(entries) > threshold`` and ``full``
+            is False, the "polish" sub-agent path is used to compress the
+            brief. Below this threshold, direct templating is used.
+        claude_bin: ``claude`` binary name or path. Forwarded to both the
+            observer and the polish call — tests swap in a shell shim.
+        timeout: Polish subprocess timeout (seconds).
+        prompt_path: Override the handoff polish prompt location.
+        observer_prompt_path: Override the observer prompt location
+            (forwarded to ``observe_session``).
+        observer_batch_threshold: Threshold passed to ``observe_session``.
+            Defaults to 1 — handoff wants maximum coverage.
+        observer_timeout: Timeout passed to ``observe_session``.
+        reflect_fn: Callable invoked after the observer returns, with
+            signature ``(conn, session_id, *, claude_bin, timeout,
+            prompt_path) -> dict``. Defaults to
+            ``reflector.reflect_session`` per ADR-022 ("reflector runs as
+            a follow-up step" for on-demand observer invocations). Pass
+            ``None`` to skip the reflector pass entirely (debug / tests).
+            Any exception raised is caught and logged into the returned
+            dict's ``reflector_error`` key — a reflector failure never
+            breaks the handoff.
+        reflector_prompt_path: Override the reflector prompt location
+            (forwarded to ``reflect_fn`` as ``prompt_path``).
+        reflector_timeout: Timeout passed to ``reflect_fn``.
+
+    Returns:
+        Dict::
+
+            {
+              "status": "ok" | "no_source" | "no_observations" | "failed",
+              "brief":  <str>,          # markdown brief (empty on error)
+              "mode":   "direct" | "polish" | "full",
+              "entry_count": <int>,     # observations used
+              "obs_path": <str>,
+              "observer_result": <dict | None>,  # observe_session return
+              "message": <str>,         # human-readable status line
+            }
+
+        Never raises on expected failures — callers branch on ``status``
+        and can still display ``brief`` on ``ok`` regardless of ``mode``.
+    """
+    prompt_path = prompt_path or POLISH_PROMPT_PATH
+
+    # Resolve ``reflect_fn`` late so tests / callers can monkeypatch
+    # ``reflector.reflect_session`` after module import and still affect
+    # the default. Passing ``reflect_fn=None`` explicitly still disables
+    # the reflector; passing any callable overrides it.
+    if reflect_fn == "default":
+        reflect_fn = reflector.reflect_session
+
+    # --- Step 1: run the observer (catch-up or first-time extraction). ----
+    observer_result = observer.observe_session(
+        conn, session_id,
+        source_path=source_path,
+        batch_threshold=observer_batch_threshold,
+        claude_bin=claude_bin,
+        timeout=observer_timeout,
+        prompt_path=observer_prompt_path,
+    )
+
+    obs_status = observer_result.get("status")
+
+    # ``no_source`` is the only condition that stops the handoff cold —
+    # with no transcript AND no prior observations there is literally
+    # nothing to hand off. All other observer failures (failed, timeout)
+    # are soft: any existing observations are still readable.
+    if obs_status == "no_source":
+        state = db.get_observation_state(conn, session_id)
+        if state is None or int(state.get("entry_count") or 0) == 0:
+            return {
+                "status": "no_source",
+                "brief": "",
+                "mode": "direct",
+                "entry_count": 0,
+                "obs_path": observer_result.get("obs_path", ""),
+                "observer_result": observer_result,
+                "message": observer_result.get(
+                    "message", "No source JSONL for this session."
+                ),
+            }
+
+    # --- Step 2: run the reflector (ADR-022 on-demand follow-up). --------
+    # Per ADR-022: "When the observer core function runs on-demand (e.g.,
+    # threadhop handoff or threadhop conflicts), the reflector runs as a
+    # follow-up step." The reflector compares new decisions from this
+    # session against peers in the same project, and appends
+    # ``type: "conflict"`` entries to the same observation JSONL — so
+    # those conflicts show up in the brief we render below. The reflector
+    # gates itself (no_decisions / no_project / up_to_date) so calling it
+    # unconditionally here is safe and cheap.
+    reflector_result: dict[str, Any] | None = None
+    reflector_error: str | None = None
+    if reflect_fn is not None and obs_status != "no_source":
+        try:
+            reflector_result = reflect_fn(
+                conn, session_id,
+                claude_bin=claude_bin,
+                timeout=reflector_timeout,
+                prompt_path=reflector_prompt_path,
+            )
+        except Exception as e:
+            # A reflector failure MUST NOT break the handoff — the
+            # observer's output is already on disk and usable. Record
+            # the error and continue to the format step.
+            reflector_error = f"{type(e).__name__}: {e}"
+
+    # --- Step 3: locate observation file and read entries. ----------------
+    obs_path_str = observer_result.get("obs_path") or ""
+    if not obs_path_str:
+        state = db.get_observation_state(conn, session_id)
+        if state is not None:
+            obs_path_str = state["obs_path"]
+    obs_path = Path(obs_path_str) if obs_path_str else None
+    entries = _read_observations(obs_path) if obs_path else []
+
+    if not entries:
+        # Observer ran but extracted nothing, and no prior observations
+        # exist. Common for short or routine sessions.
+        return _attach_reflector_info({
+            "status": "no_observations",
+            "brief": "",
+            "mode": "direct",
+            "entry_count": 0,
+            "obs_path": str(obs_path) if obs_path else "",
+            "observer_result": observer_result,
+            "message": (
+                "No observations extracted for this session. "
+                "The transcript may be too short or contain no "
+                "decisions/TODOs/observations worth surfacing."
+            ),
+        }, reflector_result, reflector_error)
+
+    # --- Step 3: pick format path. ----------------------------------------
+    session_meta = db.get_session(conn, session_id)
+    use_polish = full or len(entries) > large_set_threshold
+
+    if not use_polish:
+        brief = _format_brief_direct(session_id, session_meta, entries)
+        return _attach_reflector_info({
+            "status": "ok",
+            "brief": brief,
+            "mode": "direct",
+            "entry_count": len(entries),
+            "obs_path": str(obs_path) if obs_path else "",
+            "observer_result": observer_result,
+            "message": (
+                f"Formatted {len(entries)} observation"
+                f"{'' if len(entries) == 1 else 's'} directly."
+            ),
+        }, reflector_result, reflector_error)
+
+    # Polish via Haiku sub-agent. Any failure below falls back to the
+    # direct formatter so the user still gets a usable brief.
+    try:
+        template = prompt_path.read_text()
+    except OSError as e:
+        return _attach_reflector_info(
+            _fallback_direct(
+                session_id, session_meta, entries, obs_path, observer_result,
+                reason=f"handoff prompt missing ({e})",
+            ),
+            reflector_result, reflector_error,
+        )
+
+    transcript: str | None = None
+    if full:
+        transcript = _rendered_transcript(conn, session_id, source_path)
+
+    obs_jsonl = "\n".join(json.dumps(e) for e in entries)
+    mode_label = "full" if full else "polish"
+    polished, meta = _invoke_polish(
+        template, obs_jsonl, transcript, mode_label,
+        claude_bin=claude_bin, timeout=timeout,
+    )
+
+    if not polished:
+        reason = meta.get("error") or "polish returned no output"
+        return _attach_reflector_info(
+            _fallback_direct(
+                session_id, session_meta, entries, obs_path, observer_result,
+                reason=reason,
+                stderr=meta.get("stderr"),
+            ),
+            reflector_result, reflector_error,
+        )
+
+    return _attach_reflector_info({
+        "status": "ok",
+        "brief": polished,
+        "mode": mode_label,
+        "entry_count": len(entries),
+        "obs_path": str(obs_path),
+        "observer_result": observer_result,
+        "message": (
+            f"Polished {len(entries)} observations via Haiku "
+            f"({'full mode — with transcript excerpts' if full else 'compression mode'})."
+        ),
+    }, reflector_result, reflector_error)
+
+
+def _attach_reflector_info(
+    result: dict[str, Any],
+    reflector_result: dict[str, Any] | None,
+    reflector_error: str | None,
+) -> dict[str, Any]:
+    """Decorate a returned handoff dict with reflector outcome fields.
+
+    Keeps the reflector state out of every return-site literal — each of
+    ``build_handoff``'s exit paths just wraps its dict in this helper.
+    We always attach ``reflector_result`` (possibly ``None`` when the
+    reflector was disabled or skipped); ``reflector_error`` is only
+    present when ``reflect_fn`` raised, so the CLI can surface that
+    specifically without having to dig into the dict.
+    """
+    result["reflector_result"] = reflector_result
+    if reflector_error is not None:
+        result["reflector_error"] = reflector_error
+    return result
+
+
+def _fallback_direct(
+    session_id: str,
+    session_meta: dict | None,
+    entries: list[dict],
+    obs_path: Path,
+    observer_result: dict,
+    *,
+    reason: str,
+    stderr: str | None = None,
+) -> dict[str, Any]:
+    """Shared tail for polish-failure branches.
+
+    Returns ``status="ok"`` because the user still gets a usable brief —
+    ``message`` carries the reason so the CLI can surface it without the
+    caller having to special-case the fallback.
+    """
+    brief = _format_brief_direct(session_id, session_meta, entries)
+    msg = (
+        f"Formatted {len(entries)} observations directly "
+        f"(fallback: {reason})."
+    )
+    result = {
+        "status": "ok",
+        "brief": brief,
+        "mode": "direct",
+        "entry_count": len(entries),
+        "obs_path": str(obs_path),
+        "observer_result": observer_result,
+        "message": msg,
+    }
+    if stderr:
+        result["polish_stderr"] = stderr
+    return result

--- a/prompts/handoff.md
+++ b/prompts/handoff.md
@@ -1,0 +1,150 @@
+# ThreadHop Handoff Polish Prompt
+
+You are composing a **handoff brief** that lets a new Claude Code session
+pick up where an older one left off. The brief is injected into the new
+session as context; keep it dense, faithful to the source, and free of
+filler.
+
+## Inputs
+
+The `<observations>` block is a JSONL feed of typed observations
+extracted by the ThreadHop observer from the source session. Each line
+has the shape:
+
+```json
+{"type":"<type>","text":"<description>","context":"<rationale>","ts":"<ISO 8601>"}
+```
+
+Conflict entries additionally carry `refs` (array of session IDs
+involved) and `topic` (semantic grouping key).
+
+Observation types:
+
+| Type | Meaning |
+|------|---------|
+| `decision` | A choice made between alternatives, with rationale. |
+| `adr` | A fully-argued architectural decision (context → decision → rationale). |
+| `todo` | Identified, not yet done. |
+| `done` | Completed or confirmed working. |
+| `observation` | Insight/constraint worth remembering that isn't a decision or task. |
+| `conflict` | Contradiction detected across sessions (from the reflector). |
+
+## Mode
+
+The `## Mode` section names either `polish` or `full`. The requirements
+below are mode-specific — follow the one that matches.
+
+---
+
+### Mode: `polish`
+
+Short-form brief for fast onboarding. No transcript is supplied; work
+**only** from observations.
+
+Produce markdown with this shape:
+
+```markdown
+# Handoff — session <first 12 chars of session id> · project `<project>`
+
+<one or two sentence summary of what the session was working on, inferred
+ strictly from the observation texts.>
+
+## Decisions
+- <text>  _(<context>)_
+
+## ADRs
+- <text>  _(<context>)_
+
+## Open TODOs
+- <text>  _(<context>)_
+
+## Completed
+- <text>
+
+## Observations
+- <text>  _(<context>)_
+
+## Conflicts
+- <text>  — refs: <sess1>, <sess2>
+```
+
+Rules:
+
+- Drop sections whose type has zero entries. Never emit an empty heading.
+- Merge near-duplicates (same decision described twice across turns) into
+  a single bullet. Preserve the original phrasing of the kept entry —
+  do not paraphrase.
+- Keep bullets to one line each when possible. Never split an entry
+  across multiple bullets.
+- Target 30-50 output lines total. Trim the lowest-signal `observation`
+  entries first if over budget.
+- Do NOT add a "Next steps" or "Recommendations" section. The brief is a
+  record of what happened, not advice.
+
+---
+
+### Mode: `full`
+
+Comprehensive handoff. A `<transcript>` block is included — the cleaned,
+role-labelled conversation. Use it to ground quotes and rationale.
+
+Produce markdown with this shape:
+
+```markdown
+# Handoff — session <first 12 chars of session id> · project `<project>`
+
+## Summary
+
+<two or three paragraph summary of what the session was about, the
+ problem being solved, and the state at the end of the transcript.>
+
+## Decisions & ADRs
+
+### <short title>
+- **Decision:** <text from observation>
+- **Rationale:** <pulled from transcript or observation context>
+- **Excerpt:**
+  > <≤5 line verbatim quote from the transcript that grounds the decision>
+
+<repeat per decision/ADR; group tightly related decisions under one title>
+
+## Open TODOs
+- <text>  _(<context>)_
+
+## Completed in this session
+- <text>
+
+## Observations
+- <text>  _(<context>)_
+
+## Conflicts
+- <text>  — refs: <sess1>, <sess2>
+  > <≤5 line quote from the transcript if the conflict was discussed>
+
+## Conversation excerpts
+
+<2-4 short (≤5 line) verbatim quotes from the transcript that weren't
+ already inlined above but carry important context a reader picking up
+ this session should see first. Each quote gets a one-line caption.>
+```
+
+Rules:
+
+- Excerpts must be **verbatim** — copy from the transcript, do not
+  rephrase. Preserve role prefixes (user/assistant) inside the quote
+  block if that clarifies attribution.
+- Skip any section whose inputs are empty. Do not emit placeholders.
+- Keep the total brief under ~150 lines. Omit low-signal observations
+  before truncating quotes.
+
+---
+
+## Output rules (both modes)
+
+- Emit markdown to stdout. No preamble, no "here's the brief", no
+  self-reference. Start with the H1 title.
+- Do not ask questions, do not list uncertainties, do not describe what
+  you are about to do.
+- Do not fabricate content. If an observation field is empty, drop it
+  from the bullet — do not invent context.
+- Do not include the raw JSON of observations in the output.

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: handoff
+description: Produce a ThreadHop handoff brief for another Claude Code session so this conversation can pick up where that one left off. Pass the target session id; add --full for a comprehensive brief with transcript excerpts. Uses the ThreadHop observer + a Haiku sub-agent.
+---
+
+# /threadhop:handoff
+
+You have been invoked to produce a **handoff brief** for a prior Claude
+Code session, so the current conversation can carry its context forward.
+
+## Arguments
+
+The user invokes this skill as:
+
+```
+/threadhop:handoff <session_id> [--full]
+```
+
+- `<session_id>` — required. The Claude Code session UUID (or the
+  first unambiguous prefix) the user wants to hand off from. Usually
+  lifted from the ThreadHop TUI or `~/.claude/projects/`.
+- `--full` — optional. Request a comprehensive brief with rationale,
+  file/code references, and verbatim transcript excerpts. Without it,
+  you get a short brief (~30-50 lines).
+
+Parse those from `$ARGUMENTS` exactly. If `<session_id>` is missing,
+stop and ask the user for it — do not guess.
+
+## What you do
+
+1. Run the ThreadHop `handoff` subcommand with the parsed arguments.
+   It already handles every observer/observation detail per ADR-018:
+     - Seeds the `sessions` row if the transcript exists.
+     - Runs the observer to catch up incrementally (or extract from
+       byte 0 if this session was never observed).
+     - Reads the per-session unified observation JSONL
+       (observer + reflector conflict entries, ADR-020).
+     - Formats short sets directly; polishes large sets / `--full`
+       through a Haiku sub-agent.
+
+   ```bash
+   threadhop handoff <session_id>          # short brief
+   threadhop handoff <session_id> --full   # comprehensive brief
+   ```
+
+   The command prints the markdown brief to **stdout**. Status and
+   diagnostic lines (e.g. "Polished 12 observations via Haiku", or the
+   fallback reason if Haiku polish failed) go to **stderr** — surface
+   those only if something noteworthy happened (fallback, error).
+
+2. Present the brief to the user inside a clearly bounded context
+   block so it's visually distinct from your own reasoning. Start with
+   a one-line preface that names the session id and mode, then render
+   the markdown the command emitted verbatim (do not paraphrase,
+   truncate, or reflow).
+
+   Example layout:
+
+   ```
+   Handoff brief for session abc12345 (short):
+
+   <markdown stdout from `threadhop handoff`>
+   ```
+
+3. After the brief, do NOT automatically start acting on any TODOs
+   it lists. Wait for the user to tell you what to do with the
+   handed-off context. This skill only *loads* context; it does not
+   *execute* on it.
+
+## Error handling
+
+- Exit code 1 (`no_source` — transcript not found): tell the user the
+  session id couldn't be located and suggest they confirm it via the
+  ThreadHop TUI or `ls ~/.claude/projects/`. Do not retry with a
+  different id unless the user provides one.
+- Exit code 0 with empty stdout (`no_observations`): the stderr message
+  explains — usually the target session is too short or routine for the
+  observer to find decisions/TODOs. Pass that message through to the
+  user; do not fabricate a brief.
+- Any other non-zero exit: show the stderr message verbatim. Do not
+  retry silently.
+
+## Constraints
+
+- Do NOT try to read the raw JSONL transcript yourself. Always go
+  through `threadhop handoff` — it owns the observer invocation,
+  prompt template, and state tracking.
+- Do NOT re-run the subcommand multiple times hoping for a better
+  brief. The observer is deterministic-enough that a retry at the same
+  state returns the same output.
+- Do NOT edit `~/.config/threadhop/observations/*.jsonl` or the
+  ThreadHop SQLite DB yourself. Those files are append-only and
+  maintained by the observer/reflector (ADR-020).

--- a/tests/test_handoff.py
+++ b/tests/test_handoff.py
@@ -1,0 +1,620 @@
+"""Tests for the handoff brief builder (task #26, ADR-012/016/018/020).
+
+Covers the orchestration:
+
+  * Direct-format path for short observation sets.
+  * Polish path when the set is large (Haiku sub-agent, faked).
+  * --full path with transcript injection (fake claude sees the
+    ``<transcript>`` block).
+  * no_source when neither a session row nor prior observations exist.
+  * no_observations when the observer runs but nothing is extracted and
+    there are no prior observations.
+  * Catch-up behaviour when the source JSONL grew since last observation.
+  * Graceful fall-back to direct formatting when the polish prompt is
+    missing or the sub-agent exits non-zero.
+
+The real observer and handoff polish both shell out to ``claude -p``.
+Tests inject a fake shell script via the ``claude_bin`` argument so we
+exercise the whole pipeline end-to-end without needing Haiku.
+
+Run from the repo root::
+
+    python -m pytest tests/test_handoff.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+import db
+import handoff
+
+
+# --- Fixtures -------------------------------------------------------------
+
+
+@pytest.fixture
+def obs_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``db.OBS_DIR`` into tmp_path so observations don't escape."""
+    d = tmp_path / "observations"
+    d.mkdir()
+    monkeypatch.setattr(db, "OBS_DIR", d)
+    return d
+
+
+@pytest.fixture(autouse=True)
+def _quiet_reflector(monkeypatch: pytest.MonkeyPatch):
+    """Default the reflector to a benign stub across every test in this file.
+
+    ``build_handoff`` resolves ``reflect_fn`` late (when the sentinel
+    ``"default"`` is passed, which is the signature default), so patching
+    ``reflector.reflect_session`` here replaces the call without forcing
+    every existing test to thread ``reflect_fn=None`` through.
+
+    Reflector-specific tests pass their own callable via ``reflect_fn=<fake>``
+    which takes precedence over this stub.
+    """
+    import reflector as reflector_mod
+
+    def _noop_reflect(conn, session_id, **_kwargs):
+        return {"status": "up_to_date", "new_entries": 0, "entry_count": 0}
+
+    monkeypatch.setattr(reflector_mod, "reflect_session", _noop_reflect)
+
+
+@pytest.fixture
+def fake_claude_factory(tmp_path: Path):
+    """Build a shell script that stands in for ``claude -p ...``.
+
+    The observer invokes ``claude -p <prompt> --model haiku
+    --permission-mode acceptEdits``. The handoff polish invokes the same
+    flags. We distinguish the two by looking at the prompt body:
+
+      * Observer prompt contains ``Append observations to: <path>``.
+        → Append the supplied ``observer_entries`` JSONL to that path.
+      * Handoff polish prompt contains ``## Mode``.
+        → Print ``polish_output`` to stdout.
+
+    Either entry can be set to ``None`` to leave the script inert for
+    that role (useful for testing a path that shouldn't trigger it).
+
+    If ``capture_polish_prompt`` is supplied, the polish invocation
+    writes its whole prompt payload to that path — lets tests assert
+    the ``--full`` transcript actually made it through.
+    """
+    def _make(
+        observer_entries: list[dict] | None = None,
+        polish_output: str | None = None,
+        capture_polish_prompt: Path | None = None,
+        polish_exit_code: int = 0,
+        polish_stderr: str = "",
+    ) -> Path:
+        path = tmp_path / "fake_claude"
+        obs_payload = tmp_path / "fake_observer_entries.jsonl"
+        if observer_entries is not None:
+            obs_payload.write_text(
+                "\n".join(json.dumps(e) for e in observer_entries) + "\n"
+            )
+        else:
+            obs_payload.write_text("")
+
+        polish_payload = tmp_path / "fake_polish_output.md"
+        if polish_output is not None:
+            polish_payload.write_text(polish_output)
+        else:
+            polish_payload.write_text("")
+
+        capture_line = (
+            f'printf "%s" "$prompt" > "{capture_polish_prompt}"'
+            if capture_polish_prompt is not None
+            else "true"
+        )
+
+        body = f"""#!/usr/bin/env bash
+set -euo pipefail
+# Args: -p <prompt> --model haiku --permission-mode acceptEdits
+prompt="$2"
+
+if printf "%s" "$prompt" | grep -q '^Append observations to: '; then
+    obs_path=$(printf '%s' "$prompt" | sed -n 's/^Append observations to: //p' | tail -n 1)
+    if [ -s "{obs_payload}" ]; then
+        cat "{obs_payload}" >> "$obs_path"
+    fi
+    exit 0
+fi
+
+# Handoff polish invocation.
+{capture_line}
+if [ "{polish_exit_code}" != "0" ]; then
+    printf "%s" "{polish_stderr}" 1>&2
+    exit {polish_exit_code}
+fi
+cat "{polish_payload}"
+"""
+        path.write_text(body)
+        path.chmod(
+            path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH
+        )
+        return path
+
+    return _make
+
+
+# --- JSONL builders (mirror test_observer.py) -----------------------------
+
+
+def _user_line(uuid: str, text: str, sid: str = "sess-1") -> str:
+    return json.dumps({
+        "type": "user",
+        "uuid": uuid,
+        "sessionId": sid,
+        "timestamp": "2026-04-17T10:00:00Z",
+        "message": {
+            "id": f"umsg_{uuid}",
+            "content": [{"type": "text", "text": text}],
+        },
+    })
+
+
+def _assistant_line(uuid: str, mid: str, text: str, sid: str = "sess-1") -> str:
+    return json.dumps({
+        "type": "assistant",
+        "uuid": uuid,
+        "sessionId": sid,
+        "timestamp": "2026-04-17T10:00:01Z",
+        "message": {
+            "id": mid,
+            "content": [{"type": "text", "text": text}],
+        },
+    })
+
+
+def _write_session(tmp_path: Path, name: str, lines: list[str]) -> Path:
+    jsonl = tmp_path / f"{name}.jsonl"
+    jsonl.write_text("\n".join(lines) + "\n")
+    return jsonl
+
+
+def _seed_session_row(conn, session_id: str, session_path: Path):
+    db.upsert_session(
+        conn, session_id, str(session_path),
+        project="test-project",
+    )
+
+
+def _three_turn_session(tmp_path: Path, sid: str = "sess-1") -> Path:
+    """Three-turn session — meets the default observer threshold."""
+    return _write_session(tmp_path, sid, [
+        _user_line("u1", "Should we use SQLite?", sid=sid),
+        _assistant_line(
+            "a1", "m1", "Yes, SQLite fits the use case.", sid=sid,
+        ),
+        _user_line("u2", "Great, decided.", sid=sid),
+    ])
+
+
+# --- Direct-format unit tests --------------------------------------------
+
+
+class TestFormatBriefDirect:
+    def test_groups_entries_by_type_in_display_order(self):
+        entries = [
+            {"type": "observation", "text": "JSONL has dup ids",
+             "context": "", "ts": "t1"},
+            {"type": "decision", "text": "REST over gRPC",
+             "context": "SDK constraints", "ts": "t2"},
+            {"type": "todo", "text": "Write tests", "context": "",
+             "ts": "t3"},
+            {"type": "adr", "text": "Use SQLite",
+             "context": "single-file deployment", "ts": "t4"},
+        ]
+        out = handoff._format_brief_direct(
+            "abc123456789xxx", {"project": "atlas"}, entries,
+        )
+        # Title carries short session id and project.
+        assert out.splitlines()[0] == "# Handoff — session abc123456789 · project `atlas`"
+        # Ordering: decision, adr, todo, observation.
+        decisions_idx = out.index("## Decisions")
+        adrs_idx = out.index("## ADRs")
+        todos_idx = out.index("## Open TODOs")
+        obs_idx = out.index("## Observations")
+        assert decisions_idx < adrs_idx < todos_idx < obs_idx
+
+    def test_empty_sections_are_omitted(self):
+        entries = [
+            {"type": "decision", "text": "x", "context": "", "ts": "t"},
+        ]
+        out = handoff._format_brief_direct("abc", None, entries)
+        assert "## Decisions" in out
+        assert "## Open TODOs" not in out
+        assert "## ADRs" not in out
+
+    def test_context_rendered_as_parenthetical(self):
+        entries = [
+            {"type": "decision", "text": "REST over gRPC",
+             "context": "SDK constraints", "ts": "t"},
+        ]
+        out = handoff._format_brief_direct("abc", None, entries)
+        assert "- REST over gRPC  _(SDK constraints)_" in out
+
+    def test_conflict_includes_refs(self):
+        entries = [
+            {"type": "conflict", "text": "REST vs gRPC",
+             "context": "", "ts": "t",
+             "refs": ["abcd1234efgh", "ijkl5678mnop"]},
+        ]
+        out = handoff._format_brief_direct("sid", None, entries)
+        assert "## Conflicts" in out
+        # First 8 chars of each ref.
+        assert "refs: abcd1234, ijkl5678" in out
+
+    def test_unknown_type_still_surfaces(self):
+        entries = [
+            {"type": "mystery", "text": "unknown", "context": "",
+             "ts": "t"},
+        ]
+        out = handoff._format_brief_direct("sid", None, entries)
+        assert "## Mystery" in out
+        assert "- unknown" in out
+
+
+class TestReadObservations:
+    def test_missing_file_returns_empty(self, tmp_path: Path):
+        assert handoff._read_observations(tmp_path / "nope.jsonl") == []
+
+    def test_skips_malformed_lines(self, tmp_path: Path):
+        p = tmp_path / "obs.jsonl"
+        p.write_text(
+            '{"type":"decision","text":"ok","context":"","ts":"t"}\n'
+            "not-json\n"
+            "\n"
+            '{"type":"todo","text":"x","context":"","ts":"t"}\n'
+        )
+        entries = handoff._read_observations(p)
+        assert [e["type"] for e in entries] == ["decision", "todo"]
+
+
+# --- Orchestration tests --------------------------------------------------
+
+
+class TestBuildHandoff:
+    def test_no_source_when_unknown_session(
+        self, tmp_path, conn, obs_dir, fake_claude_factory,
+    ):
+        claude = fake_claude_factory()
+        result = handoff.build_handoff(
+            conn, "ghost", claude_bin=str(claude),
+        )
+        assert result["status"] == "no_source"
+        assert result["brief"] == ""
+
+    def test_direct_format_when_observer_extracts_few_entries(
+        self, tmp_path, conn, obs_dir, fake_claude_factory,
+    ):
+        jsonl = _three_turn_session(tmp_path)
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        canned = [
+            {"type": "decision", "text": "Use SQLite",
+             "context": "single-file deployment",
+             "ts": "2026-04-17T10:00:03Z"},
+            {"type": "todo", "text": "Write schema migration",
+             "context": "", "ts": "2026-04-17T10:00:03Z"},
+        ]
+        # No polish output — direct path should never invoke polish.
+        claude = fake_claude_factory(observer_entries=canned)
+
+        result = handoff.build_handoff(
+            conn, "sess-1", claude_bin=str(claude),
+        )
+
+        assert result["status"] == "ok"
+        assert result["mode"] == "direct"
+        assert result["entry_count"] == 2
+        brief = result["brief"]
+        assert brief.startswith("# Handoff — session sess-1")
+        assert "## Decisions" in brief
+        assert "- Use SQLite  _(single-file deployment)_" in brief
+        assert "## Open TODOs" in brief
+        assert "- Write schema migration" in brief
+
+    def test_no_observations_when_observer_extracts_nothing(
+        self, tmp_path, conn, obs_dir, fake_claude_factory,
+    ):
+        jsonl = _three_turn_session(tmp_path)
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        # Observer runs but writes no observation lines.
+        claude = fake_claude_factory(observer_entries=[])
+
+        result = handoff.build_handoff(
+            conn, "sess-1", claude_bin=str(claude),
+        )
+        assert result["status"] == "no_observations"
+        assert result["brief"] == ""
+        # Observer did run — its result is attached.
+        assert result["observer_result"]["status"] == "extracted"
+
+    def test_polish_path_when_set_exceeds_large_threshold(
+        self, tmp_path, conn, obs_dir, fake_claude_factory,
+    ):
+        jsonl = _three_turn_session(tmp_path)
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        many = [
+            {"type": "decision", "text": f"decision {i}",
+             "context": "", "ts": "t"}
+            for i in range(5)
+        ]
+        polished = "# Handoff — polished\n\n- compressed bullet\n"
+        claude = fake_claude_factory(
+            observer_entries=many, polish_output=polished,
+        )
+
+        result = handoff.build_handoff(
+            conn, "sess-1", claude_bin=str(claude),
+            large_set_threshold=3,  # force polish path
+        )
+        assert result["status"] == "ok"
+        assert result["mode"] == "polish"
+        assert result["entry_count"] == 5
+        assert result["brief"] == polished + "\n" or result["brief"].startswith(polished)
+        assert "polished" in result["brief"]
+
+    def test_polish_fallback_to_direct_on_nonzero_exit(
+        self, tmp_path, conn, obs_dir, fake_claude_factory,
+    ):
+        jsonl = _three_turn_session(tmp_path)
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        canned = [
+            {"type": "decision", "text": "x", "context": "", "ts": "t"},
+            {"type": "decision", "text": "y", "context": "", "ts": "t"},
+            {"type": "decision", "text": "z", "context": "", "ts": "t"},
+            {"type": "decision", "text": "w", "context": "", "ts": "t"},
+        ]
+        claude = fake_claude_factory(
+            observer_entries=canned,
+            polish_output="should-not-appear",
+            polish_exit_code=7,
+            polish_stderr="synthetic failure",
+        )
+
+        result = handoff.build_handoff(
+            conn, "sess-1", claude_bin=str(claude),
+            large_set_threshold=2,  # force polish
+        )
+        assert result["status"] == "ok"
+        assert result["mode"] == "direct"  # fell back
+        assert "fallback" in result["message"]
+        assert "polish exited 7" in result["message"]
+        assert "should-not-appear" not in result["brief"]
+        assert "- x" in result["brief"]
+
+    def test_full_flag_always_invokes_polish_with_transcript(
+        self, tmp_path, conn, obs_dir, fake_claude_factory,
+    ):
+        jsonl = _three_turn_session(tmp_path)
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        canned = [
+            {"type": "decision", "text": "Use SQLite",
+             "context": "", "ts": "t"},
+        ]  # only 1 entry — wouldn't trigger polish without --full
+        capture = tmp_path / "polish_prompt.txt"
+        polished = "# Handoff — full\n\n## Summary\n\nstub full handoff\n"
+        claude = fake_claude_factory(
+            observer_entries=canned,
+            polish_output=polished,
+            capture_polish_prompt=capture,
+        )
+
+        result = handoff.build_handoff(
+            conn, "sess-1", full=True, claude_bin=str(claude),
+        )
+        assert result["status"] == "ok"
+        assert result["mode"] == "full"
+        assert polished.strip() in result["brief"]
+
+        # Polish prompt saw both the observations and the transcript.
+        prompt_text = capture.read_text()
+        assert "<observations>" in prompt_text
+        assert '"text": "Use SQLite"' in prompt_text or '"text":"Use SQLite"' in prompt_text
+        assert "<transcript>" in prompt_text
+        # The cleaned transcript renders our three user/assistant turns.
+        assert "Should we use SQLite?" in prompt_text
+        assert "SQLite fits the use case" in prompt_text
+
+    def test_catch_up_reads_appended_bytes(
+        self, tmp_path, conn, obs_dir, fake_claude_factory,
+    ):
+        jsonl = _three_turn_session(tmp_path)
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        # First handoff — extracts 1 decision.
+        first_entries = [{
+            "type": "decision", "text": "First pass", "context": "",
+            "ts": "t1",
+        }]
+        claude_first = fake_claude_factory(observer_entries=first_entries)
+        r1 = handoff.build_handoff(
+            conn, "sess-1", claude_bin=str(claude_first),
+        )
+        assert r1["status"] == "ok"
+        assert r1["entry_count"] == 1
+
+        # Append more turns to the source JSONL.
+        with open(jsonl, "a") as f:
+            f.write(_assistant_line("a2", "m2", "new thought") + "\n")
+            f.write(_user_line("u3", "follow-up") + "\n")
+            f.write(_assistant_line("a3", "m3", "another decision") + "\n")
+
+        # Second handoff — extracts 1 more decision from the NEW bytes only.
+        second_entries = [{
+            "type": "decision", "text": "Second pass", "context": "",
+            "ts": "t2",
+        }]
+        claude_second = fake_claude_factory(observer_entries=second_entries)
+        r2 = handoff.build_handoff(
+            conn, "sess-1", claude_bin=str(claude_second),
+        )
+        assert r2["status"] == "ok"
+        # The observation file accumulates — both entries are in the brief.
+        assert r2["entry_count"] == 2
+        assert "First pass" in r2["brief"]
+        assert "Second pass" in r2["brief"]
+
+    def test_existing_observations_used_when_observer_fails(
+        self, tmp_path, conn, obs_dir, fake_claude_factory,
+    ):
+        # Seed an observation file directly — no session row, no claude.
+        obs_file = obs_dir / "sess-1.jsonl"
+        obs_file.write_text(
+            '{"type":"decision","text":"Prior decision","context":"","ts":"t"}\n'
+        )
+        # Seed observation_state so the observer can find the file on resume.
+        jsonl = _three_turn_session(tmp_path)
+        _seed_session_row(conn, "sess-1", jsonl)
+        db.upsert_observation_state(
+            conn, "sess-1", str(jsonl), str(obs_file),
+            source_byte_offset=jsonl.stat().st_size,  # cursor at EOF
+            entry_count=1,
+        )
+
+        # Fake claude will fail if invoked — but it shouldn't be: with
+        # cursor already at EOF, the observer returns up_to_date without
+        # running claude.
+        bad_claude = tmp_path / "bad_claude"
+        bad_claude.write_text("#!/usr/bin/env bash\nexit 99\n")
+        bad_claude.chmod(0o755)
+
+        result = handoff.build_handoff(
+            conn, "sess-1", claude_bin=str(bad_claude),
+        )
+        assert result["status"] == "ok"
+        assert result["entry_count"] == 1
+        assert "Prior decision" in result["brief"]
+
+    def test_polish_prompt_missing_falls_back_to_direct(
+        self, tmp_path, conn, obs_dir, fake_claude_factory,
+    ):
+        jsonl = _three_turn_session(tmp_path)
+        _seed_session_row(conn, "sess-1", jsonl)
+
+        canned = [
+            {"type": "decision", "text": f"d{i}", "context": "", "ts": "t"}
+            for i in range(5)
+        ]
+        # observer_entries supplied; polish_output irrelevant since we
+        # point the prompt_path at a non-existent file.
+        claude = fake_claude_factory(observer_entries=canned)
+
+        result = handoff.build_handoff(
+            conn, "sess-1", claude_bin=str(claude),
+            large_set_threshold=2,  # force polish path
+            prompt_path=tmp_path / "does-not-exist.md",
+        )
+        assert result["status"] == "ok"
+        assert result["mode"] == "direct"
+        assert "fallback" in result["message"]
+        assert "- d0" in result["brief"]
+
+    def test_reflect_fn_invoked_after_observer(
+        self, tmp_path, conn, obs_dir, fake_claude_factory,
+    ):
+        """ADR-022: the reflector runs as a follow-up step after the observer.
+
+        Asserts ``reflect_fn`` is called with ``(conn, session_id)`` and that
+        a ``reflector_result`` appears in the returned dict so the CLI (and
+        eventual consumers) can surface reflector state.
+        """
+        jsonl = _three_turn_session(tmp_path)
+        _seed_session_row(conn, "sess-1", jsonl)
+        canned = [
+            {"type": "decision", "text": "Use SQLite",
+             "context": "", "ts": "t"},
+        ]
+        claude = fake_claude_factory(observer_entries=canned)
+
+        calls: list[dict] = []
+
+        def fake_reflect(conn_arg, session_id, **kwargs):
+            calls.append({"session_id": session_id, **kwargs})
+            return {"status": "extracted", "new_entries": 1}
+
+        result = handoff.build_handoff(
+            conn, "sess-1",
+            claude_bin=str(claude),
+            reflect_fn=fake_reflect,
+        )
+
+        assert result["status"] == "ok"
+        assert len(calls) == 1
+        assert calls[0]["session_id"] == "sess-1"
+        # claude_bin is forwarded so the reflector uses the same fake binary.
+        assert calls[0]["claude_bin"] == str(claude)
+        # Reflector outcome surfaces on the returned dict.
+        assert result["reflector_result"] == {
+            "status": "extracted", "new_entries": 1,
+        }
+        # No error when the reflector succeeds.
+        assert "reflector_error" not in result
+
+    def test_reflect_fn_exception_is_swallowed(
+        self, tmp_path, conn, obs_dir, fake_claude_factory,
+    ):
+        """A reflector failure MUST NOT break the handoff — the observer's
+        output is already on disk and the brief should still render.
+        """
+        jsonl = _three_turn_session(tmp_path)
+        _seed_session_row(conn, "sess-1", jsonl)
+        canned = [
+            {"type": "decision", "text": "Use SQLite",
+             "context": "", "ts": "t"},
+        ]
+        claude = fake_claude_factory(observer_entries=canned)
+
+        def boom(conn_arg, session_id, **kwargs):
+            raise RuntimeError("synthetic reflector failure")
+
+        result = handoff.build_handoff(
+            conn, "sess-1",
+            claude_bin=str(claude),
+            reflect_fn=boom,
+        )
+
+        assert result["status"] == "ok"
+        assert "Use SQLite" in result["brief"]
+        assert result["reflector_result"] is None
+        assert "RuntimeError: synthetic reflector failure" in result["reflector_error"]
+
+    def test_reflect_fn_none_skips_reflector(
+        self, tmp_path, conn, obs_dir, fake_claude_factory,
+    ):
+        """Explicit ``reflect_fn=None`` disables the reflector entirely —
+        useful for ``--no-reflect`` debugging and for tests that don't want
+        to care about the reflector.
+        """
+        jsonl = _three_turn_session(tmp_path)
+        _seed_session_row(conn, "sess-1", jsonl)
+        canned = [
+            {"type": "decision", "text": "Use SQLite",
+             "context": "", "ts": "t"},
+        ]
+        claude = fake_claude_factory(observer_entries=canned)
+
+        result = handoff.build_handoff(
+            conn, "sess-1",
+            claude_bin=str(claude),
+            reflect_fn=None,
+        )
+
+        assert result["status"] == "ok"
+        # Nothing attempted — reflector_result stays None.
+        assert result["reflector_result"] is None
+        assert "reflector_error" not in result

--- a/threadhop
+++ b/threadhop
@@ -37,6 +37,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import db  # noqa: E402
 import indexer  # noqa: E402
 import cli_queries  # noqa: E402
+import handoff as handoff_mod  # noqa: E402
 import observation_queries  # noqa: E402
 import observer  # noqa: E402
 import reflector  # noqa: E402
@@ -4863,6 +4864,48 @@ def build_parser():
         ),
     )
 
+    handoff_p = subparsers.add_parser(
+        "handoff",
+        help="Produce a handoff brief for a session",
+        description=(
+            "Run the observer (first-time or catch-up) followed by the "
+            "reflector, then print a markdown handoff brief composed "
+            "from the per-session observation JSONL. Short observation "
+            "sets format directly; larger sets (or --full) go through "
+            "a Haiku sub-agent for polish. The `/threadhop:handoff` "
+            "skill shells out to this subcommand. Unlike `tag`/`observe`, "
+            "handoff is always about a *different* session than the "
+            "caller's — pass the session id explicitly."
+        ),
+    )
+    handoff_p.add_argument(
+        "session_id",
+        type=str,
+        help="Session id to hand off (required, positional)",
+    )
+    handoff_p.add_argument(
+        "--full",
+        action="store_true",
+        default=False,
+        help=(
+            "Produce a comprehensive handoff with rationale and "
+            "verbatim transcript excerpts. Always uses the Haiku "
+            "sub-agent regardless of observation count."
+        ),
+    )
+    handoff_p.add_argument(
+        "--no-reflect",
+        action="store_true",
+        default=False,
+        help=(
+            "Skip the reflector pass between observer and brief. "
+            "Defaults off — ADR-022 mandates the reflector runs as a "
+            "follow-up step for on-demand observer invocations. Flag "
+            "is primarily for debugging; production runs should leave "
+            "it disabled."
+        ),
+    )
+
     return parser
 
 
@@ -5161,6 +5204,81 @@ def cmd_decisions(args) -> int:
     return 0
 
 
+def cmd_handoff(args) -> int:
+    """Produce a handoff brief for ``args.session_id`` and print it.
+
+    The ``/threadhop:handoff`` skill shells out to this subcommand. It
+    parses ``session_id`` positionally and ``--full`` / ``--no-reflect``
+    as optional flags. Unlike ``cmd_observe``, this handler does NOT
+    auto-detect the current terminal's session — handoff is always
+    about a *different* session than the one the skill is invoked
+    from, so the caller must name it explicitly.
+
+    Seeds the sessions row when the transcript is discoverable under
+    ``~/.claude/projects`` but the TUI hasn't indexed it yet. If the
+    session is unknown to both the filesystem scan AND the DB,
+    ``build_handoff`` still falls back to reading any existing
+    observation file via the ``observation_state`` row.
+
+    Brief goes to stdout (so the skill can inject it as markdown).
+    Status / fallback lines go to stderr so stdout stays pure markdown.
+    """
+    session_path = find_session_path(args.session_id)
+    conn = db.init_db()
+    try:
+        if session_path is not None:
+            db.upsert_session(
+                conn, args.session_id, str(session_path),
+                project=session_path.parent.name,
+            )
+        reflect_fn = None if args.no_reflect else reflector.reflect_session
+        result = handoff_mod.build_handoff(
+            conn, args.session_id,
+            full=args.full,
+            reflect_fn=reflect_fn,
+        )
+    finally:
+        conn.close()
+
+    status = result.get("status")
+    brief = result.get("brief", "")
+
+    if status == "no_source":
+        print(
+            f"threadhop handoff: {result.get('message', 'no source JSONL')}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if status == "no_observations":
+        # Expected outcome for short/routine sessions. Exit 0 so the
+        # skill doesn't treat this as an error; message goes to stderr
+        # so stdout stays empty and the skill can cleanly surface
+        # "nothing to hand off".
+        print(
+            f"threadhop handoff: {result.get('message', 'no observations')}",
+            file=sys.stderr,
+        )
+        return 0
+
+    # ok path — brief is markdown, emit to stdout for the skill to inject.
+    if brief:
+        sys.stdout.write(brief if brief.endswith("\n") else brief + "\n")
+
+    msg = result.get("message")
+    if msg:
+        print(f"threadhop handoff: {msg}", file=sys.stderr)
+    if result.get("reflector_error"):
+        print(
+            f"  reflector:     {result['reflector_error']} (ignored)",
+            file=sys.stderr,
+        )
+    stderr = result.get("polish_stderr")
+    if stderr:
+        print(f"  polish stderr: {stderr}", file=sys.stderr)
+    return 0
+
+
 def main():
     parser = build_parser()
     args = parser.parse_args()
@@ -5198,6 +5316,8 @@ def main():
         return cmd_conflicts(args)
     if args.command == "observations":
         return cmd_observations(args)
+    if args.command == "handoff":
+        return cmd_handoff(args)
     return _cli_stub(args.command)
 
 


### PR DESCRIPTION
## Summary

- Implements task #26 per ADR-012 / ADR-016 / ADR-018 / ADR-020 / ADR-022: the `/threadhop:handoff <id> [--full]` skill and its supporting CLI subcommand.
- Three-layer architecture: `handoff.py::build_handoff` (Python orchestrator) → `threadhop handoff` (argparse subcommand) → `skills/handoff/SKILL.md` (Claude Code plugin skill). The skill shells out to the CLI; the CLI calls the orchestrator; the orchestrator runs observer → reflector → read obs JSONL → direct/polish format.
- Reflector wiring: `build_handoff` calls `reflector.reflect_session` between observer and obs-file read (late-resolved via a `"default"` sentinel so tests can monkeypatch). ADR-022 on-demand follow-up. `--no-reflect` escape hatch for debugging. Reflector exceptions are caught and surfaced via `reflector_error` — a reflector failure never breaks the handoff.
- Polish fallback ladder: missing prompt / non-zero Haiku exit / timeout / empty stdout → direct Python template. The user always gets a brief.

## What it does (short version)

`/threadhop:handoff abc123` → CLI runs observer on session `abc123` (first-time or catch-up), runs reflector for any fresh decisions, reads `~/.config/threadhop/observations/abc123.jsonl`, formats into ~30-50 line markdown (or ~150 lines with `--full`, with verbatim transcript excerpts). Skill injects that as a bounded context block in the new Claude Code session.

## Entry points

| Surface | Form | LLM turn? |
|---|---|---|
| Claude Code skill | `/threadhop:handoff <id> [--full]` | Skill turn + 1-3 Haiku subprocess calls |
| Inside Claude Code, bash passthrough | `!threadhop handoff <id>` | 0 skill turns, 1-3 Haiku subprocess calls |
| Terminal | `threadhop handoff <id> [--full]` | Same subprocess calls, no skill |
| Python import | `handoff.build_handoff(conn, id)` | Same subprocess calls |

No hook, no daemon, no HTTP endpoint. Always user-initiated.

## Database & filesystem surface

- **Direct reads:** `db.get_observation_state`, `db.get_session`.
- **Transitive writes:** `db.upsert_session` (CLI wrapper seeds the row); `db.upsert_observation_state` (observer advances byte cursor + entry count); `db.update_reflector_offset` (reflector advances entry offset).
- **Appends to:** `~/.config/threadhop/observations/<session_id>.jsonl` (via observer / reflector, ADR-020 unified file).
- **Reads:** source JSONL, `prompts/observer.md`, `prompts/handoff.md`.

## Tests

Added `tests/test_handoff.py` with 19 tests:

| Class | Tests | Status on this branch |
|---|---|---|
| `TestFormatBriefDirect` | 5 — type ordering, empty-section skip, context render, conflict refs, unknown types | ✅ passing |
| `TestReadObservations` | 2 — missing file, malformed line skip | ✅ passing |
| `TestBuildHandoff` | 12 — no_source / no_observations / direct / polish / --full / catch-up / existing-obs fallback / prompt-missing fallback + 3 reflector-wiring tests (invoked, exception swallowed, None skips) | ⚠️ blocked on Python-version issue (see wrinkle below) |

### ⚠️ Wrinkle: re-run `TestBuildHandoff` locally after merge

The 12 DB-dependent handoff tests need a working database connection, which means they need to run every migration on a fresh temp DB. One of the existing migrations on this branch (the one that hardens the session-status enum into a DB-level CHECK constraint) edits `sqlite_master` in place via `PRAGMA writable_schema = ON` — and that path is only unblocked on Python 3.12+ where `conn.setconfig(sqlite3.SQLITE_DBCONFIG_DEFENSIVE, False)` became available. The sandbox this PR was built in is on Python 3.9.6, so migration 006 crashes with `table sqlite_master may not be modified` before the handoff tests even get to run.

**Not introduced by this PR** — the same error blocks 117 other tests across the branch (`test_observer.py`, `test_reflector.py`, `test_cli_observe.py`, `test_conflicts.py`, `test_bookmarks.py`, etc.). This is a Python 3.9 vs 3.12+ divergence in migration 006, not a handoff-code bug.

**Action item after merging this PR:** check out `docs/adr` locally (where the dev environment has Python 3.12+ and the database connection works), and re-run:

\`\`\`bash
python3 -m pytest tests/test_handoff.py -v
\`\`\`

All 19 tests should pass in that environment. Specifically confirm the 12 `TestBuildHandoff` cases — they cover the observer orchestration, polish fallback ladder, catch-up after source JSONL grows, existing-observations reuse when the observer can't run, and the three new reflector-wiring tests (invocation after observer, exception swallowed, \`None\` skips the reflector entirely).

If you'd rather fix the underlying migration-006 issue so CI can run the suite too, happy to open a follow-up PR that adds a Python-version-aware path (use `setconfig` on 3.12+, fall back to a staged rebuild-with-temporary-FK-disable dance on 3.9-3.11). Didn't bundle that into this PR to keep scope tight.

## Notes on divergence from the original task description

- Skill layout: `skills/handoff/SKILL.md` with YAML frontmatter (`name: handoff`, `description: ...`). Task #23 (skill packaging research) is still open, so this is a best-guess convention — easy to relocate if the final layout lands elsewhere.
- `--no-reflect`: new flag not in the original task text. Added as a debug escape hatch; defaults off so ADR-022 behaviour is the normal path.
- Observer `batch_threshold`: handoff lowers to 1 (via `HANDOFF_BATCH_THRESHOLD`) so a short tail still extracts. The observer's own docstring warns about low thresholds, but for handoff the alternative is losing tail context entirely.

## Test plan

- [ ] `./threadhop handoff --help` renders expected usage.
- [ ] `python3 -m pytest tests/test_handoff.py::TestFormatBriefDirect tests/test_handoff.py::TestReadObservations` passes (7 tests) — runs anywhere, no DB needed.
- [ ] **After merge, in local dev env (Python 3.12+):** `python3 -m pytest tests/test_handoff.py -v` — all 19 tests pass, including the 12 `TestBuildHandoff` cases that are blocked on this machine.
- [ ] Manual: run `./threadhop handoff <some observed session id>` and confirm markdown brief on stdout + status on stderr.
- [ ] Manual: `/threadhop:handoff <id>` from inside a Claude Code session — confirm brief is injected as a context block.
- [ ] Verify reflector integration: observe session A in project X, observe session B in same project with a contradicting decision, then `threadhop handoff B` — confirm a `## Conflicts` section in the brief with both session refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)