### PR TITLE
[codex] Align reflector prompt docs with runtime

### DIFF
--- a/docs/DESIGN-DECISIONS.md
+++ b/docs/DESIGN-DECISIONS.md
@@ -1084,7 +1084,8 @@ If you find contradictions, append conflict entries to: observations/abc123.json
 ```
 
 **The reflector prompt** lives at `~/.config/threadhop/prompts/reflector.md`
-(alongside `observer.md`). It constrains:
+(or bundled with the app at `prompts/reflector.md`, alongside `observer.md`).
+It constrains:
 
 1. **Append-only**: Same rules as observer — forward-only, no deletions.
 2. **One JSON line per conflict**: Each conflict is a self-contained entry.
@@ -1097,14 +1098,19 @@ If you find contradictions, append conflict entries to: observations/abc123.json
 **Conflict entry format:**
 
 ```jsonl
-{"type":"conflict","text":"REST vs gRPC scope overlap — session abc decided REST for client API, session def decided gRPC for all services","refs":["abc123","def456"],"topic":"api-protocol","session":"abc123","project":"atlas","ts":"2026-04-14T12:00:00Z"}
+{"type":"conflict","text":"REST vs gRPC scope overlap — session abc decided REST for client API, session def decided gRPC for all services","refs":["abc123","def456"],"topic":"api-protocol","ts":"2026-04-14T12:00:00Z"}
 ```
 
 Fields:
+- `type`: always `"conflict"`
+- `text`: concise explanation of the contradiction
 - `refs`: array of session IDs involved in the contradiction
 - `topic`: semantic grouping key (helps dedup and display)
-- `session`: the session this entry lives in (where the reflector was triggered)
-- Other fields same as observer entries
+- `ts`: ISO 8601 timestamp
+
+The conflict entry does **not** include inline `session` or `project` fields.
+The session is implied by which observation file the entry was appended to,
+and project context comes from SQLite session mapping.
 
 **Trigger mechanism — observer spawns reflector:**
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -197,8 +197,8 @@ _Contradiction detection across sessions. Reflector writes `type: "conflict"` en
 to the SAME per-session observation JSONL (ADR-020, ADR-022). Triggered by observer
 process — not independent. Uses `reflector_entry_offset` for incremental processing._
 
-- [ ] **49. Create reflector prompt** *(prereq for: #31)*
-  Write `~/.config/threadhop/prompts/reflector.md`. Constrains Haiku: append-only, one JSON line per conflict, dedup check against existing conflicts (same `refs` pair + `topic` = skip). Input shape: recent decisions from current session + all decisions from other sessions in same project. Output: `type: "conflict"` entries with `refs`, `topic`, `text` fields. _(ADR-022)_
+- [x] **49. Create reflector prompt** *(prereq for: #31)*
+  **DONE.** Reflector prompt is bundled at `prompts/reflector.md` (repo-local equivalent of `~/.config/threadhop/prompts/reflector.md`). It constrains Haiku to append-only conflict writes, one JSON line per conflict, dedup against existing conflicts using the same `refs` pair + `topic`, and consume `<current_session_decisions>`, `<project_decisions>`, and `<existing_conflicts>`. Output shape is `type: "conflict"` with `refs`, `topic`, `text`, and `ts`. _(ADR-022)_
 
 - [x] **31. Build conflict detection reflector core function** *(blocked by: #18, #49)*
   **DONE.** `reflector.py` now runs the second `claude -p --model haiku --permission-mode acceptEdits` pass against recent current-session decisions and peer decisions from other same-project observation files, appends `type: "conflict"` lines to the current session's observation JSONL, and advances `reflector_entry_offset` / `entry_count` in SQLite. Tests in `tests/test_reflector.py`. _(ADR-015, ADR-020, ADR-022)_


### PR DESCRIPTION
## Summary
- align ADR-022 with the bundled reflector prompt path used at runtime
- document the shipped conflict entry shape without inline `session`/`project` fields
- mark task #49 done and describe the actual prompt inputs and output fields

## Why
The prompt already exists and is wired up correctly, but the docs still described an older conflict payload shape and did not clearly note that the app bundles `prompts/reflector.md` locally.

## Impact
This keeps the design docs and task tracking consistent with the reflector implementation and tests.

## Validation
- `uv run --with pytest pytest -q tests/test_reflector.py`
