### PR TITLE
[codex] Add TUI observation indicator

### DIFF
--- a/db.py
+++ b/db.py
@@ -830,6 +830,35 @@ def get_session_statuses(conn: sqlite3.Connection) -> dict[str, str]:
     return {r["session_id"]: r["status"] for r in rows}
 
 
+def get_session_sidebar_metadata(
+    conn: sqlite3.Connection,
+) -> dict[str, dict[str, object]]:
+    """Return bulk sidebar state for every known session.
+
+    The TUI refresh loop uses this to stamp persisted session status and
+    the ADR-021 observation indicator bit in one query, instead of
+    issuing row-by-row lookups during the 5-second refresh cycle.
+    """
+    rows = conn.execute(
+        """
+        SELECT
+            s.session_id,
+            s.status,
+            CASE WHEN COALESCE(os.entry_count, 0) > 0 THEN 1 ELSE 0 END
+                AS has_observations
+        FROM sessions s
+        LEFT JOIN observation_state os ON os.session_id = s.session_id
+        """
+    ).fetchall()
+    return {
+        row["session_id"]: {
+            "status": row["status"],
+            "has_observations": bool(row["has_observations"]),
+        }
+        for row in rows
+    }
+
+
 def set_session_status(
     conn: sqlite3.Connection,
     session_id: str,

--- a/tests/test_tui_observation_indicator.py
+++ b/tests/test_tui_observation_indicator.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+import db
+
+
+def _load_threadhop_module():
+    path = Path(__file__).resolve().parent.parent / "threadhop"
+    loader = SourceFileLoader("threadhop_app", str(path))
+    spec = importlib.util.spec_from_loader("threadhop_app", loader)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault("threadhop_app", module)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_get_session_sidebar_metadata_marks_observed_sessions(conn):
+    db.upsert_session(conn, "sess-observed", "/tmp/sess-observed.jsonl")
+    db.upsert_session(conn, "sess-plain", "/tmp/sess-plain.jsonl")
+    db.upsert_observation_state(
+        conn,
+        "sess-observed",
+        source_path="/tmp/sess-observed.jsonl",
+        obs_path="/tmp/sess-observed.obs.jsonl",
+        entry_count=2,
+    )
+    db.upsert_observation_state(
+        conn,
+        "sess-plain",
+        source_path="/tmp/sess-plain.jsonl",
+        obs_path="/tmp/sess-plain.obs.jsonl",
+        entry_count=0,
+    )
+
+    metadata = db.get_session_sidebar_metadata(conn)
+
+    assert metadata["sess-observed"]["status"] == "active"
+    assert metadata["sess-observed"]["has_observations"] is True
+    assert metadata["sess-plain"]["status"] == "active"
+    assert metadata["sess-plain"]["has_observations"] is False
+
+
+def test_render_session_label_text_adds_observation_marker(monkeypatch):
+    threadhop = _load_threadhop_module()
+    monkeypatch.setenv("THREADHOP_ASCII_OBSERVATION_MARKER", "1")
+
+    label = threadhop.render_session_label_text(
+        {
+            "project": "project-alpha",
+            "title": "active-work",
+            "modified": 0,
+            "is_active": True,
+            "is_working": True,
+            "has_observations": True,
+        },
+        spinner_frame=0,
+    )
+
+    assert label.plain.startswith("◐ ")
+    assert "active-work ≡" in label.plain
+
+
+def test_render_session_label_text_omits_marker_without_observations(monkeypatch):
+    threadhop = _load_threadhop_module()
+    monkeypatch.setenv("THREADHOP_ASCII_OBSERVATION_MARKER", "1")
+
+    label = threadhop.render_session_label_text(
+        {
+            "project": "project-beta",
+            "title": "plain-session",
+            "modified": 0,
+            "is_active": False,
+            "is_working": False,
+            "has_observations": False,
+        }
+    )
+
+    assert label.plain.startswith("○ ")
+    assert "≡" not in label.plain

--- a/threadhop
+++ b/threadhop
@@ -123,6 +123,8 @@ def save_app_config(config):
 
 # --- Configuration ---
 DISPLAY_NAME_WIDTH = 22
+OBSERVATION_MARKER = "🗒"
+OBSERVATION_MARKER_FALLBACK = "≡"
 MAX_SESSIONS = 50
 REFRESH_INTERVAL = 5
 SPINNER_INTERVAL = 0.25
@@ -402,6 +404,77 @@ def format_age(timestamp: float) -> str:
         return f"{int(age / 86400)}d"
 
 
+def _supports_observation_emoji() -> bool:
+    """Return whether the current terminal can safely encode the emoji marker."""
+    if os.environ.get("THREADHOP_ASCII_OBSERVATION_MARKER") == "1":
+        return False
+    encoding = sys.stdout.encoding or "utf-8"
+    try:
+        OBSERVATION_MARKER.encode(encoding)
+    except (LookupError, UnicodeEncodeError):
+        return False
+    return True
+
+
+def _observation_marker_text() -> Text:
+    """Return the ADR-021 observed-session marker."""
+    if _supports_observation_emoji():
+        return Text(OBSERVATION_MARKER, style="dim")
+    return Text(OBSERVATION_MARKER_FALLBACK, style="dim cyan")
+
+
+def _session_display_name(session_data: dict, custom_name: str | None) -> str:
+    """Resolve the user-facing session label before sidebar truncation."""
+    title = session_data.get("title", "")
+    if custom_name:
+        return custom_name
+    if title:
+        return title
+    return session_data["project"]
+
+
+def render_session_label_text(
+    session_data: dict,
+    *,
+    custom_name: str | None = None,
+    spinner_frame: int = 0,
+) -> Text:
+    """Build the Rich label for one sidebar session row."""
+    is_working = session_data.get("is_working", False)
+    is_active = session_data.get("is_active", False)
+    if is_working:
+        status = SPINNER_FRAMES[spinner_frame % len(SPINNER_FRAMES)]
+    elif is_active:
+        status = "●"
+    else:
+        status = "○"
+
+    display = _session_display_name(session_data, custom_name)
+    indicator = (
+        _observation_marker_text()
+        if session_data.get("has_observations")
+        else None
+    )
+    reserved_width = 0
+    if indicator is not None:
+        reserved_width = 1 + indicator.cell_len
+    name_width = max(DISPLAY_NAME_WIDTH - reserved_width, 0)
+
+    middle = Text(display[:name_width])
+    if indicator is not None:
+        middle.append(" ")
+        middle.append_text(indicator)
+    if middle.cell_len < DISPLAY_NAME_WIDTH:
+        middle.append(" " * (DISPLAY_NAME_WIDTH - middle.cell_len))
+
+    age_str = format_age(session_data["modified"])
+    text = Text()
+    text.append(f"{status} ")
+    text.append_text(middle)
+    text.append(f" {age_str:>4}")
+    return text
+
+
 class SessionItem(ListItem):
     """A session in the list"""
 
@@ -419,61 +492,55 @@ class SessionItem(ListItem):
         super().__init__()
 
     def compose(self) -> ComposeResult:
-        age_str = format_age(self.session_data["modified"])
-        project = self.session_data["project"]
-        is_working = self.session_data.get("is_working", False)
-        is_active = self.session_data.get("is_active", False)
+        label = Static(self._render_label(), classes="session-label")
+        self._sync_label_classes(label)
+        yield label
 
-        if is_working:
-            status = SPINNER_FRAMES[self.spinner_frame % len(SPINNER_FRAMES)]
-        elif is_active:
-            status = "●"
-        else:
-            status = "○"
+    def _render_label(self) -> Text:
+        return render_session_label_text(
+            self.session_data,
+            custom_name=self.custom_name,
+            spinner_frame=self.spinner_frame,
+        )
 
-        # Priority: custom name (from our config) > session title (from JSONL) > project path
-        title = self.session_data.get("title", "")
-        if self.custom_name:
-            display = self.custom_name
-        elif title:
-            display = title
-        else:
-            display = project
-        display = f"{display[:DISPLAY_NAME_WIDTH]:<{DISPLAY_NAME_WIDTH}}"
-
-        label = Static(f"{status} {display} {age_str:>4}", classes="session-label")
+    def _sync_label_classes(self, label: Static) -> None:
         if self.is_unread:
             label.add_class("unread")
-        if is_working:
+        else:
+            label.remove_class("unread")
+
+        if self.session_data.get("is_working", False):
             label.add_class("working")
-        elif is_active:
+        else:
+            label.remove_class("working")
+
+        if (
+            self.session_data.get("is_active", False)
+            and not self.session_data.get("is_working", False)
+        ):
             label.add_class("active")
+        else:
+            label.remove_class("active")
+
         if self.session_data.get("status") == "archived":
             label.add_class("archived")
-        yield label
+        else:
+            label.remove_class("archived")
+
+    def refresh_label(self) -> None:
+        try:
+            label = self.query_one(".session-label", Static)
+            label.update(self._render_label())
+            self._sync_label_classes(label)
+        except Exception:
+            pass
 
     def update_spinner(self, frame: int) -> None:
         """Update spinner animation frame"""
         if not self.session_data.get("is_working"):
             return
         self.spinner_frame = frame
-        status = SPINNER_FRAMES[frame % len(SPINNER_FRAMES)]
-        age_str = format_age(self.session_data["modified"])
-
-        title = self.session_data.get("title", "")
-        if self.custom_name:
-            display = self.custom_name
-        elif title:
-            display = title
-        else:
-            display = self.session_data["project"]
-        display = f"{display[:DISPLAY_NAME_WIDTH]:<{DISPLAY_NAME_WIDTH}}"
-
-        try:
-            label = self.query_one(".session-label", Static)
-            label.update(f"{status} {display} {age_str:>4}")
-        except:
-            pass
+        self.refresh_label()
 
 
 
@@ -3059,16 +3126,22 @@ class ClaudeSessions(App):
             # in-memory self.sessions for display.
             pass
 
-        # Stamp each session dict with its persisted status so the UI can
-        # group by it. Read in bulk after the upsert so new sessions get
-        # the DEFAULT 'active' from the column definition.
+        # Stamp each session dict with its persisted sidebar metadata in
+        # one bulk read after the upsert so new sessions get the DEFAULT
+        # 'active' status and the ADR-021 observation bit without
+        # per-session queries during the 5-second refresh cycle.
         try:
-            statuses = db.get_session_statuses(self.conn)
+            sidebar_state = db.get_session_sidebar_metadata(self.conn)
             for s in self.sessions:
-                s["status"] = statuses.get(s["session_id"], "active")
+                state = sidebar_state.get(s["session_id"], {})
+                s["status"] = state.get("status", "active")
+                s["has_observations"] = bool(
+                    state.get("has_observations", False)
+                )
         except Exception:
             for s in self.sessions:
                 s.setdefault("status", "active")
+                s.setdefault("has_observations", False)
 
         self._apply_stable_ordering()
         self._update_session_list(force_rebuild)
@@ -3222,33 +3295,8 @@ class ClaudeSessions(App):
                 if isinstance(item, SessionItem):
                     sid = item.session_data.get("session_id")
                     if sid in session_map:
-                        new_is_working = session_map[sid].get("is_working", False)
-                        old_is_working = item.session_data.get("is_working", False)
-                        if new_is_working != old_is_working:
-                            item.session_data["is_working"] = new_is_working
-                            try:
-                                label = item.query_one(".session-label", Static)
-                                if new_is_working:
-                                    label.add_class("working")
-                                    item.update_spinner(self._spinner_frame)
-                                else:
-                                    label.remove_class("working")
-                                    session = item.session_data
-                                    status = "●" if session.get("is_active") else "○"
-                                    age_str = format_age(session["modified"])
-                                    title = session.get("title", "")
-                                    if item.custom_name:
-                                        display = item.custom_name
-                                    elif title:
-                                        display = title
-                                    else:
-                                        display = session["project"]
-                                    display = f"{display[:DISPLAY_NAME_WIDTH]:<{DISPLAY_NAME_WIDTH}}"
-                                    label.update(
-                                        f"{status} {display} {age_str:>4}"
-                                    )
-                            except:
-                                pass
+                        item.session_data.update(session_map[sid])
+                        item.refresh_label()
 
     def refresh_transcript(self) -> None:
         transcript = self.query_one("#transcript-scroll", TranscriptView)


### PR DESCRIPTION
## Summary
- add a bulk sidebar metadata query that carries observation presence from `observation_state.entry_count`
- render an additive observation marker in the TUI session list without replacing the existing process-state icons
- add focused tests for sidebar metadata and observation indicator rendering, including the terminal-safe fallback

## Why
ADR-021 calls for an observation indicator in the session list that updates during the existing 5-second refresh cycle without introducing extra per-session database queries.

## Validation
- `uv run python -m py_compile db.py threadhop`
- `uv run --with pytest --with rich --with textual --with watchdog --with pydantic pytest -q tests/test_tui_observation_indicator.py tests/test_observation_queries.py`
