### PR TITLE
[codex] Add transcript observation header

### DIFF
--- a/tests/test_transcript_observation_header.py
+++ b/tests/test_transcript_observation_header.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import db
+
+
+def _load_threadhop_module():
+    path = Path(__file__).resolve().parent.parent / "threadhop"
+    loader = importlib.machinery.SourceFileLoader("threadhop_app", str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def _dummy_transcript_view(module, conn):
+    dummy = SimpleNamespace(app=SimpleNamespace(conn=conn))
+    dummy._format_observation_header = (
+        lambda entry_count, obs_path: module.TranscriptView._format_observation_header(
+            dummy, entry_count, obs_path
+        )
+    )
+    return dummy
+
+
+def test_format_observation_header_uses_tilde_for_home_path(conn):
+    module = _load_threadhop_module()
+    dummy = _dummy_transcript_view(module, conn)
+
+    obs_path = str(Path.home() / ".config" / "threadhop" / "observations" / "abc123.jsonl")
+
+    header = module.TranscriptView._format_observation_header(dummy, 12, obs_path)
+
+    assert header == "─── 🗒 12 observations · ~/.config/threadhop/observations/abc123.jsonl ───"
+
+
+def test_get_observation_header_text_reads_state_from_sqlite(conn, tmp_path: Path):
+    module = _load_threadhop_module()
+    dummy = _dummy_transcript_view(module, conn)
+
+    db.upsert_session(conn, "sess-1", str(tmp_path / "sess-1.jsonl"))
+    db.upsert_observation_state(
+        conn,
+        "sess-1",
+        str(tmp_path / "sess-1.jsonl"),
+        str(Path.home() / ".config" / "threadhop" / "observations" / "sess-1.jsonl"),
+        source_byte_offset=128,
+        entry_count=3,
+    )
+
+    header = module.TranscriptView._get_observation_header_text(dummy, "sess-1")
+
+    assert header == "─── 🗒 3 observations · ~/.config/threadhop/observations/sess-1.jsonl ───"
+    assert module.TranscriptView._get_observation_header_text(dummy, "missing") is None

--- a/threadhop
+++ b/threadhop
@@ -519,6 +519,12 @@ class ToolMessage(_SelectableMessage):
     pass
 
 
+class ObservationInfoHeader(Static):
+    """Passive observation metadata shown above the transcript."""
+
+    can_focus = False
+
+
 class TranscriptView(VerticalScroll):
     """Shows full conversation from selected session"""
 
@@ -567,6 +573,37 @@ class TranscriptView(VerticalScroll):
         self._find_query: str = ""
         self._find_matches: list[int] = []
         self._find_current: int = -1
+
+    def _format_observation_header(self, entry_count: int, obs_path: str) -> str:
+        """Return the passive transcript header for observed sessions."""
+        noun = "observation" if entry_count == 1 else "observations"
+        try:
+            display_path = str(Path(obs_path).expanduser())
+            home = str(Path.home())
+            if display_path == home:
+                display_path = "~"
+            elif display_path.startswith(home + os.sep):
+                display_path = "~" + display_path[len(home):]
+        except Exception:
+            display_path = obs_path
+        return f"─── 🗒 {entry_count} {noun} · {display_path} ───"
+
+    def _get_observation_header_text(self, session_id: str) -> str | None:
+        """Look up observation metadata for the current transcript."""
+        try:
+            state = db.get_observation_state(self.app.conn, session_id)
+        except Exception:
+            return None
+
+        if not state:
+            return None
+
+        entry_count = int(state.get("entry_count") or 0)
+        obs_path = str(state.get("obs_path") or "").strip()
+        if entry_count <= 0 or not obs_path:
+            return None
+
+        return self._format_observation_header(entry_count, obs_path)
 
     def _get_message_widgets(self):
         """Return all message widgets in order."""
@@ -944,6 +981,7 @@ class TranscriptView(VerticalScroll):
         self.current_path = session_path
 
         messages = self._parse_messages(session_path)
+        observation_header = self._get_observation_header_text(session_path.stem)
 
         # Remove all existing message widgets (await ensures completion)
         await self._remove_all_messages()
@@ -954,6 +992,13 @@ class TranscriptView(VerticalScroll):
 
         # Build widgets with visual boundaries
         widgets = []
+        if observation_header:
+            widgets.append(
+                ObservationInfoHeader(
+                    observation_header,
+                    classes="observation-info-header",
+                )
+            )
         tool_batch = []
 
         def flush_tools():
@@ -2606,6 +2651,13 @@ class ClaudeSessions(App):
         height: 1fr;
         border: solid $secondary;
         border-title-color: $text;
+    }
+
+    ObservationInfoHeader {
+        padding: 0 1;
+        margin: 0;
+        color: $text-muted;
+        background: $panel;
     }
 
     FindBar {


### PR DESCRIPTION
## Summary
- render a passive observation metadata line above the first transcript message when `observation_state.entry_count > 0`
- format the header per ADR-021 with observation count plus the per-session JSONL path, normalized to `~` for quick copy/reference
- keep the header inside `TranscriptView` so it stays below the title area, scrolls with the transcript, and does not interfere with the persistent find bar
- add focused coverage for header formatting and SQLite-backed observation lookup

## Why
ADR-021 calls for a subtle transcript-level indicator for observed sessions so users can see, at a glance, that observations exist and where the backing JSONL file lives, without opening a CLI view or changing the interaction model of the transcript pane.

## Validation
- `uv run python -m py_compile threadhop`
- `uv run --with pytest --with textual --with watchdog --with pydantic python -m pytest tests/test_transcript_observation_header.py -q`
