### PR TITLE
[codex] Add export markdown cleanup

### DIFF
--- a/tests/test_export_cleanup.py
+++ b/tests/test_export_cleanup.py
@@ -1,0 +1,117 @@
+"""Tests for startup cleanup of exported markdown files."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+THREADHOP = ROOT / "threadhop"
+
+
+def _load_threadhop_module():
+    loader = importlib.machinery.SourceFileLoader(
+        "threadhop_test_module", str(THREADHOP)
+    )
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[loader.name] = module
+    loader.exec_module(module)
+    return module
+
+
+def _touch_with_mtime(path: Path, when: datetime) -> None:
+    path.write_text(path.name)
+    ts = when.timestamp()
+    os.utime(path, (ts, ts))
+
+
+def test_cleanup_deletes_only_stale_safe_exports(tmp_path: Path):
+    threadhop_mod = _load_threadhop_module()
+    export_dir = tmp_path / "threadhop"
+    export_dir.mkdir()
+
+    now = datetime(2026, 4, 20, 12, 0, 0)
+    stale = export_dir / "stale.md"
+    stale_open = export_dir / "stale-open.md"
+    retained = export_dir / "retained.md"
+    recent = export_dir / "recent.md"
+    ignored = export_dir / "ignored.txt"
+
+    _touch_with_mtime(stale, now - timedelta(days=9))
+    _touch_with_mtime(stale_open, now - timedelta(days=10))
+    _touch_with_mtime(retained, now - timedelta(days=3))
+    _touch_with_mtime(recent, now - timedelta(minutes=30))
+    _touch_with_mtime(ignored, now - timedelta(days=30))
+
+    result = threadhop_mod.cleanup_export_markdown_files(
+        export_dir,
+        retention_days=7,
+        now=now,
+        open_paths={stale_open},
+    )
+
+    assert result.deleted == 1
+    assert result.scanned == 4
+    assert result.skipped_open == 1
+    assert result.skipped_recent == 1
+    assert result.errors == 0
+    assert not stale.exists()
+    assert stale_open.exists()
+    assert retained.exists()
+    assert recent.exists()
+    assert ignored.exists()
+
+
+def test_cleanup_missing_directory_is_a_no_op(tmp_path: Path):
+    threadhop_mod = _load_threadhop_module()
+    export_dir = tmp_path / "missing-threadhop"
+
+    result = threadhop_mod.cleanup_export_markdown_files(export_dir)
+
+    assert result.directory_missing is True
+    assert result.deleted == 0
+    assert result.scanned == 0
+    assert result.footer_message() is None
+
+
+def test_load_config_defaults_export_retention_days(
+    tmp_path: Path, monkeypatch
+):
+    threadhop_mod = _load_threadhop_module()
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"theme": "textual-light"}))
+
+    monkeypatch.setattr(threadhop_mod, "CONFIG_FILE", config_path)
+    monkeypatch.setattr(threadhop_mod.db, "get_custom_names", lambda conn: {})
+    monkeypatch.setattr(threadhop_mod.db, "get_session_order", lambda conn: [])
+    monkeypatch.setattr(threadhop_mod.db, "get_last_viewed", lambda conn: {})
+
+    config = threadhop_mod.load_config(conn=None)
+
+    assert config["theme"] == "textual-light"
+    assert config["export_retention_days"] == 7
+
+
+def test_load_config_coerces_export_retention_days_from_json(
+    tmp_path: Path, monkeypatch
+):
+    threadhop_mod = _load_threadhop_module()
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"export_retention_days": "14"}))
+
+    monkeypatch.setattr(threadhop_mod, "CONFIG_FILE", config_path)
+    monkeypatch.setattr(threadhop_mod.db, "get_custom_names", lambda conn: {})
+    monkeypatch.setattr(threadhop_mod.db, "get_session_order", lambda conn: [])
+    monkeypatch.setattr(threadhop_mod.db, "get_last_viewed", lambda conn: {})
+
+    config = threadhop_mod.load_config(conn=None)
+
+    assert config["export_retention_days"] == 14

--- a/threadhop
+++ b/threadhop
@@ -55,14 +55,173 @@ def get_available_themes():
 # App-level keys that live in config.json post-migration. Session-level
 # state (session_names, session_order, last_viewed) lives in SQLite per
 # ADR-001. Anything unknown is preserved on save so future settings
-# (sidebar_width, user-added keys) don't get silently dropped.
-APP_CONFIG_KEYS = {"theme", "sidebar_width"}
+# (sidebar_width, export_retention_days, user-added keys) don't get
+# silently dropped.
+APP_CONFIG_KEYS = {"theme", "sidebar_width", "export_retention_days"}
+
+EXPORT_DIR = Path("/tmp/threadhop")
+EXPORT_RETENTION_DAYS_DEFAULT = 7
+EXPORT_RECENT_GRACE_PERIOD = timedelta(hours=1)
+
+
+@dataclass(frozen=True)
+class ExportCleanupResult:
+    """Summary of a startup cleanup pass for exported markdown files."""
+
+    scanned: int = 0
+    deleted: int = 0
+    skipped_recent: int = 0
+    skipped_open: int = 0
+    errors: int = 0
+    directory_missing: bool = False
+    retention_days: int = EXPORT_RETENTION_DAYS_DEFAULT
+    recent_grace_seconds: int = int(EXPORT_RECENT_GRACE_PERIOD.total_seconds())
+
+    def debug_message(self) -> str:
+        grace_hours = max(1, int(self.recent_grace_seconds / 3600))
+        if self.directory_missing:
+            return (
+                "Export cleanup: skipped "
+                f"({EXPORT_DIR} missing, retention={self.retention_days}d, "
+                f"grace={grace_hours}h)"
+            )
+        return (
+            "Export cleanup: "
+            f"removed {self.deleted}, scanned {self.scanned}, "
+            f"skipped_recent {self.skipped_recent}, "
+            f"skipped_open {self.skipped_open}, errors {self.errors} "
+            f"(retention={self.retention_days}d)"
+        )
+
+    def footer_message(self) -> str | None:
+        if self.errors:
+            noun = "error" if self.errors == 1 else "errors"
+            return f"Export cleanup: {self.errors} {noun}"
+        if self.deleted:
+            noun = "stale export" if self.deleted == 1 else "stale exports"
+            return f"Cleaned {self.deleted} {noun}"
+        return None
+
+
+def _coerce_retention_days(value) -> int:
+    """Return a non-negative retention window in days."""
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return EXPORT_RETENTION_DAYS_DEFAULT
+
+
+def _open_export_paths(export_dir: Path) -> set[Path]:
+    """Best-effort detection of open export files under ``export_dir``.
+
+    Uses ``lsof +D`` on macOS. Failures degrade to an empty set so
+    cleanup stays non-blocking.
+    """
+    try:
+        proc = subprocess.run(
+            ["lsof", "+D", str(export_dir), "-Fn"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return set()
+
+    open_paths: set[Path] = set()
+    for line in proc.stdout.splitlines():
+        if not line.startswith("n"):
+            continue
+        try:
+            path = Path(line[1:]).resolve()
+        except Exception:
+            continue
+        if path.parent == export_dir.resolve() and path.suffix == ".md":
+            open_paths.add(path)
+    return open_paths
+
+
+def cleanup_export_markdown_files(
+    export_dir: Path = EXPORT_DIR,
+    *,
+    retention_days: int = EXPORT_RETENTION_DAYS_DEFAULT,
+    recent_grace_period: timedelta = EXPORT_RECENT_GRACE_PERIOD,
+    now: datetime | None = None,
+    open_paths: set[Path] | None = None,
+) -> ExportCleanupResult:
+    """Delete stale exported markdown files from ``export_dir``.
+
+    Files modified within ``recent_grace_period`` are always preserved,
+    even when they exceed the configured retention window. Open-file
+    detection is best-effort and non-fatal.
+    """
+    retention_days = _coerce_retention_days(retention_days)
+    now = now or datetime.now()
+    recent_cutoff = (now - recent_grace_period).timestamp()
+    retention_cutoff = (now - timedelta(days=retention_days)).timestamp()
+
+    if not export_dir.exists() or not export_dir.is_dir():
+        return ExportCleanupResult(
+            directory_missing=True,
+            retention_days=retention_days,
+            recent_grace_seconds=int(recent_grace_period.total_seconds()),
+        )
+
+    resolved_dir = export_dir.resolve()
+    resolved_open_paths = (
+        {p.resolve() for p in open_paths}
+        if open_paths is not None else _open_export_paths(export_dir)
+    )
+
+    scanned = 0
+    deleted = 0
+    skipped_recent = 0
+    skipped_open = 0
+    errors = 0
+
+    for path in export_dir.glob("*.md"):
+        scanned += 1
+        try:
+            stat = path.stat()
+            resolved_path = path.resolve()
+        except OSError:
+            errors += 1
+            continue
+
+        if resolved_path.parent != resolved_dir:
+            continue
+        if stat.st_mtime >= recent_cutoff:
+            skipped_recent += 1
+            continue
+        if resolved_path in resolved_open_paths:
+            skipped_open += 1
+            continue
+        if stat.st_mtime >= retention_cutoff:
+            continue
+
+        try:
+            path.unlink()
+            deleted += 1
+        except FileNotFoundError:
+            continue
+        except OSError:
+            errors += 1
+
+    return ExportCleanupResult(
+        scanned=scanned,
+        deleted=deleted,
+        skipped_recent=skipped_recent,
+        skipped_open=skipped_open,
+        errors=errors,
+        retention_days=retention_days,
+        recent_grace_seconds=int(recent_grace_period.total_seconds()),
+    )
 
 
 def load_config(conn):
     """Return the combined in-memory config.
 
-    App-level keys (`theme`, `sidebar_width`) come from config.json.
+    App-level keys (`theme`, `sidebar_width`, `export_retention_days`)
+    come from config.json.
     Session-level keys (`session_names`, `session_order`, `last_viewed`)
     come from the SQLite `sessions` table — this is the ADR-001 split.
 
@@ -86,6 +245,9 @@ def load_config(conn):
         config.pop(key, None)
 
     config.setdefault("theme", "textual-dark")
+    config["export_retention_days"] = _coerce_retention_days(
+        config.get("export_retention_days", EXPORT_RETENTION_DAYS_DEFAULT)
+    )
 
     # 2. Session-level from SQLite.
     try:
@@ -103,8 +265,8 @@ def load_config(conn):
 
 
 def save_app_config(config):
-    """Persist only app-level keys (theme, sidebar_width, unknown extras)
-    to config.json.
+    """Persist only app-level keys (theme, sidebar_width,
+    export_retention_days, unknown extras) to config.json.
 
     Session-level keys are deliberately excluded — they live in SQLite
     now and are written through at each mutation site (rename, reorder,
@@ -811,9 +973,9 @@ class TranscriptView(VerticalScroll):
     def _export_selection(self):
         """Export selected messages to a temp markdown file (ADR-008).
 
-        Writes to /tmp/threadhop/<session_id>-<timestamp>.md.
-        The /tmp directory is auto-cleaned by macOS on reboot — these are
-        ephemeral reference files, not permanent exports. Users reference
+        Writes to /tmp/threadhop/<session_id>-<timestamp>.md. ThreadHop
+        prunes stale exports on TUI startup, but these remain ephemeral
+        reference files rather than permanent exports. Users reference
         them from other sessions via: Read /tmp/threadhop/<file>.md
         """
         selected = self.get_selected_messages()
@@ -888,10 +1050,7 @@ class TranscriptView(VerticalScroll):
 
         content = "\n".join(lines)
 
-        # /tmp/threadhop/ is auto-cleaned by macOS on reboot — no manual
-        # cleanup needed. This is intentional: exports are ephemeral
-        # reference files for cross-session context sharing.
-        export_dir = Path("/tmp/threadhop")
+        export_dir = EXPORT_DIR
         try:
             os.makedirs(export_dir, exist_ok=True)
             export_path = export_dir / f"{session_id}-{ts_now}.md"
@@ -2459,9 +2618,9 @@ class ContextualFooter(Static):
 
     def __init__(self, *args, **kwargs):
         super().__init__("", *args, **kwargs)
-        self._last_scopes: tuple[str, ...] = ()
+        self._last_render: tuple[tuple[str, ...], str | None] = ((), None)
 
-    def render_for(self, scopes: list[str]) -> None:
+    def render_for(self, scopes: list[str], note: str | None = None) -> None:
         """Rebuild the footer content for the given list of active scopes.
 
         Scopes are evaluated in the order passed — the registry entries
@@ -2469,10 +2628,11 @@ class ContextualFooter(Static):
         is Reply/Send globally but Send in the reply scope).
         """
         scope_tuple = tuple(scopes)
-        if scope_tuple == self._last_scopes:
+        signature = (scope_tuple, note)
+        if signature == self._last_render:
             # Footer already reflects the right context — skip the rebuild.
             return
-        self._last_scopes = scope_tuple
+        self._last_render = signature
 
         # Keep the help shortcut pinned on the far left so it stays
         # discoverable regardless of current focus.
@@ -2495,6 +2655,9 @@ class ContextualFooter(Static):
             for cmd in commands_for_scope(scope):
                 if cmd.footer and cmd.keys != ("?",):
                     add(cmd)
+
+        if note:
+            parts.append(f"[dim]{escape(note)}[/dim]")
 
         if not parts:
             self.update("")
@@ -2782,6 +2945,8 @@ class ClaudeSessions(App):
         # Debounce timer for the in-transcript find bar so fast typing
         # collapses into a single highlight pass.
         self._find_timer = None
+        self._footer_note: str | None = None
+        self._footer_note_timer = None
 
         # Open the SQLite store and run the one-time config.json → SQLite
         # migration (ADR-001). Both calls are idempotent — init_db applies
@@ -2842,6 +3007,7 @@ class ClaudeSessions(App):
         self.set_interval(REFRESH_INTERVAL, self.auto_refresh_background)
         self._spinner_frame = 0
         self.set_interval(SPINNER_INTERVAL, self.animate_spinners)
+        self._run_export_cleanup()
         # Prime the contextual footer now that all widgets are mounted
         # and the sidebar has focus. on_descendant_focus also covers
         # this, but calling refresh_footer directly makes startup
@@ -3489,7 +3655,38 @@ class ClaudeSessions(App):
             footer = self.query_one("#contextual-footer", ContextualFooter)
         except Exception:
             return
-        footer.render_for(self._current_scopes())
+        footer.render_for(self._current_scopes(), note=self._footer_note)
+
+    def _set_footer_note(self, message: str | None, *, timeout: float = 8.0) -> None:
+        """Show a transient note in the footer without using a toast."""
+        self._footer_note = message
+        if self._footer_note_timer is not None:
+            try:
+                self._footer_note_timer.stop()
+            except Exception:
+                pass
+            self._footer_note_timer = None
+        if message and timeout > 0:
+            self._footer_note_timer = self.set_timer(
+                timeout, lambda: self._set_footer_note(None, timeout=0)
+            )
+        self.refresh_footer()
+
+    def _run_export_cleanup(self) -> None:
+        """Best-effort cleanup of stale markdown exports at TUI startup."""
+        result = cleanup_export_markdown_files(
+            retention_days=self.config.get(
+                "export_retention_days",
+                EXPORT_RETENTION_DAYS_DEFAULT,
+            ),
+        )
+        try:
+            self.log(result.debug_message())
+        except Exception:
+            pass
+        message = result.footer_message()
+        if message:
+            self._set_footer_note(message)
 
     def on_descendant_focus(self, event) -> None:
         self.refresh_footer()


### PR DESCRIPTION
## What changed
- add startup cleanup for exported markdown files in `/tmp/threadhop`
- make export retention configurable via `config.json` with `export_retention_days` defaulting to `7`
- skip files modified within the last hour and best-effort skip files currently open
- surface cleanup results quietly via the TUI footer/debug logging
- add focused tests for cleanup behavior and config coercion/defaults

## Why
Exported markdown files accumulate for users who do not reboot often, because the prior behavior relied only on macOS eventually clearing `/tmp`.

## User impact
ThreadHop now prunes stale temp exports automatically on TUI launch without intrusive notifications, while preserving recent or active files.

## Root cause
The export flow wrote temp markdown files into `/tmp/threadhop` but had no app-level retention pass.

## Validation
- `uv run --with pytest --with 'textual>=0.89.0' --with 'watchdog>=4.0.0' --with 'pydantic>=2.0' --with rich pytest tests/test_export_cleanup.py -q`
- `uv run --with pytest --with 'textual>=0.89.0' --with 'watchdog>=4.0.0' --with 'pydantic>=2.0' --with rich pytest tests/test_migration.py -q -k 'theme_and_sidebar_width_preserved or unknown_app_level_keys_are_preserved'`
- `python3 -m py_compile threadhop tests/test_export_cleanup.py`
