### PR TITLE
Add TUI observation keybindings for observer control

### DIFF
--- a/db.py
+++ b/db.py
@@ -1252,7 +1252,7 @@ def get_observed_sessions(
     """
     return query_all(
         conn,
-        "SELECT session_id, entry_count, status, observer_pid "
+        "SELECT session_id, entry_count, status, observer_pid, obs_path "
         "FROM observation_state WHERE entry_count > 0",
     )
 

--- a/tests/test_tui_observation_actions.py
+++ b/tests/test_tui_observation_actions.py
@@ -1,0 +1,158 @@
+"""Focused tests for TUI observation helpers and action routing."""
+
+from __future__ import annotations
+
+import runpy
+import time
+from pathlib import Path
+
+import db
+
+
+ROOT = Path(__file__).resolve().parent.parent
+THREADHOP = ROOT / "threadhop"
+
+
+def _load_threadhop_ns() -> dict:
+    return runpy.run_path(str(THREADHOP))
+
+
+class _FakeItem:
+    def __init__(self, session_data: dict):
+        self.session_data = session_data
+
+
+class _FakeApp:
+    def __init__(self, item: _FakeItem, state: dict | None = None):
+        self._item = item
+        self._state = state
+        self.notifications: list[tuple[str, dict]] = []
+        self.confirmations: list[tuple[str, str, str]] = []
+
+    def _input_has_focus(self) -> bool:
+        return False
+
+    def _highlighted_session_item(self):
+        return self._item
+
+    def _refresh_session_observation(self, session_id: str) -> dict | None:
+        assert session_id == self._item.session_data["session_id"]
+        return self._state
+
+    def _confirm_observer_start(
+        self, session_id: str, prompt: str, success_message: str
+    ) -> None:
+        self.confirmations.append((session_id, prompt, success_message))
+
+    def notify(self, message, **kwargs) -> None:
+        self.notifications.append((str(message), kwargs))
+
+
+def test_get_observed_sessions_includes_obs_path(conn, tmp_path: Path):
+    source_path = tmp_path / "sess-1.jsonl"
+    source_path.write_text("")
+    obs_path = tmp_path / "observations" / "sess-1.jsonl"
+    obs_path.parent.mkdir()
+    db.upsert_session(conn, "sess-1", str(source_path), project="test-project")
+
+    db.upsert_observation_state(
+        conn,
+        "sess-1",
+        str(source_path),
+        str(obs_path),
+        entry_count=3,
+        status="stopped",
+    )
+
+    rows = db.get_observed_sessions(conn)
+
+    assert len(rows) == 1
+    assert rows[0]["session_id"] == "sess-1"
+    assert rows[0]["obs_path"] == str(obs_path)
+
+
+def test_build_observe_command_targets_current_script():
+    ns = _load_threadhop_ns()
+
+    argv = ns["build_observe_command"]("sess-1")
+
+    assert argv == [str(THREADHOP.resolve()), "observe", "--session", "sess-1"]
+
+
+def test_format_session_label_adds_observation_indicator():
+    ns = _load_threadhop_ns()
+    session_data = {
+        "modified": time.time(),
+        "project": "proj",
+        "title": "demo",
+        "is_observed": True,
+    }
+
+    observed = ns["format_session_label"](session_data, None, "○")
+    plain = ns["format_session_label"]({**session_data, "is_observed": False}, None, "○")
+
+    assert ns["OBS_INDICATOR"] in observed
+    assert ns["OBS_INDICATOR"] not in plain
+
+
+def test_action_observe_session_copies_observation_path(monkeypatch):
+    ns = _load_threadhop_ns()
+    copied: list[str] = []
+    monkeypatch.setitem(
+        ns["ClaudeSessions"].action_observe_session.__globals__,
+        "copy_to_clipboard",
+        lambda text: copied.append(text) or True,
+    )
+    app = _FakeApp(
+        _FakeItem(
+            {
+                "session_id": "sess-1",
+                "is_observed": True,
+                "observation_obs_path": "/tmp/sess-1.jsonl",
+            }
+        )
+    )
+
+    ns["ClaudeSessions"].action_observe_session(app)
+
+    assert copied == ["/tmp/sess-1.jsonl"]
+    assert app.notifications == [("Observation path copied", {})]
+
+
+def test_action_observe_session_prompts_to_start_when_unobserved():
+    ns = _load_threadhop_ns()
+    app = _FakeApp(_FakeItem({"session_id": "sess-1", "is_observed": False}))
+
+    ns["ClaudeSessions"].action_observe_session(app)
+
+    assert app.confirmations == [
+        (
+            "sess-1",
+            "No observations yet. Start observing? (y/n)",
+            "Observer starting in background",
+        )
+    ]
+
+
+def test_action_resume_observation_prompts_when_stopped_and_observed():
+    ns = _load_threadhop_ns()
+    app = _FakeApp(
+        _FakeItem(
+            {
+                "session_id": "sess-1",
+                "is_observed": True,
+                "observation_entry_count": 4,
+            }
+        ),
+        state={"entry_count": 4, "observer_pid": None, "status": "stopped"},
+    )
+
+    ns["ClaudeSessions"].action_resume_observation(app)
+
+    assert app.confirmations == [
+        (
+            "sess-1",
+            "Resume observation from last offset? (y/n)",
+            "Observation resumed in background",
+        )
+    ]

--- a/tests/test_tui_observation_actions.py
+++ b/tests/test_tui_observation_actions.py
@@ -79,20 +79,27 @@ def test_build_observe_command_targets_current_script():
     assert argv == [str(THREADHOP.resolve()), "observe", "--session", "sess-1"]
 
 
-def test_format_session_label_adds_observation_indicator():
+def test_render_session_label_text_adds_observation_indicator():
     ns = _load_threadhop_ns()
     session_data = {
         "modified": time.time(),
         "project": "proj",
         "title": "demo",
-        "is_observed": True,
+        "has_observations": True,
     }
 
-    observed = ns["format_session_label"](session_data, None, "○")
-    plain = ns["format_session_label"]({**session_data, "is_observed": False}, None, "○")
+    observed = ns["render_session_label_text"](session_data)
+    plain = ns["render_session_label_text"](
+        {**session_data, "has_observations": False}
+    )
 
-    assert ns["OBS_INDICATOR"] in observed
-    assert ns["OBS_INDICATOR"] not in plain
+    indicator = (
+        ns["OBSERVATION_MARKER"]
+        if ns["_supports_observation_emoji"]()
+        else ns["OBSERVATION_MARKER_FALLBACK"]
+    )
+    assert indicator in observed.plain
+    assert indicator not in plain.plain
 
 
 def test_action_observe_session_copies_observation_path(monkeypatch):
@@ -107,10 +114,10 @@ def test_action_observe_session_copies_observation_path(monkeypatch):
         _FakeItem(
             {
                 "session_id": "sess-1",
-                "is_observed": True,
-                "observation_obs_path": "/tmp/sess-1.jsonl",
+                "has_observations": True,
             }
-        )
+        ),
+        state={"entry_count": 2, "obs_path": "/tmp/sess-1.jsonl"},
     )
 
     ns["ClaudeSessions"].action_observe_session(app)
@@ -121,7 +128,7 @@ def test_action_observe_session_copies_observation_path(monkeypatch):
 
 def test_action_observe_session_prompts_to_start_when_unobserved():
     ns = _load_threadhop_ns()
-    app = _FakeApp(_FakeItem({"session_id": "sess-1", "is_observed": False}))
+    app = _FakeApp(_FakeItem({"session_id": "sess-1", "has_observations": False}))
 
     ns["ClaudeSessions"].action_observe_session(app)
 
@@ -140,8 +147,7 @@ def test_action_resume_observation_prompts_when_stopped_and_observed():
         _FakeItem(
             {
                 "session_id": "sess-1",
-                "is_observed": True,
-                "observation_entry_count": 4,
+                "has_observations": True,
             }
         ),
         state={"entry_count": 4, "observer_pid": None, "status": "stopped"},

--- a/threadhop
+++ b/threadhop
@@ -330,10 +330,11 @@ def clear_recent_searches(config: dict | None) -> None:
 
 # --- Configuration ---
 DISPLAY_NAME_WIDTH = 22
+OBSERVATION_MARKER = "🗒"
+OBSERVATION_MARKER_FALLBACK = "≡"
 MAX_SESSIONS = 50
 REFRESH_INTERVAL = 5
 SPINNER_INTERVAL = 0.25
-OBS_INDICATOR = "≡"
 SEARCH_PAGE_SIZE = 50
 MAX_RECENT_SEARCHES = 8
 
@@ -616,6 +617,35 @@ def format_age(timestamp: float) -> str:
         return f"{int(age / 86400)}d"
 
 
+def _supports_observation_emoji() -> bool:
+    """Return whether the current terminal can safely encode the emoji marker."""
+    if os.environ.get("THREADHOP_ASCII_OBSERVATION_MARKER") == "1":
+        return False
+    encoding = sys.stdout.encoding or "utf-8"
+    try:
+        OBSERVATION_MARKER.encode(encoding)
+    except (LookupError, UnicodeEncodeError):
+        return False
+    return True
+
+
+def _observation_marker_text() -> Text:
+    """Return the ADR-021 observed-session marker."""
+    if _supports_observation_emoji():
+        return Text(OBSERVATION_MARKER, style="dim")
+    return Text(OBSERVATION_MARKER_FALLBACK, style="dim cyan")
+
+
+def _session_display_name(session_data: dict, custom_name: str | None) -> str:
+    """Resolve the user-facing session label before sidebar truncation."""
+    title = session_data.get("title", "")
+    if custom_name:
+        return custom_name
+    if title:
+        return title
+    return session_data["project"]
+
+
 def copy_to_clipboard(text: str) -> bool:
     """Copy text to the system clipboard."""
     try:
@@ -637,24 +667,46 @@ def build_observe_command(session_id: str) -> list[str]:
     return [str(Path(__file__).resolve()), "observe", "--session", session_id]
 
 
-def format_session_label(
+def render_session_label_text(
     session_data: dict,
-    custom_name: str | None,
-    status: str,
-) -> str:
-    """Render one sidebar row, including the observation indicator."""
-    age_str = format_age(session_data["modified"])
-    project = session_data["project"]
-    title = session_data.get("title", "")
-    if custom_name:
-        display = custom_name
-    elif title:
-        display = title
+    *,
+    custom_name: str | None = None,
+    spinner_frame: int = 0,
+) -> Text:
+    """Build the Rich label for one sidebar session row."""
+    is_working = session_data.get("is_working", False)
+    is_active = session_data.get("is_active", False)
+    if is_working:
+        status = SPINNER_FRAMES[spinner_frame % len(SPINNER_FRAMES)]
+    elif is_active:
+        status = "●"
     else:
-        display = project
-    display = f"{display[:DISPLAY_NAME_WIDTH]:<{DISPLAY_NAME_WIDTH}}"
-    obs = OBS_INDICATOR if session_data.get("is_observed") else " "
-    return f"{status} {display} {obs} {age_str:>4}"
+        status = "○"
+
+    display = _session_display_name(session_data, custom_name)
+    indicator = (
+        _observation_marker_text()
+        if session_data.get("has_observations")
+        else None
+    )
+    reserved_width = 0
+    if indicator is not None:
+        reserved_width = 1 + indicator.cell_len
+    name_width = max(DISPLAY_NAME_WIDTH - reserved_width, 0)
+
+    middle = Text(display[:name_width])
+    if indicator is not None:
+        middle.append(" ")
+        middle.append_text(indicator)
+    if middle.cell_len < DISPLAY_NAME_WIDTH:
+        middle.append(" " * (DISPLAY_NAME_WIDTH - middle.cell_len))
+
+    age_str = format_age(session_data["modified"])
+    text = Text()
+    text.append(f"{status} ")
+    text.append_text(middle)
+    text.append(f" {age_str:>4}")
+    return text
 
 
 class SessionItem(ListItem):
@@ -674,41 +726,55 @@ class SessionItem(ListItem):
         super().__init__()
 
     def compose(self) -> ComposeResult:
-        is_working = self.session_data.get("is_working", False)
-        is_active = self.session_data.get("is_active", False)
+        label = Static(self._render_label(), classes="session-label")
+        self._sync_label_classes(label)
+        yield label
 
-        if is_working:
-            status = SPINNER_FRAMES[self.spinner_frame % len(SPINNER_FRAMES)]
-        elif is_active:
-            status = "●"
-        else:
-            status = "○"
-
-        label = Static(
-            format_session_label(self.session_data, self.custom_name, status),
-            classes="session-label",
+    def _render_label(self) -> Text:
+        return render_session_label_text(
+            self.session_data,
+            custom_name=self.custom_name,
+            spinner_frame=self.spinner_frame,
         )
+
+    def _sync_label_classes(self, label: Static) -> None:
         if self.is_unread:
             label.add_class("unread")
-        if is_working:
+        else:
+            label.remove_class("unread")
+
+        if self.session_data.get("is_working", False):
             label.add_class("working")
-        elif is_active:
+        else:
+            label.remove_class("working")
+
+        if (
+            self.session_data.get("is_active", False)
+            and not self.session_data.get("is_working", False)
+        ):
             label.add_class("active")
+        else:
+            label.remove_class("active")
+
         if self.session_data.get("status") == "archived":
             label.add_class("archived")
-        yield label
+        else:
+            label.remove_class("archived")
+
+    def refresh_label(self) -> None:
+        try:
+            label = self.query_one(".session-label", Static)
+            label.update(self._render_label())
+            self._sync_label_classes(label)
+        except Exception:
+            pass
 
     def update_spinner(self, frame: int) -> None:
         """Update spinner animation frame"""
         if not self.session_data.get("is_working"):
             return
         self.spinner_frame = frame
-        status = SPINNER_FRAMES[frame % len(SPINNER_FRAMES)]
-        try:
-            label = self.query_one(".session-label", Static)
-            label.update(format_session_label(self.session_data, self.custom_name, status))
-        except:
-            pass
+        self.refresh_label()
 
 
 
@@ -3811,34 +3877,22 @@ class ClaudeSessions(App):
             # in-memory self.sessions for display.
             pass
 
-        # Stamp each session dict with its persisted status so the UI can
-        # group by it. Read in bulk after the upsert so new sessions get
-        # the DEFAULT 'active' from the column definition.
+        # Stamp each session dict with its persisted sidebar metadata in
+        # one bulk read after the upsert so new sessions get the DEFAULT
+        # 'active' status and the ADR-021 observation bit without
+        # per-session queries during the 5-second refresh cycle.
         try:
-            statuses = db.get_session_statuses(self.conn)
+            sidebar_state = db.get_session_sidebar_metadata(self.conn)
             for s in self.sessions:
-                s["status"] = statuses.get(s["session_id"], "active")
+                state = sidebar_state.get(s["session_id"], {})
+                s["status"] = state.get("status", "active")
+                s["has_observations"] = bool(
+                    state.get("has_observations", False)
+                )
         except Exception:
             for s in self.sessions:
                 s.setdefault("status", "active")
-
-        try:
-            observed = {
-                row["session_id"]: row
-                for row in db.get_observed_sessions(self.conn)
-            }
-            for s in self.sessions:
-                row = observed.get(s["session_id"])
-                s["is_observed"] = bool(row)
-                s["observation_entry_count"] = int(row["entry_count"]) if row else 0
-                s["observation_status"] = row.get("status") if row else None
-                s["observation_obs_path"] = row.get("obs_path") if row else None
-        except Exception:
-            for s in self.sessions:
-                s["is_observed"] = False
-                s["observation_entry_count"] = 0
-                s["observation_status"] = None
-                s["observation_obs_path"] = None
+                s.setdefault("has_observations", False)
 
         self._apply_stable_ordering()
         self._update_session_list(force_rebuild)
@@ -3930,20 +3984,13 @@ class ClaudeSessions(App):
                 if isinstance(item, SessionStatusHeader):
                     out.append(("h", item.status))
                 elif isinstance(item, SessionItem):
-                    sid = item.session_data.get("session_id", "")
-                    observed = "1" if item.session_data.get("is_observed") else "0"
-                    out.append(("s", f"{sid}:{observed}"))
+                    out.append(("s", item.session_data.get("session_id", "")))
             return out
 
-        new_fp: list[tuple[str, str]] = []
-        for kind, val in plan:
-            if kind == "header":
-                new_fp.append(("h", val))  # type: ignore[arg-type]
-                continue
-            session = val  # type: ignore[assignment]
-            sid = session.get("session_id", "")  # type: ignore[union-attr]
-            observed = "1" if session.get("is_observed") else "0"  # type: ignore[union-attr]
-            new_fp.append(("s", f"{sid}:{observed}"))
+        new_fp: list[tuple[str, str]] = [
+            ("h", val) if kind == "header" else ("s", val.get("session_id", ""))  # type: ignore[union-attr]
+            for kind, val in plan
+        ]
         current_fp = _fingerprint_children()
 
         if force_rebuild or current_fp != new_fp:
@@ -3999,29 +4046,8 @@ class ClaudeSessions(App):
                 if isinstance(item, SessionItem):
                     sid = item.session_data.get("session_id")
                     if sid in session_map:
-                        old_is_working = item.session_data.get("is_working", False)
                         item.session_data.update(session_map[sid])
-                        new_is_working = item.session_data.get("is_working", False)
-                        if new_is_working != old_is_working:
-                            item.session_data["is_working"] = new_is_working
-                            try:
-                                label = item.query_one(".session-label", Static)
-                                if new_is_working:
-                                    label.add_class("working")
-                                    item.update_spinner(self._spinner_frame)
-                                else:
-                                    label.remove_class("working")
-                                    session = item.session_data
-                                    status = "●" if session.get("is_active") else "○"
-                                    label.update(
-                                        format_session_label(
-                                            session,
-                                            item.custom_name,
-                                            status,
-                                        )
-                                    )
-                            except:
-                                pass
+                        item.refresh_label()
 
     def refresh_transcript(self) -> None:
         transcript = self.query_one("#transcript-scroll", TranscriptView)
@@ -4231,13 +4257,11 @@ class ClaudeSessions(App):
         session = item.session_data
         session_id = session.get("session_id", "")
         state = self._refresh_session_observation(session_id)
-        is_observed = bool(session.get("is_observed"))
+        is_observed = bool(session.get("has_observations"))
         if state is not None and int(state.get("entry_count") or 0) > 0:
             is_observed = True
         if is_observed:
-            obs_path = session.get("observation_obs_path")
-            if not obs_path:
-                obs_path = state.get("obs_path") if state else None
+            obs_path = state.get("obs_path") if state else None
             if obs_path and copy_to_clipboard(str(obs_path)):
                 self.notify("Observation path copied")
             elif obs_path:
@@ -4267,8 +4291,6 @@ class ClaudeSessions(App):
         entry_count = 0
         if state is not None:
             entry_count = int(state.get("entry_count") or 0)
-        elif session.get("is_observed"):
-            entry_count = int(session.get("observation_entry_count") or 0)
         if entry_count <= 0:
             self.notify("No observations to resume", severity="warning")
             return

--- a/threadhop
+++ b/threadhop
@@ -126,6 +126,7 @@ DISPLAY_NAME_WIDTH = 22
 MAX_SESSIONS = 50
 REFRESH_INTERVAL = 5
 SPINNER_INTERVAL = 0.25
+OBS_INDICATOR = "≡"
 
 # --- Paths ---
 CLAUDE_PROJECTS = Path.home() / ".claude" / "projects"
@@ -275,6 +276,8 @@ COMMAND_REGISTRY: list[Command] = [
     ),
     Command(("n",), "Rename session", SCOPE_SESSION_LIST, "rename_session", footer=True),
     Command(("g",), "Copy resume command", SCOPE_SESSION_LIST, "copy_session_id"),
+    Command(("o",), "Copy observation path / start observing", SCOPE_SESSION_LIST, "observe_session"),
+    Command(("O",), "Resume observation", SCOPE_SESSION_LIST, "resume_observation"),
     Command(("s",), "Cycle status forward", SCOPE_SESSION_LIST, "cycle_status_forward"),
     Command(("S",), "Cycle status backward", SCOPE_SESSION_LIST, "cycle_status_backward"),
     Command(("a",), "Archive session", SCOPE_SESSION_LIST, "archive_session"),
@@ -402,6 +405,47 @@ def format_age(timestamp: float) -> str:
         return f"{int(age / 86400)}d"
 
 
+def copy_to_clipboard(text: str) -> bool:
+    """Copy text to the system clipboard."""
+    try:
+        if sys.platform == "darwin":
+            subprocess.run(["pbcopy"], input=text.encode(), check=True)
+        else:
+            subprocess.run(
+                ["xclip", "-selection", "clipboard"],
+                input=text.encode(),
+                check=True,
+            )
+        return True
+    except Exception:
+        return False
+
+
+def build_observe_command(session_id: str) -> list[str]:
+    """Spawn the CLI sidecar through the current executable script."""
+    return [str(Path(__file__).resolve()), "observe", "--session", session_id]
+
+
+def format_session_label(
+    session_data: dict,
+    custom_name: str | None,
+    status: str,
+) -> str:
+    """Render one sidebar row, including the observation indicator."""
+    age_str = format_age(session_data["modified"])
+    project = session_data["project"]
+    title = session_data.get("title", "")
+    if custom_name:
+        display = custom_name
+    elif title:
+        display = title
+    else:
+        display = project
+    display = f"{display[:DISPLAY_NAME_WIDTH]:<{DISPLAY_NAME_WIDTH}}"
+    obs = OBS_INDICATOR if session_data.get("is_observed") else " "
+    return f"{status} {display} {obs} {age_str:>4}"
+
+
 class SessionItem(ListItem):
     """A session in the list"""
 
@@ -419,8 +463,6 @@ class SessionItem(ListItem):
         super().__init__()
 
     def compose(self) -> ComposeResult:
-        age_str = format_age(self.session_data["modified"])
-        project = self.session_data["project"]
         is_working = self.session_data.get("is_working", False)
         is_active = self.session_data.get("is_active", False)
 
@@ -431,17 +473,10 @@ class SessionItem(ListItem):
         else:
             status = "○"
 
-        # Priority: custom name (from our config) > session title (from JSONL) > project path
-        title = self.session_data.get("title", "")
-        if self.custom_name:
-            display = self.custom_name
-        elif title:
-            display = title
-        else:
-            display = project
-        display = f"{display[:DISPLAY_NAME_WIDTH]:<{DISPLAY_NAME_WIDTH}}"
-
-        label = Static(f"{status} {display} {age_str:>4}", classes="session-label")
+        label = Static(
+            format_session_label(self.session_data, self.custom_name, status),
+            classes="session-label",
+        )
         if self.is_unread:
             label.add_class("unread")
         if is_working:
@@ -458,20 +493,9 @@ class SessionItem(ListItem):
             return
         self.spinner_frame = frame
         status = SPINNER_FRAMES[frame % len(SPINNER_FRAMES)]
-        age_str = format_age(self.session_data["modified"])
-
-        title = self.session_data.get("title", "")
-        if self.custom_name:
-            display = self.custom_name
-        elif title:
-            display = title
-        else:
-            display = self.session_data["project"]
-        display = f"{display[:DISPLAY_NAME_WIDTH]:<{DISPLAY_NAME_WIDTH}}"
-
         try:
             label = self.query_one(".session-label", Static)
-            label.update(f"{status} {display} {age_str:>4}")
+            label.update(format_session_label(self.session_data, self.custom_name, status))
         except:
             pass
 
@@ -2342,6 +2366,62 @@ class LabelPromptScreen(ModalScreen):
         self.action_submit()
 
 
+class ConfirmScreen(ModalScreen):
+    """Minimal yes/no confirmation modal for TUI actions."""
+
+    BINDINGS = [
+        Binding("y", "confirm", "Yes", priority=True, show=False),
+        Binding("n", "cancel", "No", priority=True, show=False),
+        Binding("enter", "confirm", "Yes", priority=True, show=False),
+        Binding("escape", "cancel", "No", priority=True, show=False),
+    ]
+
+    CSS = """
+    ConfirmScreen {
+        layout: vertical;
+        align: center middle;
+        background: $background 70%;
+    }
+
+    #confirm-container {
+        width: 72;
+        max-width: 90%;
+        height: auto;
+        background: $surface;
+        border: thick $accent;
+        padding: 1 2;
+        layout: vertical;
+    }
+
+    #confirm-title {
+        color: $text;
+        text-style: bold;
+    }
+
+    #confirm-hint {
+        height: 1;
+        margin-top: 1;
+        color: $text-muted;
+        text-style: italic;
+    }
+    """
+
+    def __init__(self, title: str):
+        super().__init__()
+        self._title = title
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="confirm-container"):
+            yield Static(self._title, id="confirm-title")
+            yield Static("y/Enter = yes • n/Esc = no", id="confirm-hint")
+
+    def action_confirm(self) -> None:
+        self.dismiss(True)
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)
+
+
 class HelpScreen(ModalScreen):
     """Full-app help overlay grouped by scope (ADR-017, task #42).
 
@@ -3070,6 +3150,24 @@ class ClaudeSessions(App):
             for s in self.sessions:
                 s.setdefault("status", "active")
 
+        try:
+            observed = {
+                row["session_id"]: row
+                for row in db.get_observed_sessions(self.conn)
+            }
+            for s in self.sessions:
+                row = observed.get(s["session_id"])
+                s["is_observed"] = bool(row)
+                s["observation_entry_count"] = int(row["entry_count"]) if row else 0
+                s["observation_status"] = row.get("status") if row else None
+                s["observation_obs_path"] = row.get("obs_path") if row else None
+        except Exception:
+            for s in self.sessions:
+                s["is_observed"] = False
+                s["observation_entry_count"] = 0
+                s["observation_status"] = None
+                s["observation_obs_path"] = None
+
         self._apply_stable_ordering()
         self._update_session_list(force_rebuild)
         self.refresh_transcript()
@@ -3160,13 +3258,20 @@ class ClaudeSessions(App):
                 if isinstance(item, SessionStatusHeader):
                     out.append(("h", item.status))
                 elif isinstance(item, SessionItem):
-                    out.append(("s", item.session_data.get("session_id", "")))
+                    sid = item.session_data.get("session_id", "")
+                    observed = "1" if item.session_data.get("is_observed") else "0"
+                    out.append(("s", f"{sid}:{observed}"))
             return out
 
-        new_fp: list[tuple[str, str]] = [
-            ("h", val) if kind == "header" else ("s", val.get("session_id", ""))  # type: ignore[union-attr]
-            for kind, val in plan
-        ]
+        new_fp: list[tuple[str, str]] = []
+        for kind, val in plan:
+            if kind == "header":
+                new_fp.append(("h", val))  # type: ignore[arg-type]
+                continue
+            session = val  # type: ignore[assignment]
+            sid = session.get("session_id", "")  # type: ignore[union-attr]
+            observed = "1" if session.get("is_observed") else "0"  # type: ignore[union-attr]
+            new_fp.append(("s", f"{sid}:{observed}"))
         current_fp = _fingerprint_children()
 
         if force_rebuild or current_fp != new_fp:
@@ -3222,8 +3327,9 @@ class ClaudeSessions(App):
                 if isinstance(item, SessionItem):
                     sid = item.session_data.get("session_id")
                     if sid in session_map:
-                        new_is_working = session_map[sid].get("is_working", False)
                         old_is_working = item.session_data.get("is_working", False)
+                        item.session_data.update(session_map[sid])
+                        new_is_working = item.session_data.get("is_working", False)
                         if new_is_working != old_is_working:
                             item.session_data["is_working"] = new_is_working
                             try:
@@ -3235,17 +3341,12 @@ class ClaudeSessions(App):
                                     label.remove_class("working")
                                     session = item.session_data
                                     status = "●" if session.get("is_active") else "○"
-                                    age_str = format_age(session["modified"])
-                                    title = session.get("title", "")
-                                    if item.custom_name:
-                                        display = item.custom_name
-                                    elif title:
-                                        display = title
-                                    else:
-                                        display = session["project"]
-                                    display = f"{display[:DISPLAY_NAME_WIDTH]:<{DISPLAY_NAME_WIDTH}}"
                                     label.update(
-                                        f"{status} {display} {age_str:>4}"
+                                        format_session_label(
+                                            session,
+                                            item.custom_name,
+                                            status,
+                                        )
                                     )
                             except:
                                 pass
@@ -3402,18 +3503,111 @@ class ClaudeSessions(App):
         session_id = list_view.highlighted_child.session_data.get("session_id", "")
         cmd = f"claude -r {session_id}"
         try:
-            if sys.platform == "darwin":
-                subprocess.run(["pbcopy"], input=cmd.encode(), check=True)
-            else:
-                subprocess.run(
-                    ["xclip", "-selection", "clipboard"],
-                    input=cmd.encode(),
-                    check=True,
-                )
+            if not copy_to_clipboard(cmd):
+                raise RuntimeError("clipboard unavailable")
             self.notify(f"Copied: {cmd}")
         except Exception:
             # Fallback: just show the command
             self.notify(f"Resume: {cmd}", timeout=10)
+
+    def _highlighted_session_item(self) -> SessionItem | None:
+        list_view = self.query_one("#session-list", ListView)
+        item = list_view.highlighted_child
+        if isinstance(item, SessionItem):
+            return item
+        return None
+
+    def _spawn_observer(self, session_id: str) -> bool:
+        try:
+            subprocess.Popen(
+                build_observe_command(session_id),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            return True
+        except Exception as e:
+            self.notify(f"Failed to start observer: {e}", severity="error")
+            return False
+
+    def _refresh_session_observation(self, session_id: str) -> dict | None:
+        try:
+            return _refresh_observer_state(self.conn, session_id)
+        except Exception:
+            return None
+
+    def _confirm_observer_start(self, session_id: str, prompt: str, success_message: str) -> None:
+        def _after(confirm: bool | None) -> None:
+            if not confirm:
+                return
+            state = self._refresh_session_observation(session_id)
+            if state is not None and state.get("observer_pid") is not None:
+                self.notify("Observer already running")
+                return
+            if self._spawn_observer(session_id):
+                self.notify(success_message)
+
+        self.push_screen(ConfirmScreen(prompt), _after)
+
+    def action_observe_session(self) -> None:
+        if self._input_has_focus():
+            return
+        item = self._highlighted_session_item()
+        if item is None:
+            return
+        session = item.session_data
+        session_id = session.get("session_id", "")
+        state = self._refresh_session_observation(session_id)
+        is_observed = bool(session.get("is_observed"))
+        if state is not None and int(state.get("entry_count") or 0) > 0:
+            is_observed = True
+        if is_observed:
+            obs_path = session.get("observation_obs_path")
+            if not obs_path:
+                obs_path = state.get("obs_path") if state else None
+            if obs_path and copy_to_clipboard(str(obs_path)):
+                self.notify("Observation path copied")
+            elif obs_path:
+                self.notify(str(obs_path), timeout=10)
+            else:
+                self.notify("Observation path unavailable", severity="warning")
+            return
+
+        if state is not None and state.get("observer_pid") is not None:
+            self.notify("Observer already running")
+            return
+        self._confirm_observer_start(
+            session_id,
+            "No observations yet. Start observing? (y/n)",
+            "Observer starting in background",
+        )
+
+    def action_resume_observation(self) -> None:
+        if self._input_has_focus():
+            return
+        item = self._highlighted_session_item()
+        if item is None:
+            return
+        session = item.session_data
+        session_id = session.get("session_id", "")
+        state = self._refresh_session_observation(session_id)
+        entry_count = 0
+        if state is not None:
+            entry_count = int(state.get("entry_count") or 0)
+        elif session.get("is_observed"):
+            entry_count = int(session.get("observation_entry_count") or 0)
+        if entry_count <= 0:
+            self.notify("No observations to resume", severity="warning")
+            return
+        if state is not None and state.get("observer_pid") is not None:
+            self.notify("Observer already running")
+            return
+        self._confirm_observer_start(
+            session_id,
+            "Resume observation from last offset? (y/n)",
+            "Observation resumed in background",
+        )
 
     def _input_has_focus(self) -> bool:
         if self.query_one("#reply-input", TextArea).has_focus:


### PR DESCRIPTION
## Summary

This PR finishes the ADR-021 TUI observation workflow by adding sidebar actions for observation files and observer lifecycle control.

It builds on the observation indicator and transcript header work already on `docs/adr` and keeps this branch aligned with the latest sidebar rendering changes.

## Changes

- add `o` in the session list to copy the observation file path for observed sessions
- add `o` in the session list to prompt to start observing for sessions with no observations yet
- add `O` in the session list to prompt to resume observation for stopped, previously observed sessions
- reuse the existing `threadhop observe --session <id>` sidecar path instead of duplicating observer logic in the TUI
- add focused tests for the new keybinding behavior and update them to match the latest observation-indicator implementation from `docs/adr`

## Why

ADR-021 calls for observation actions directly in the session list so users can move from "this session has observations" to "copy the path / start observing / resume observing" without dropping to a separate CLI step.

## Validation

- `uv run --with pytest --with rich --with textual --with watchdog --with pydantic python -m pytest tests/test_tui_observation_indicator.py tests/test_tui_observation_actions.py tests/test_cli_observe.py tests/test_observer.py tests/test_export_cleanup.py tests/test_search_panel.py tests/test_transcript_observation_header.py -q`