### PR TITLE
Add trigram fallback for search

### DIFF
--- a/db.py
+++ b/db.py
@@ -40,7 +40,7 @@ DB_PATH = DB_DIR / "sessions.db"
 # --- Schema version ---
 # Each migration N in MIGRATIONS moves the DB from version N to N+1.
 # The DB's current version lives in PRAGMA user_version.
-SCHEMA_VERSION = 7
+SCHEMA_VERSION = 8
 
 
 # --- Migrations -----------------------------------------------------------
@@ -72,8 +72,9 @@ def _migration_001_initial(conn: sqlite3.Connection) -> None:
             project       TEXT,
             cwd           TEXT,
             custom_name   TEXT,
-            status        TEXT NOT NULL DEFAULT 'active',
-                -- active | in_progress | in_review | done | archived
+            status        TEXT NOT NULL DEFAULT 'active'
+                CHECK (status IN
+                    ('active', 'in_progress', 'in_review', 'done', 'archived')),
             sort_order    INTEGER,
             last_viewed   REAL,
             created_at    REAL,
@@ -323,15 +324,30 @@ def _migration_006_sessions_status_check(conn: sqlite3.Connection) -> None:
         """
     )
 
+    schema_row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'sessions'"
+    ).fetchone()
+    schema_sql = str(schema_row[0] or "") if schema_row is not None else ""
+    if "CHECK (status IN" in schema_sql:
+        return
+
     current_sv = conn.execute("PRAGMA schema_version").fetchone()[0]
 
     conn.execute("PRAGMA writable_schema = ON")
     try:
-        conn.execute(
-            "UPDATE sqlite_master SET sql = ? "
-            "WHERE type = 'table' AND name = 'sessions'",
-            (_SESSIONS_TABLE_DDL_WITH_CHECK,),
-        )
+        try:
+            conn.execute(
+                "UPDATE sqlite_master SET sql = ? "
+                "WHERE type = 'table' AND name = 'sessions'",
+                (_SESSIONS_TABLE_DDL_WITH_CHECK,),
+            )
+        except sqlite3.OperationalError as exc:
+            # Newer SQLite builds may hard-block sqlite_master writes even
+            # with writable_schema enabled. In that case we leave legacy DBs
+            # without the CHECK constraint rather than fail startup.
+            if "sqlite_master may not be modified" in str(exc):
+                return
+            raise
         # Bumping schema_version forces SQLite to re-parse sqlite_master
         # on the next statement — without this, the same connection keeps
         # using its cached pre-CHECK definition until it's reopened.
@@ -383,6 +399,63 @@ def _migration_007_bookmarks(conn: sqlite3.Connection) -> None:
     )
 
 
+def _migration_008_trigram_search(conn: sqlite3.Connection) -> None:
+    """Task #32: trigram-backed fuzzy-search fallback.
+
+    The primary search path remains the existing porter/unicode61 prefix
+    index. This secondary FTS5 table is only consulted when the prefix
+    query returns zero hits, so the normal per-keystroke path keeps its
+    current latency profile.
+
+    The table mirrors ``messages_fts`` as external-content FTS over
+    ``messages(rowid)``. Existing rows are backfilled with FTS5's
+    ``rebuild`` command so upgraded databases can use fuzzy fallback
+    immediately without forcing a full reindex from JSONL.
+    """
+    conn.execute(
+        """
+        CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts_trigram USING fts5(
+            text,
+            content='messages',
+            content_rowid='rowid',
+            tokenize='trigram'
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS messages_ai_trigram
+        AFTER INSERT ON messages BEGIN
+            INSERT INTO messages_fts_trigram(rowid, text)
+            VALUES (new.rowid, new.text);
+        END
+        """
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS messages_ad_trigram
+        AFTER DELETE ON messages BEGIN
+            INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, text)
+            VALUES ('delete', old.rowid, old.text);
+        END
+        """
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS messages_au_trigram
+        AFTER UPDATE ON messages BEGIN
+            INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, text)
+            VALUES ('delete', old.rowid, old.text);
+            INSERT INTO messages_fts_trigram(rowid, text)
+            VALUES (new.rowid, new.text);
+        END
+        """
+    )
+    conn.execute(
+        "INSERT INTO messages_fts_trigram(messages_fts_trigram) VALUES ('rebuild')"
+    )
+
+
 # Ordered list; MIGRATIONS[i] moves schema from version i to i+1.
 MIGRATIONS: list = [
     _migration_001_initial,
@@ -392,6 +465,7 @@ MIGRATIONS: list = [
     _migration_005_conflict_reviews,
     _migration_006_sessions_status_check,
     _migration_007_bookmarks,
+    _migration_008_trigram_search,
 ]
 
 assert len(MIGRATIONS) == SCHEMA_VERSION, (

--- a/search_queries.py
+++ b/search_queries.py
@@ -1,0 +1,352 @@
+"""Search helpers shared by the TUI search panel.
+
+Keeps the query/parser logic free of Textual imports so the prefix path
+and fuzzy fallback can be unit-tested directly.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from typing import Any
+
+import db
+
+
+# Sentinel characters bracketing matched spans in snippet text. The TUI
+# converts these to highlighted Rich spans when rendering results.
+FTS_MATCH_START = "\x01"
+FTS_MATCH_END = "\x02"
+
+_FALLBACK_MIN_SCORE = 0.55
+_FALLBACK_CANDIDATE_LIMIT = 200
+
+
+def _parse_search_query(raw: str) -> tuple[list[str], str | None, str | None]:
+    """Parse raw input into (search_terms, role_filter, project_filter)."""
+    tokens = raw.strip().split()
+    role: str | None = None
+    project: str | None = None
+    terms: list[str] = []
+    for tok in tokens:
+        low = tok.lower()
+        if low == "user:":
+            role = "user"
+        elif low == "assistant:":
+            role = "assistant"
+        elif low.startswith("project:"):
+            val = tok[len("project:"):]
+            if val:
+                project = val
+        else:
+            clean = re.sub(r"[^\w]", "", tok)
+            if clean:
+                terms.append(clean)
+    return terms, role, project
+
+
+def _build_prefix_fts_query(terms: list[str]) -> str:
+    """Return an AND-ed FTS5 prefix expression for the supplied terms."""
+    return " ".join(term + "*" for term in terms)
+
+
+def _apply_message_filters(
+    sql: str,
+    params: dict[str, Any],
+    *,
+    role: str | None,
+    project: str | None,
+) -> tuple[str, dict[str, Any]]:
+    if role:
+        sql += " AND m.role = :role"
+        params["role"] = role
+    if project:
+        sql += " AND s.project LIKE :project"
+        params["project"] = f"%{project}%"
+    return sql, params
+
+
+def _search_filter_only(
+    conn: sqlite3.Connection,
+    *,
+    role: str | None,
+    project: str | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    sql = (
+        "SELECT m.uuid AS uuid, m.session_id AS session_id, "
+        "m.role AS role, m.timestamp AS timestamp, "
+        "substr(m.text, 1, 160) AS snippet, "
+        "s.custom_name AS custom_name, s.project AS project, "
+        "s.session_path AS session_path "
+        "FROM messages m "
+        "LEFT JOIN sessions s ON s.session_id = m.session_id "
+        "WHERE 1=1"
+    )
+    params: dict[str, Any] = {}
+    sql, params = _apply_message_filters(sql, params, role=role, project=project)
+    sql += " ORDER BY m.timestamp DESC LIMIT :lim"
+    params["lim"] = limit
+    return db.query_all(conn, sql, params)
+
+
+def _search_prefix(
+    conn: sqlite3.Connection,
+    *,
+    fts_expr: str,
+    role: str | None,
+    project: str | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    sql = (
+        "SELECT m.uuid AS uuid, m.session_id AS session_id, "
+        "m.role AS role, m.timestamp AS timestamp, "
+        "snippet(messages_fts, 0, :mstart, :mend, '…', 16) AS snippet, "
+        "s.custom_name AS custom_name, s.project AS project, "
+        "s.session_path AS session_path "
+        "FROM messages_fts "
+        "JOIN messages m ON m.rowid = messages_fts.rowid "
+        "LEFT JOIN sessions s ON s.session_id = m.session_id "
+        "WHERE messages_fts MATCH :q"
+    )
+    params: dict[str, Any] = {
+        "q": fts_expr,
+        "mstart": FTS_MATCH_START,
+        "mend": FTS_MATCH_END,
+    }
+    sql, params = _apply_message_filters(sql, params, role=role, project=project)
+    sql += " ORDER BY rank LIMIT :lim"
+    params["lim"] = limit
+    return db.query_all(conn, sql, params)
+
+
+def _term_trigrams(term: str) -> set[str]:
+    low = term.lower()
+    if len(low) < 3:
+        return set()
+    return {low[i:i + 3] for i in range(len(low) - 2)}
+
+
+def _build_trigram_match_expr(terms: list[str]) -> str:
+    trigrams: set[str] = set()
+    for term in terms:
+        trigrams.update(_term_trigrams(term))
+    return " OR ".join(sorted(trigrams))
+
+
+def _search_trigram_candidates(
+    conn: sqlite3.Connection,
+    *,
+    trigram_expr: str,
+    role: str | None,
+    project: str | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    sql = (
+        "SELECT m.uuid AS uuid, m.session_id AS session_id, "
+        "m.role AS role, m.timestamp AS timestamp, "
+        "m.text AS text, "
+        "s.custom_name AS custom_name, s.project AS project, "
+        "s.session_path AS session_path, "
+        "bm25(messages_fts_trigram) AS trigram_rank "
+        "FROM messages_fts_trigram "
+        "JOIN messages m ON m.rowid = messages_fts_trigram.rowid "
+        "LEFT JOIN sessions s ON s.session_id = m.session_id "
+        "WHERE messages_fts_trigram MATCH :q"
+    )
+    params: dict[str, Any] = {"q": trigram_expr}
+    sql, params = _apply_message_filters(sql, params, role=role, project=project)
+    sql += " ORDER BY trigram_rank LIMIT :lim"
+    params["lim"] = limit
+    return db.query_all(conn, sql, params)
+
+
+def _similarity(query_term: str, candidate_word: str) -> float:
+    query = query_term.lower()
+    candidate = candidate_word.lower()
+    if not query or not candidate:
+        return 0.0
+    if query == candidate:
+        return 1.0
+    if query in candidate:
+        return max(0.8, len(query) / len(candidate))
+    if candidate in query:
+        return max(0.7, len(candidate) / len(query))
+
+    q_trigrams = _term_trigrams(query)
+    c_trigrams = _term_trigrams(candidate)
+    if not q_trigrams or not c_trigrams:
+        return 0.0
+    overlap = len(q_trigrams & c_trigrams)
+    if overlap == 0:
+        return 0.0
+    return (2.0 * overlap) / (len(q_trigrams) + len(c_trigrams))
+
+
+def _score_candidate_row(
+    row: dict[str, Any],
+    query_terms: list[str],
+) -> tuple[float, str | None] | None:
+    text = str(row.get("text") or "")
+    words = re.findall(r"\w+", text)
+    if not words:
+        return None
+
+    scores: list[float] = []
+    best_word: str | None = None
+    best_word_score = 0.0
+
+    for term in query_terms:
+        best_score = 0.0
+        best_for_term: str | None = None
+        for word in words:
+            score = _similarity(term, word)
+            if score > best_score:
+                best_score = score
+                best_for_term = word
+            if best_score >= 1.0:
+                break
+        if best_score < _FALLBACK_MIN_SCORE:
+            return None
+        scores.append(best_score)
+        if best_score > best_word_score:
+            best_word = best_for_term
+            best_word_score = best_score
+
+    if not scores:
+        return None
+    return sum(scores) / len(scores), best_word
+
+
+def _build_fallback_snippet(text: str, highlight_term: str | None) -> str:
+    if not text:
+        return ""
+    if not highlight_term:
+        return text[:160]
+
+    match = re.search(re.escape(highlight_term), text, flags=re.IGNORECASE)
+    if not match:
+        return text[:160]
+
+    start = max(0, match.start() - 60)
+    end = min(len(text), max(start + 160, match.end() + 60))
+    snippet = text[start:end]
+    rel_start = match.start() - start
+    rel_end = match.end() - start
+
+    parts = []
+    if start > 0:
+        parts.append("…")
+    parts.append(snippet[:rel_start])
+    parts.append(FTS_MATCH_START)
+    parts.append(snippet[rel_start:rel_end])
+    parts.append(FTS_MATCH_END)
+    parts.append(snippet[rel_end:])
+    if end < len(text):
+        parts.append("…")
+    return "".join(parts)
+
+
+def _search_trigram_fallback(
+    conn: sqlite3.Connection,
+    *,
+    query_terms: list[str],
+    role: str | None,
+    project: str | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    trigram_expr = _build_trigram_match_expr(query_terms)
+    if not trigram_expr:
+        return []
+
+    candidates = _search_trigram_candidates(
+        conn,
+        trigram_expr=trigram_expr,
+        role=role,
+        project=project,
+        limit=max(limit * 4, _FALLBACK_CANDIDATE_LIMIT),
+    )
+
+    scored: list[tuple[float, float, dict[str, Any], str | None]] = []
+    for row in candidates:
+        result = _score_candidate_row(row, query_terms)
+        if result is None:
+            continue
+        score, highlight_term = result
+        trigram_rank = float(row.get("trigram_rank") or 0.0)
+        scored.append((score, trigram_rank, row, highlight_term))
+
+    scored.sort(key=lambda item: (-item[0], item[1], item[2].get("timestamp") or ""))
+
+    results: list[dict[str, Any]] = []
+    for score, _, row, highlight_term in scored[:limit]:
+        results.append(
+            {
+                "uuid": row.get("uuid"),
+                "session_id": row.get("session_id"),
+                "role": row.get("role"),
+                "timestamp": row.get("timestamp"),
+                "snippet": _build_fallback_snippet(
+                    str(row.get("text") or ""),
+                    highlight_term,
+                ),
+                "custom_name": row.get("custom_name"),
+                "project": row.get("project"),
+                "session_path": row.get("session_path"),
+                "score": score,
+            }
+        )
+    return results
+
+
+def search_messages(
+    conn: sqlite3.Connection,
+    raw_query: str,
+    limit: int = 50,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Run the search-panel query.
+
+    Returns ``(rows, used_fuzzy_fallback)``. The trigram path only runs
+    when the primary FTS5 prefix query returns zero rows.
+    """
+    query_terms, role, project = _parse_search_query(raw_query)
+
+    if not query_terms:
+        if not role and not project:
+            return [], False
+        try:
+            return _search_filter_only(
+                conn,
+                role=role,
+                project=project,
+                limit=limit,
+            ), False
+        except sqlite3.OperationalError:
+            return [], False
+
+    try:
+        rows = _search_prefix(
+            conn,
+            fts_expr=_build_prefix_fts_query(query_terms),
+            role=role,
+            project=project,
+            limit=limit,
+        )
+    except sqlite3.OperationalError:
+        rows = []
+
+    if rows:
+        return rows, False
+
+    try:
+        fallback_rows = _search_trigram_fallback(
+            conn,
+            query_terms=query_terms,
+            role=role,
+            project=project,
+            limit=limit,
+        )
+    except sqlite3.OperationalError:
+        fallback_rows = []
+
+    return fallback_rows, bool(fallback_rows)

--- a/tests/test_search_queries.py
+++ b/tests/test_search_queries.py
@@ -1,0 +1,142 @@
+"""Tests for prefix search plus trigram fallback."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import db
+import search_queries
+
+
+def _seed_message(
+    conn,
+    *,
+    session_id: str,
+    project: str,
+    uuid: str,
+    role: str,
+    text: str,
+    timestamp: str = "2026-04-20T10:00:00Z",
+) -> None:
+    session_path = str(Path("/tmp") / project / f"{session_id}.jsonl")
+    db.upsert_session(
+        conn,
+        session_id,
+        session_path,
+        project=project,
+        created_at=1.0,
+        modified_at=1.0,
+    )
+    conn.execute(
+        """
+        INSERT INTO messages (uuid, session_id, role, text, timestamp)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (uuid, session_id, role, text, timestamp),
+    )
+
+
+def test_prefix_hit_does_not_invoke_fuzzy_fallback(conn, monkeypatch):
+    _seed_message(
+        conn,
+        session_id="s1",
+        project="atlas",
+        uuid="m1",
+        role="assistant",
+        text="Retry the request after reconnecting.",
+    )
+
+    def _boom(*args, **kwargs):  # pragma: no cover - should never run
+        raise AssertionError("fuzzy fallback should not run on exact prefix hits")
+
+    monkeypatch.setattr(search_queries, "_search_trigram_fallback", _boom)
+
+    rows, used_fallback = search_queries.search_messages(conn, "retry", limit=10)
+
+    assert used_fallback is False
+    assert [row["uuid"] for row in rows] == ["m1"]
+
+
+def test_trigram_fallback_matches_inserted_typo(conn):
+    _seed_message(
+        conn,
+        session_id="s1",
+        project="atlas",
+        uuid="m1",
+        role="assistant",
+        text="Use connect() first, then retry with backoff.",
+    )
+
+    rows, used_fallback = search_queries.search_messages(conn, "connnect", limit=10)
+
+    assert used_fallback is True
+    assert [row["uuid"] for row in rows] == ["m1"]
+    assert "connect" in rows[0]["snippet"].lower()
+    assert search_queries.FTS_MATCH_START in rows[0]["snippet"]
+    assert search_queries.FTS_MATCH_END in rows[0]["snippet"]
+
+
+def test_trigram_fallback_still_respects_role_and_project_filters(conn):
+    _seed_message(
+        conn,
+        session_id="s1",
+        project="atlas",
+        uuid="m1",
+        role="assistant",
+        text="Use connect() first, then retry with backoff.",
+    )
+    _seed_message(
+        conn,
+        session_id="s2",
+        project="apollo",
+        uuid="m2",
+        role="user",
+        text="Maybe connect again once the socket is reset.",
+    )
+
+    rows, used_fallback = search_queries.search_messages(
+        conn,
+        "assistant: project:atlas connnect",
+        limit=10,
+    )
+
+    assert used_fallback is True
+    assert [row["uuid"] for row in rows] == ["m1"]
+
+
+def test_migration_rebuilds_trigram_index_for_existing_messages(tmp_path):
+    db_path = tmp_path / "legacy.db"
+    conn = db.connect(db_path)
+    try:
+        for i, migration in enumerate(db.MIGRATIONS[:7]):
+            conn.execute("BEGIN")
+            try:
+                migration(conn)
+                db._set_schema_version(conn, i + 1)
+                conn.execute("COMMIT")
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
+
+        _seed_message(
+            conn,
+            session_id="s1",
+            project="atlas",
+            uuid="m1",
+            role="assistant",
+            text="Use connect() first, then retry with backoff.",
+        )
+
+        assert db.get_schema_version(conn) == 7
+
+        db.apply_migrations(conn)
+
+        rows, used_fallback = search_queries.search_messages(
+            conn, "connnect", limit=10
+        )
+
+        assert db.get_schema_version(conn) == 8
+        assert used_fallback is True
+        assert [row["uuid"] for row in rows] == ["m1"]
+    finally:
+        conn.close()

--- a/threadhop
+++ b/threadhop
@@ -16,6 +16,7 @@ import signal
 import sqlite3
 import subprocess
 import sys
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -40,6 +41,7 @@ import cli_queries  # noqa: E402
 import handoff as handoff_mod  # noqa: E402
 import observation_queries  # noqa: E402
 import observer  # noqa: E402
+import search_queries  # noqa: E402
 
 
 def get_available_themes():
@@ -1510,143 +1512,24 @@ class TranscriptView(VerticalScroll):
 #   assistant:      — only role = 'assistant'
 # Remaining whitespace-separated tokens become FTS5 prefix terms.
 
-# Sentinel characters bracketing matched spans in the SQL `snippet()`
-# output. Using control chars avoids collisions with user text. Parsed
-# back out by `_render_snippet` into Rich Text with a highlight style.
-_FTS_MATCH_START = "\x01"
-_FTS_MATCH_END = "\x02"
-
-
-def _build_fts_query(raw: str) -> tuple[str, str | None, str | None]:
-    """Parse raw input into (fts_match_expr, role_filter, project_filter).
-
-    The FTS5 expression uses AND semantics across prefix terms
-    (e.g. ``rate* lim*``). Non-filter tokens are sanitized to word chars
-    only so stray punctuation can't produce an invalid MATCH expression.
-    An empty expression means no searchable terms were supplied —
-    callers may still return filter-only results (see `search_messages`).
-    """
-    tokens = raw.strip().split()
-    role: str | None = None
-    project: str | None = None
-    terms: list[str] = []
-    for tok in tokens:
-        low = tok.lower()
-        if low == "user:":
-            role = "user"
-        elif low == "assistant:":
-            role = "assistant"
-        elif low.startswith("project:"):
-            val = tok[len("project:"):]
-            if val:
-                project = val
-        else:
-            # Keep only word chars (letters/digits/underscore). FTS5's
-            # unicode61 tokenizer is fine with these, and stripping
-            # punctuation prevents syntax errors at MATCH time.
-            clean = re.sub(r"[^\w]", "", tok)
-            if clean:
-                terms.append(clean + "*")
-    return " ".join(terms), role, project
-
-
-def search_messages(
-    conn: sqlite3.Connection,
-    raw_query: str,
-    limit: int = 50,
-) -> list[dict]:
-    """Run the FTS5 search for the search panel.
-
-    Returns rows with keys: uuid, session_id, role, timestamp, snippet,
-    custom_name, project, session_path. ``snippet`` contains
-    _FTS_MATCH_START / _FTS_MATCH_END sentinels around each match span.
-
-    A malformed FTS5 expression (shouldn't happen after sanitization, but
-    defensive) returns an empty list rather than propagating the
-    exception up into the TUI event loop.
-    """
-    fts_expr, role, project = _build_fts_query(raw_query)
-
-    # No search terms: allow a filter-only query so typing just
-    # `project:foo` lists recent messages in that project.
-    if not fts_expr:
-        if not role and not project:
-            return []
-        sql = (
-            "SELECT m.uuid AS uuid, m.session_id AS session_id, "
-            "m.role AS role, m.timestamp AS timestamp, "
-            "substr(m.text, 1, 160) AS snippet, "
-            "s.custom_name AS custom_name, s.project AS project, "
-            "s.session_path AS session_path "
-            "FROM messages m "
-            "LEFT JOIN sessions s ON s.session_id = m.session_id "
-            "WHERE 1=1"
-        )
-        params: dict = {}
-        if role:
-            sql += " AND m.role = :role"
-            params["role"] = role
-        if project:
-            sql += " AND s.project LIKE :project"
-            params["project"] = f"%{project}%"
-        sql += " ORDER BY m.timestamp DESC LIMIT :lim"
-        params["lim"] = limit
-        try:
-            return db.query_all(conn, sql, params)
-        except sqlite3.OperationalError:
-            return []
-
-    sql = (
-        "SELECT m.uuid AS uuid, m.session_id AS session_id, "
-        "m.role AS role, m.timestamp AS timestamp, "
-        "snippet(messages_fts, 0, :mstart, :mend, '…', 16) AS snippet, "
-        "s.custom_name AS custom_name, s.project AS project, "
-        "s.session_path AS session_path "
-        "FROM messages_fts "
-        "JOIN messages m ON m.rowid = messages_fts.rowid "
-        "LEFT JOIN sessions s ON s.session_id = m.session_id "
-        "WHERE messages_fts MATCH :q"
-    )
-    params = {
-        "q": fts_expr,
-        "mstart": _FTS_MATCH_START,
-        "mend": _FTS_MATCH_END,
-    }
-    if role:
-        sql += " AND m.role = :role"
-        params["role"] = role
-    if project:
-        sql += " AND s.project LIKE :project"
-        params["project"] = f"%{project}%"
-    sql += " ORDER BY rank LIMIT :lim"
-    params["lim"] = limit
-
-    try:
-        return db.query_all(conn, sql, params)
-    except sqlite3.OperationalError:
-        # Malformed expressions still slip through on edge cases
-        # (e.g. a bare `*`). Surface as "no results" rather than crash.
-        return []
-
-
 def _render_snippet(snippet: str) -> Text:
     """Convert an FTS5 snippet with sentinel-wrapped matches to Rich Text."""
     out = Text()
     remaining = snippet or ""
     while True:
-        i = remaining.find(_FTS_MATCH_START)
+        i = remaining.find(search_queries.FTS_MATCH_START)
         if i < 0:
             out.append(remaining)
             break
         out.append(remaining[:i])
-        remaining = remaining[i + len(_FTS_MATCH_START):]
-        j = remaining.find(_FTS_MATCH_END)
+        remaining = remaining[i + len(search_queries.FTS_MATCH_START):]
+        j = remaining.find(search_queries.FTS_MATCH_END)
         if j < 0:
             # Unterminated — highlight the rest and stop.
             out.append(remaining, style="bold black on yellow")
             break
         out.append(remaining[:j], style="bold black on yellow")
-        remaining = remaining[j + len(_FTS_MATCH_END):]
+        remaining = remaining[j + len(search_queries.FTS_MATCH_END):]
     return out
 
 
@@ -1795,7 +1678,7 @@ class SearchScreen(ModalScreen):
             container.border_title = "Search"
             yield Input(
                 placeholder=(
-                    "Search (prefix match) — "
+                    "Search (prefix first, fuzzy fallback) — "
                     "filters: project:<name> user: assistant:"
                 ),
                 id="search-input",
@@ -1838,7 +1721,11 @@ class SearchScreen(ModalScreen):
             return
 
         try:
-            rows = search_messages(self.conn, raw, limit=50)
+            started_at = time.perf_counter()
+            rows, used_fallback = search_queries.search_messages(
+                self.conn, raw, limit=50
+            )
+            elapsed_ms = (time.perf_counter() - started_at) * 1000.0
         except Exception as e:  # noqa: BLE001
             results_list.clear()
             status.update(f"Search error: {e}")
@@ -1850,11 +1737,15 @@ class SearchScreen(ModalScreen):
 
         count = len(rows)
         if count == 0:
-            status.update("No results")
+            status.update(f"No results in {elapsed_ms:.1f} ms")
         else:
             noun = "result" if count == 1 else "results"
+            prefix = "Fuzzy fallback: " if used_fallback else ""
             status.update(
-                f"{count} {noun}" + (" (showing first 50)" if count >= 50 else "")
+                prefix
+                + f"{count} {noun}"
+                + (" (showing first 50)" if count >= 50 else "")
+                + f" in {elapsed_ms:.1f} ms"
             )
 
     def on_key(self, event) -> None:


### PR DESCRIPTION
Add trigram-based fuzzy search for typo tolerance (blocked by task #14).

Requirements:
- Add a secondary FTS5 virtual table using the trigram tokenizer
- Fall back to the trigram table when the primary FTS5 prefix query returns zero results
- Should handle spelling mistakes (e.g., `retr` matches `retry`, `connnect` matches `connect`)
- Keep this strictly as a fallback — do not slow down the primary search path
- Expose it as part of the same `/` search panel from task #14

Only add when volume/user experience demands it.

Reference: ADR-007 in docs/DESIGN-DECISIONS.md

Testing:
- `python3 -m pytest tests/test_search_queries.py tests/test_incremental_index.py -q`
- `uv run --with pytest --with rich --with textual --with watchdog --with pydantic python -m pytest tests/test_search_panel.py -q`