### PR TITLE
Add chat bookmark ingest path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ The project is expanding from a transcript viewer into a cross-session context m
 
 # CLI subcommands (all accept --project / --session)
 ./threadhop tag <status>            # backlog|in_progress|in_review|done|archived
+./threadhop bookmark [kind]         # bookmark|research against latest msg or --message <uuid>
 ./threadhop todos                   # open TODOs from observations
 ./threadhop decisions               # decisions extracted by observer
 ./threadhop observations            # raw observation JSONL, newest first
@@ -97,5 +98,6 @@ Every message line has native fields useful for indexing:
 
 ## In Progress
 
+- Chat-side bookmark ingest uses `threadhop bookmark [bookmark|research]` and defaults to the latest message in the current detected session
 - Skill plugin `/threadhop:handoff <session_id>` sits on top of the observer/reflector pipeline and is still being assembled
 - See `docs/DESIGN-DECISIONS.md` for ADRs and the phase roadmap, and `docs/TASKS.md` for open tasks

--- a/README.md
+++ b/README.md
@@ -126,6 +126,73 @@ Prefer a slash-style trigger? A Claude Code `UserPromptSubmit` hook can intercep
 
 The hook reads the prompt from stdin as JSON, matches `/tag <status>`, invokes `threadhop tag`, and exits `2` — which tells Claude Code to block the submission and show the stderr output to the user.
 
+## Bookmarking from inside Claude Code
+
+Use the same `!` bash passthrough pattern to bookmark the current conversation without opening the TUI first.
+
+General keep-for-later bookmark against the latest message in the current session:
+
+```bash
+!threadhop bookmark
+```
+
+Research follow-up bookmark with a short note:
+
+```bash
+!threadhop bookmark research --note "compare retry strategies later"
+```
+
+Output:
+
+```text
+✓ bookmarked kind=research session=8f3b2a1c-... message=6d2e... role=assistant text="We should compare retry strategies later." note="compare retry strategies later"
+```
+
+Targeting rules:
+
+- Session auto-detect works the same way as `threadhop tag`: inside a live Claude Code terminal it walks the parent process tree for the current `claude` session.
+- Without `--message`, ThreadHop bookmarks the latest indexed message in that session.
+- If you need a specific message, pass `--session <id> --message <uuid>`.
+- Built-in classes are intentionally narrow for now: `bookmark` and `research`.
+
+The ingest path is shared and deterministic: chat commands use the same bookmark primitive that future TUI actions can call later.
+
+### Optional: `/bookmark` and `/research` via a UserPromptSubmit hook
+
+Prefer slash-style triggers? This hook blocks the prompt before it reaches the model and shells out to `threadhop bookmark`.
+
+1. Drop this script at `~/.claude/hooks/threadhop-bookmark.sh` and `chmod +x` it:
+
+    ```bash
+    #!/usr/bin/env bash
+    set -euo pipefail
+    INPUT=$(cat)
+    PROMPT=$(printf '%s' "$INPUT" | jq -r '.prompt')
+    if [[ "$PROMPT" =~ ^/bookmark([[:space:]]+(.*))?$ ]]; then
+      NOTE="${BASH_REMATCH[2]-}"
+      if [[ -n "$NOTE" ]]; then
+        threadhop bookmark --note "$NOTE" >&2
+      else
+        threadhop bookmark >&2
+      fi
+      exit 2
+    fi
+    if [[ "$PROMPT" =~ ^/research([[:space:]]+(.*))?$ ]]; then
+      NOTE="${BASH_REMATCH[2]-}"
+      if [[ -n "$NOTE" ]]; then
+        threadhop bookmark research --note "$NOTE" >&2
+      else
+        threadhop bookmark research >&2
+      fi
+      exit 2
+    fi
+    exit 0
+    ```
+
+2. Register it in `~/.claude/settings.json` the same way as the `/tag` example above.
+
+This gives you two low-friction chat-side buckets now, while keeping the app-side bookmark model ready for later generalized categories.
+
 ## Roadmap
 
 - Cross-session search (SQLite FTS5, per-keystroke)

--- a/db.py
+++ b/db.py
@@ -40,7 +40,7 @@ DB_PATH = DB_DIR / "sessions.db"
 # --- Schema version ---
 # Each migration N in MIGRATIONS moves the DB from version N to N+1.
 # The DB's current version lives in PRAGMA user_version.
-SCHEMA_VERSION = 7
+SCHEMA_VERSION = 8
 
 
 # --- Migrations -----------------------------------------------------------
@@ -361,7 +361,7 @@ def _migration_007_bookmarks(conn: sqlite3.Connection) -> None:
     :class:`models.Bookmark` shape declared for this table in
     ``models.py`` (task #24's model/schema lockstep rule). The tag
     *editor UX* is deferred — tracked separately — so the column exists
-    but only ``label`` has a TUI surface in this migration's companion
+    but only ``note`` has a TUI surface in this migration's companion
     commit.
     """
     conn.execute(
@@ -369,7 +369,9 @@ def _migration_007_bookmarks(conn: sqlite3.Connection) -> None:
         CREATE TABLE IF NOT EXISTS bookmarks (
             id           INTEGER PRIMARY KEY AUTOINCREMENT,
             message_uuid TEXT NOT NULL UNIQUE,
-            label        TEXT,
+            note         TEXT,
+            kind         TEXT NOT NULL DEFAULT 'bookmark'
+                CHECK (kind IN ('bookmark', 'research')),
             tags         TEXT NOT NULL DEFAULT '[]',
             created_at   REAL NOT NULL,
             FOREIGN KEY (message_uuid) REFERENCES messages(uuid)
@@ -380,6 +382,77 @@ def _migration_007_bookmarks(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_bookmarks_created_at "
         "ON bookmarks(created_at)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_bookmarks_kind_created_at "
+        "ON bookmarks(kind, created_at)"
+    )
+
+
+def _migration_008_bookmark_kinds_and_notes(conn: sqlite3.Connection) -> None:
+    """Evolve bookmarks from a TUI label into shared kind + note fields.
+
+    Task #59 will eventually replace the built-in ``kind`` enum with SQL-backed
+    arbitrary categories. This migration keeps today's ingest path stable by:
+
+    - renaming legacy ``label`` -> ``note`` so the data model is chat/TUI-neutral
+    - seeding every existing row as ``kind='bookmark'``
+    - retaining the one-bookmark-per-message invariant for the existing toggle UX
+
+    SQLite cannot add a CHECK constraint to an existing column in place, so we
+    rebuild the table inside the migration transaction.
+    """
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(bookmarks)").fetchall()}
+    if "note" in cols and "kind" in cols and "label" not in cols:
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_bookmarks_kind_created_at "
+            "ON bookmarks(kind, created_at)"
+        )
+        return
+
+    note_expr = "note" if "note" in cols else ("label" if "label" in cols else "NULL")
+    kind_expr = "kind" if "kind" in cols else "'bookmark'"
+    tags_expr = "tags" if "tags" in cols else "'[]'"
+
+    conn.execute(
+        """
+        CREATE TABLE bookmarks_v2 (
+            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            message_uuid TEXT NOT NULL UNIQUE,
+            note         TEXT,
+            kind         TEXT NOT NULL DEFAULT 'bookmark'
+                CHECK (kind IN ('bookmark', 'research')),
+            tags         TEXT NOT NULL DEFAULT '[]',
+            created_at   REAL NOT NULL,
+            FOREIGN KEY (message_uuid) REFERENCES messages(uuid)
+                ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        f"""
+        INSERT INTO bookmarks_v2 (
+            id, message_uuid, note, kind, tags, created_at
+        )
+        SELECT
+            id,
+            message_uuid,
+            {note_expr},
+            {kind_expr},
+            {tags_expr},
+            created_at
+        FROM bookmarks
+        """
+    )
+    conn.execute("DROP TABLE bookmarks")
+    conn.execute("ALTER TABLE bookmarks_v2 RENAME TO bookmarks")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_bookmarks_created_at "
+        "ON bookmarks(created_at)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_bookmarks_kind_created_at "
+        "ON bookmarks(kind, created_at)"
     )
 
 
@@ -392,6 +465,7 @@ MIGRATIONS: list = [
     _migration_005_conflict_reviews,
     _migration_006_sessions_status_check,
     _migration_007_bookmarks,
+    _migration_008_bookmark_kinds_and_notes,
 ]
 
 assert len(MIGRATIONS) == SCHEMA_VERSION, (
@@ -808,6 +882,13 @@ SESSION_STATUS_ORDER: list[str] = [
     "done",
     "archived",
 ]
+
+BOOKMARK_KIND_ORDER: list[str] = [
+    "bookmark",
+    "research",
+]
+
+_BOOKMARK_NOTE_UNSET = object()
 
 
 def get_session(
@@ -1352,17 +1433,133 @@ def _decode_bookmark_tags(row: dict | None) -> dict | None:
     return row
 
 
+def _normalize_bookmark_kind(kind: str) -> str:
+    """Validate and normalize the built-in bookmark class name."""
+    clean = (kind or "").strip().lower()
+    if clean not in BOOKMARK_KIND_ORDER:
+        raise ValueError(
+            f"invalid bookmark kind {kind!r}; "
+            f"expected one of {BOOKMARK_KIND_ORDER}"
+        )
+    return clean
+
+
+def _normalize_bookmark_note(note: str | None) -> str | None:
+    """Trim a free-text note; blank strings collapse to NULL."""
+    clean = note.strip() if note else ""
+    return clean or None
+
+
 def get_bookmark(
     conn: sqlite3.Connection, message_uuid: str
 ) -> dict | None:
     """Return the bookmark row for ``message_uuid`` or None."""
     row = query_one(
         conn,
-        "SELECT id, message_uuid, label, tags, created_at FROM bookmarks "
+        "SELECT id, message_uuid, note, kind, tags, created_at FROM bookmarks "
         "WHERE message_uuid = ?",
         (message_uuid,),
     )
     return _decode_bookmark_tags(row)
+
+
+def get_message(
+    conn: sqlite3.Connection,
+    message_uuid: str,
+    *,
+    session_id: str | None = None,
+) -> dict | None:
+    """Return one message row, optionally scoped to a specific session."""
+    sql = (
+        "SELECT uuid, session_id, role, text, timestamp, cwd, parent_uuid, "
+        "       is_sidechain, message_id "
+        "FROM messages WHERE uuid = ?"
+    )
+    params: list[str] = [message_uuid]
+    if session_id is not None:
+        sql += " AND session_id = ?"
+        params.append(session_id)
+    return query_one(conn, sql, tuple(params))
+
+
+def get_latest_message(
+    conn: sqlite3.Connection,
+    session_id: str,
+) -> dict | None:
+    """Return the newest indexed message for ``session_id``.
+
+    Uses ``rowid`` rather than ``timestamp`` as the primary ordering key so the
+    "latest visible message" matches transcript append order even when multiple
+    rows share the same second-level timestamp.
+    """
+    return query_one(
+        conn,
+        "SELECT uuid, session_id, role, text, timestamp, cwd, parent_uuid, "
+        "       is_sidechain, message_id "
+        "FROM messages WHERE session_id = ? "
+        "ORDER BY rowid DESC LIMIT 1",
+        (session_id,),
+    )
+
+
+def resolve_bookmark_target(
+    conn: sqlite3.Connection,
+    *,
+    session_id: str,
+    message_uuid: str | None = None,
+) -> dict | None:
+    """Resolve a bookmark target to one concrete indexed message row."""
+    if message_uuid:
+        return get_message(conn, message_uuid, session_id=session_id)
+    return get_latest_message(conn, session_id)
+
+
+def upsert_bookmark(
+    conn: sqlite3.Connection,
+    message_uuid: str,
+    *,
+    kind: str = "bookmark",
+    note: str | None | object = _BOOKMARK_NOTE_UNSET,
+    created_at: float | None = None,
+) -> dict:
+    """Create or update the shared bookmark record for one message.
+
+    This is the forward-compatible ingest primitive used by chat commands today
+    and by richer UIs later. Unlike ``toggle_bookmark``, it is deterministic:
+    the row exists after the call and carries the requested built-in class.
+    """
+    kind = _normalize_bookmark_kind(kind)
+    ts = created_at if created_at is not None else datetime.now().timestamp()
+    existing = get_bookmark(conn, message_uuid)
+    if existing is None:
+        clean_note = None if note is _BOOKMARK_NOTE_UNSET else _normalize_bookmark_note(note)
+        cur = conn.execute(
+            "INSERT INTO bookmarks (message_uuid, note, kind, tags, created_at) "
+            "VALUES (?, ?, ?, '[]', ?)",
+            (message_uuid, clean_note, kind, ts),
+        )
+        return {
+            "id": cur.lastrowid,
+            "message_uuid": message_uuid,
+            "note": clean_note,
+            "kind": kind,
+            "tags": [],
+            "created_at": ts,
+        }
+
+    clean_note = (
+        existing.get("note")
+        if note is _BOOKMARK_NOTE_UNSET
+        else _normalize_bookmark_note(note)
+    )
+    conn.execute(
+        "UPDATE bookmarks SET note = ?, kind = ?, created_at = ? WHERE id = ?",
+        (clean_note, kind, ts, existing["id"]),
+    )
+    existing["note"] = clean_note
+    existing["kind"] = kind
+    existing["created_at"] = ts
+    return existing
 
 
 def toggle_bookmark(
@@ -1372,11 +1569,10 @@ def toggle_bookmark(
 ) -> dict | None:
     """Toggle a bookmark on ``message_uuid``.
 
-    Returns the new bookmark dict on create, or ``None`` on delete so
-    callers can show the right toast ("Bookmarked" vs "Removed"). New
-    rows start with an empty tag list — tag editing is a follow-up to
-    this feature, but the column exists so the schema matches
-    :class:`models.Bookmark`.
+    Returns the new bookmark dict on create, or ``None`` on delete so callers
+    can show the right toast ("Bookmarked" vs "Removed"). New rows start as the
+    built-in ``bookmark`` kind with no note; richer category editing is a
+    follow-up to this ingest path.
     """
     existing = get_bookmark(conn, message_uuid)
     if existing is not None:
@@ -1384,17 +1580,31 @@ def toggle_bookmark(
         return None
     ts = created_at if created_at is not None else datetime.now().timestamp()
     cur = conn.execute(
-        "INSERT INTO bookmarks (message_uuid, label, tags, created_at) "
-        "VALUES (?, NULL, '[]', ?)",
+        "INSERT INTO bookmarks (message_uuid, note, kind, tags, created_at) "
+        "VALUES (?, NULL, 'bookmark', '[]', ?)",
         (message_uuid, ts),
     )
     return {
         "id": cur.lastrowid,
         "message_uuid": message_uuid,
-        "label": None,
+        "note": None,
+        "kind": "bookmark",
         "tags": [],
         "created_at": ts,
     }
+
+
+def set_bookmark_note(
+    conn: sqlite3.Connection,
+    bookmark_id: int,
+    note: str | None,
+) -> None:
+    """Update a bookmark's note. Empty strings collapse to NULL."""
+    clean = _normalize_bookmark_note(note)
+    conn.execute(
+        "UPDATE bookmarks SET note = ? WHERE id = ?",
+        (clean, bookmark_id),
+    )
 
 
 def set_bookmark_label(
@@ -1402,12 +1612,8 @@ def set_bookmark_label(
     bookmark_id: int,
     label: str | None,
 ) -> None:
-    """Update a bookmark's label. Empty strings collapse to NULL."""
-    clean = label.strip() if label else ""
-    conn.execute(
-        "UPDATE bookmarks SET label = ? WHERE id = ?",
-        (clean or None, bookmark_id),
-    )
+    """Backward-compatible alias for the pre-note bookmark editor."""
+    set_bookmark_note(conn, bookmark_id, label)
 
 
 def delete_bookmark(conn: sqlite3.Connection, bookmark_id: int) -> None:
@@ -1422,12 +1628,12 @@ def list_bookmarks(
 ) -> list[dict]:
     """Return bookmarks joined with message + session metadata, newest first.
 
-    ``query`` is an optional case-insensitive substring filter applied
-    across the label, the message body, and the session's project /
+    ``query`` is an optional case-insensitive substring filter applied across
+    the note, kind, the message body, and the session's project /
     custom name — mirrors the single filter input in the browser modal.
     """
     sql = (
-        "SELECT b.id, b.message_uuid, b.label, b.tags, b.created_at, "
+        "SELECT b.id, b.message_uuid, b.note, b.kind, b.tags, b.created_at, "
         "       m.session_id, m.role, m.text, m.timestamp, "
         "       s.custom_name, s.project "
         "FROM bookmarks b "
@@ -1437,11 +1643,11 @@ def list_bookmarks(
     params: tuple = ()
     if query:
         sql += (
-            "WHERE b.label LIKE ? OR m.text LIKE ? "
+            "WHERE b.note LIKE ? OR b.kind LIKE ? OR m.text LIKE ? "
             "OR s.custom_name LIKE ? OR s.project LIKE ? "
         )
         like = f"%{query}%"
-        params = (like, like, like, like)
+        params = (like, like, like, like, like)
     sql += "ORDER BY b.created_at DESC LIMIT ?"
     params = params + (limit,)
     rows = query_all(conn, sql, params)

--- a/docs/DESIGN-DECISIONS.md
+++ b/docs/DESIGN-DECISIONS.md
@@ -1476,11 +1476,12 @@ CREATE TABLE index_state (
 CREATE TABLE bookmarks (
     id            INTEGER PRIMARY KEY,
     message_uuid  TEXT NOT NULL,
-    session_id    TEXT NOT NULL,
-    label         TEXT,
+    note          TEXT,
+    kind          TEXT NOT NULL DEFAULT 'bookmark',
+        -- bookmark | research (task #59 later generalizes this)
     tags          TEXT,               -- JSON array
     created_at    REAL NOT NULL,
-    FOREIGN KEY (session_id) REFERENCES sessions(session_id)
+    FOREIGN KEY (message_uuid) REFERENCES messages(uuid)
 );
 
 -- Project memory ledger
@@ -1517,7 +1518,7 @@ CREATE TABLE observation_state (
 
 ## Skill Plugin Architecture
 
-### Principle: Four skills + bash passthrough for tagging, clear boundaries
+### Principle: Four skills + bash passthrough for tagging/bookmark ingest, clear boundaries
 
 Skills are for operations invoked mid-conversation from Claude Code. The TUI
 handles everything visual and instantaneous. The CLI handles queries and tagging
@@ -1536,7 +1537,9 @@ threadhop/
     insights.md         # /threadhop:insights
 
 # Tagging: !threadhop tag <status> (bash passthrough, no skill needed)
-# Optional: ~/.claude/hooks/threadhop-tag.sh for /tag <status> ergonomics — see README
+# Bookmark ingest: !threadhop bookmark [bookmark|research] [--note "..."]
+# Optional: ~/.claude/hooks/threadhop-tag.sh and threadhop-bookmark.sh for
+# /tag, /bookmark, /research ergonomics — see README
 ```
 
 ### What lives where
@@ -1546,7 +1549,7 @@ threadhop/
 | Search | TUI | Per-keystroke instant, visual results |
 | Message select + copy | TUI | Visual selection, clipboard transport |
 | Message export to .md | TUI | Visual selection, writes to /tmp |
-| Bookmark | TUI | Visual selection, one-key action |
+| Bookmark ingest | CLI + `!` bash passthrough + TUI | Shared primitive targets a session/message; TUI keeps a lightweight toggle seam |
 | Tag session | TUI + CLI + `!` bash passthrough | Three entry points, one DB (ADR-013) |
 | Observation queries | CLI | `threadhop todos`, `threadhop decisions` |
 | Start observation | Skill + TUI | Per-session opt-in, spawns background process |
@@ -1769,7 +1772,7 @@ For larger exports:
 - [ ] `O` key: resume observation on stopped session (ADR-021)
 
 ### Phase 5: Memory + Bookmarks
-- [ ] Build bookmark system (TUI feature)
+- [ ] Build bookmark system (shared ingest primitive + TUI/browser surfaces)
 - [ ] Explicit annotation detection (ADR:, DECISION:, TODO: markers)
 - [ ] Project memory markdown rendering from observations
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -179,7 +179,7 @@ and transcript header (ADR-021)._
 _Cross-session knowledge persistence (beyond the raw observations log)._
 
 - [ ] **27. Build bookmark system** *(blocked by: #1, #10)*
-  Add `bookmarks` table to schema. Toggle bookmark from message selection mode with `space`. Support labels and tags (JSON array). Build bookmark browser panel in TUI.
+  Add `bookmarks` table to schema and a shared bookmark-ingest primitive. Keep the initial built-in classes intentionally narrow: `bookmark` and `research`. Support an optional short note and retain tags (JSON array) as forward-compatible storage. TUI `space` keeps the lightweight toggle path for plain bookmarks, while chat/skill/plugin integrations call the same shared primitive through a scriptable CLI entrypoint. Build bookmark browser panel in TUI.
 
 - [ ] **28. Build project memory ledger** *(blocked by: #1)*
   Add `memory` table to schema. Support typed entries: `decision | todo | done | adr | observation`. Append-only, filterable by project/type/date. Manual entry from TUI (type + text). Distinct from per-session observation files: this is for curated/explicit entries with `source: 'explicit'`. _(ADR-005)_

--- a/models.py
+++ b/models.py
@@ -61,6 +61,13 @@ MemoryType = Literal["decision", "todo", "done", "adr", "observation"]
 MemorySource = Literal["explicit", "auto"]
 """Whether a memory entry came from a human annotation or the auto-observer."""
 
+BookmarkKind = Literal["bookmark", "research"]
+"""Built-in bookmark classes for the initial chat-ingest pathway.
+
+Task #59 is expected to generalize this into SQL-backed category rows. Until
+then, keep this Literal and the CHECK in ``db.py`` in lockstep.
+"""
+
 
 # --- DB row shapes -------------------------------------------------------
 # One Pydantic model per SQL table. The model is the authoritative Python
@@ -114,18 +121,20 @@ class Message(BaseModel):
 
 
 class Bookmark(BaseModel):
-    """One row of the ``bookmarks`` table (created by the migration for task #18).
+    """One row of the ``bookmarks`` table.
 
-    ``tags`` is stored as a JSON-encoded string in SQL; this model exposes
-    the decoded list so callers don't round-trip JSON twice.
+    ``kind`` is intentionally narrow for the first chat-ingest pathway:
+    ``bookmark`` for general keep-for-later items and ``research`` for deferred
+    research follow-up. ``tags`` remains as a JSON-encoded string in SQL so the
+    later generalized-category work can layer on without rewriting every caller.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     id: int | None = None  # autoincrement — None when inserting
     message_uuid: str
-    session_id: str
-    label: str | None = None
+    note: str | None = None
+    kind: BookmarkKind = "bookmark"
     tags: list[str] = Field(default_factory=list)
     created_at: float
 

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -1,12 +1,12 @@
-"""Tests for the bookmarks helpers in db.py (task #18).
+"""Tests for the shared bookmark helpers in ``db.py``.
 
-Focuses on the contract the TUI relies on:
-  - toggle is idempotent per-uuid (space keybind flips a single state)
-  - label round-trips, blanks collapse to NULL
-  - list_bookmarks returns newest-first with the joined metadata the
-    browser modal renders (session / project / timestamp / role / text)
-  - filter matches against label, message text, project, custom_name
-  - cascade delete removes orphan bookmarks when messages disappear
+Focuses on the contracts both the TUI and chat-ingest path rely on:
+  - toggle remains idempotent per-uuid for the existing TUI keybind
+  - upsert is deterministic and stores the built-in ``kind`` + optional note
+  - latest-message target resolution is session-scoped
+  - list_bookmarks returns newest-first with the joined metadata the browser
+    renders and filters across note/kind/text/session fields
+  - migration upgrades legacy ``label`` rows into ``note`` + ``kind``
 """
 
 from __future__ import annotations
@@ -52,31 +52,76 @@ def test_toggle_creates_then_removes(conn):
     first = db.toggle_bookmark(conn, "u1", created_at=500.0)
     assert first is not None
     assert first["message_uuid"] == "u1"
-    assert first["label"] is None
-    # Tags column lives in the schema to match models.Bookmark even
-    # though the editor UI is deferred — new rows default to [].
+    assert first["note"] is None
+    assert first["kind"] == "bookmark"
     assert first["tags"] == []
 
     second = db.toggle_bookmark(conn, "u1")
-    assert second is None  # removed
+    assert second is None
     assert db.get_bookmark(conn, "u1") is None
 
 
-def test_label_round_trip(conn):
+def test_note_round_trip(conn):
     _seed_session(conn, "s1")
     _seed_message(conn, "u1", "s1")
     row = db.toggle_bookmark(conn, "u1")
 
-    db.set_bookmark_label(conn, row["id"], "  important  ")
-    assert db.get_bookmark(conn, "u1")["label"] == "important"
+    db.set_bookmark_note(conn, row["id"], "  important  ")
+    assert db.get_bookmark(conn, "u1")["note"] == "important"
 
-    # Empty / whitespace collapses to NULL — the browser treats empty
-    # submissions as "clear" without a separate code path.
-    db.set_bookmark_label(conn, row["id"], "   ")
-    assert db.get_bookmark(conn, "u1")["label"] is None
+    db.set_bookmark_note(conn, row["id"], "   ")
+    assert db.get_bookmark(conn, "u1")["note"] is None
 
-    db.set_bookmark_label(conn, row["id"], None)
-    assert db.get_bookmark(conn, "u1")["label"] is None
+    db.set_bookmark_note(conn, row["id"], None)
+    assert db.get_bookmark(conn, "u1")["note"] is None
+
+
+def test_upsert_bookmark_creates_and_updates_kind_and_note(conn):
+    _seed_session(conn, "s1")
+    _seed_message(conn, "u1", "s1", role="assistant", text="compare queue backends")
+
+    created = db.upsert_bookmark(
+        conn,
+        "u1",
+        kind="research",
+        note="later",
+        created_at=1000.0,
+    )
+    assert created["kind"] == "research"
+    assert created["note"] == "later"
+    assert created["created_at"] == 1000.0
+
+    updated = db.upsert_bookmark(
+        conn,
+        "u1",
+        kind="bookmark",
+        created_at=2000.0,
+    )
+    assert updated["id"] == created["id"]
+    assert updated["kind"] == "bookmark"
+    assert updated["note"] == "later"  # omitted note preserves existing text
+    assert updated["created_at"] == 2000.0
+
+
+def test_resolve_bookmark_target_defaults_to_latest_message_in_session(conn):
+    _seed_session(conn, "s1")
+    _seed_session(conn, "s2")
+    _seed_message(conn, "u1", "s1", text="old")
+    _seed_message(conn, "u2", "s1", role="assistant", text="newest")
+    _seed_message(conn, "u3", "s2", text="other session")
+
+    latest = db.resolve_bookmark_target(conn, session_id="s1")
+    explicit = db.resolve_bookmark_target(
+        conn, session_id="s1", message_uuid="u1"
+    )
+
+    assert latest is not None
+    assert latest["uuid"] == "u2"
+    assert explicit is not None
+    assert explicit["uuid"] == "u1"
+    assert db.resolve_bookmark_target(
+        conn, session_id="s1", message_uuid="u3"
+    ) is None
 
 
 def test_list_newest_first_with_joined_metadata(conn):
@@ -85,11 +130,12 @@ def test_list_newest_first_with_joined_metadata(conn):
     _seed_message(conn, "u1", "s1", role="user", text="first question")
     _seed_message(conn, "u2", "s2", role="assistant", text="second answer")
 
-    db.toggle_bookmark(conn, "u1", created_at=1000.0)
-    db.toggle_bookmark(conn, "u2", created_at=2000.0)
+    db.upsert_bookmark(conn, "u1", note="keep", created_at=1000.0)
+    db.upsert_bookmark(conn, "u2", kind="research", created_at=2000.0)
 
     rows = db.list_bookmarks(conn)
     assert [r["message_uuid"] for r in rows] == ["u2", "u1"]
+    assert rows[0]["kind"] == "research"
     assert rows[0]["role"] == "assistant"
     assert rows[0]["custom_name"] == "project-two"
     assert rows[0]["project"] == "proj2"
@@ -100,22 +146,22 @@ def test_list_newest_first_with_joined_metadata(conn):
 @pytest.mark.parametrize(
     "query,expected",
     [
-        ("important", {"u1"}),         # matches label
-        ("SECOND", {"u2"}),            # case-insensitive, matches text
-        ("project-two", {"u2"}),       # matches custom_name
-        ("proj1", {"u1"}),             # matches project
+        ("important", {"u1"}),        # matches note
+        ("research", {"u2"}),         # matches kind
+        ("SECOND", {"u2"}),           # case-insensitive, matches text
+        ("project-two", {"u2"}),      # matches custom_name
+        ("proj1", {"u1"}),            # matches project
         ("nope", set()),
     ],
 )
-def test_filter_matches_label_text_and_session(conn, query, expected):
+def test_filter_matches_note_kind_text_and_session(conn, query, expected):
     _seed_session(conn, "s1", custom_name="project-one", project="proj1")
     _seed_session(conn, "s2", custom_name="project-two", project="proj2")
     _seed_message(conn, "u1", "s1", text="first question")
     _seed_message(conn, "u2", "s2", text="second answer")
 
-    b1 = db.toggle_bookmark(conn, "u1")
-    db.toggle_bookmark(conn, "u2")
-    db.set_bookmark_label(conn, b1["id"], "important note")
+    db.upsert_bookmark(conn, "u1", note="important note")
+    db.upsert_bookmark(conn, "u2", kind="research")
 
     got = {r["message_uuid"] for r in db.list_bookmarks(conn, query=query)}
     assert got == expected
@@ -157,24 +203,18 @@ def test_delete_bookmark_removes_row(conn):
 
 
 def test_unique_constraint_rejects_duplicate_inserts(conn):
-    """toggle_bookmark is the only public insert path and handles the
-    toggle semantics. Any attempt to insert a second row for the same
-    message_uuid directly should still be rejected at the DB layer."""
     _seed_session(conn, "s1")
     _seed_message(conn, "u1", "s1")
     db.toggle_bookmark(conn, "u1")
     with pytest.raises(sqlite3.IntegrityError):
         conn.execute(
-            "INSERT INTO bookmarks (message_uuid, label, tags, created_at) "
-            "VALUES (?, NULL, '[]', ?)",
+            "INSERT INTO bookmarks (message_uuid, note, kind, tags, created_at) "
+            "VALUES (?, NULL, 'bookmark', '[]', ?)",
             ("u1", 1.0),
         )
 
 
 def test_tags_column_round_trips_json(conn):
-    """The tags column exists to match models.Bookmark; no public setter
-    ships in this task but direct writes + the get/list helpers should
-    round-trip the JSON payload correctly for the follow-up UI work."""
     _seed_session(conn, "s1")
     _seed_message(conn, "u1", "s1")
     row = db.toggle_bookmark(conn, "u1")
@@ -185,10 +225,96 @@ def test_tags_column_round_trips_json(conn):
     )
     assert db.get_bookmark(conn, "u1")["tags"] == ["bug", "decision"]
 
-    # Corrupt JSON must not crash the reader — decode failures fall back
-    # to an empty list so the browser keeps rendering the row.
     conn.execute(
         "UPDATE bookmarks SET tags = ? WHERE id = ?",
         ("not json", row["id"]),
     )
     assert db.get_bookmark(conn, "u1")["tags"] == []
+
+
+def test_migration_upgrades_legacy_label_rows(tmp_path):
+    db_path = tmp_path / "legacy.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("PRAGMA user_version = 7")
+        conn.execute(
+            """
+            CREATE TABLE sessions (
+                session_id   TEXT PRIMARY KEY,
+                session_path TEXT NOT NULL,
+                project      TEXT,
+                cwd          TEXT,
+                custom_name  TEXT,
+                status       TEXT NOT NULL DEFAULT 'active',
+                sort_order   INTEGER,
+                last_viewed  REAL,
+                created_at   REAL,
+                modified_at  REAL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE messages (
+                uuid         TEXT PRIMARY KEY,
+                session_id   TEXT NOT NULL,
+                role         TEXT NOT NULL,
+                text         TEXT NOT NULL,
+                timestamp    TEXT,
+                cwd          TEXT,
+                parent_uuid  TEXT,
+                is_sidechain INTEGER NOT NULL DEFAULT 0,
+                message_id   TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE bookmarks (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                message_uuid TEXT NOT NULL UNIQUE,
+                label        TEXT,
+                tags         TEXT NOT NULL DEFAULT '[]',
+                created_at   REAL NOT NULL,
+                FOREIGN KEY (message_uuid) REFERENCES messages(uuid)
+                    ON DELETE CASCADE
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO sessions(session_id, session_path) VALUES (?, ?)",
+            ("s1", "/tmp/s1.jsonl"),
+        )
+        conn.execute(
+            "INSERT INTO messages(uuid, session_id, role, text) VALUES (?, ?, ?, ?)",
+            ("u1", "s1", "assistant", "legacy"),
+        )
+        conn.execute(
+            "INSERT INTO bookmarks(message_uuid, label, tags, created_at) "
+            "VALUES (?, ?, '[]', ?)",
+            ("u1", "old note", 1.0),
+        )
+        conn.commit()
+        conn.close()
+
+        upgraded = db.init_db(db_path)
+        try:
+            row = db.get_bookmark(upgraded, "u1")
+            cols = {
+                r[1] for r in upgraded.execute("PRAGMA table_info(bookmarks)").fetchall()
+            }
+            assert row is not None
+            assert row["note"] == "old note"
+            assert row["kind"] == "bookmark"
+            assert "label" not in cols
+            assert {"note", "kind"}.issubset(cols)
+        finally:
+            upgraded.close()
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass

--- a/tests/test_cli_bookmark.py
+++ b/tests/test_cli_bookmark.py
@@ -1,0 +1,163 @@
+"""CLI tests for ``threadhop bookmark``."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import db
+
+
+ROOT = Path(__file__).resolve().parent.parent
+THREADHOP = ROOT / "threadhop"
+
+
+def _user_line(uuid: str, text: str, sid: str) -> str:
+    return json.dumps({
+        "type": "user",
+        "uuid": uuid,
+        "sessionId": sid,
+        "timestamp": "2026-04-20T10:00:00Z",
+        "message": {"id": f"umsg_{uuid}", "content": [{"type": "text", "text": text}]},
+    })
+
+
+def _assistant_line(uuid: str, mid: str, text: str, sid: str) -> str:
+    return json.dumps({
+        "type": "assistant",
+        "uuid": uuid,
+        "sessionId": sid,
+        "timestamp": "2026-04-20T10:00:01Z",
+        "message": {"id": mid, "content": [{"type": "text", "text": text}]},
+    })
+
+
+def _write_session(home: Path, project: str, session_id: str) -> Path:
+    project_dir = home / ".claude" / "projects" / project
+    project_dir.mkdir(parents=True, exist_ok=True)
+    path = project_dir / f"{session_id}.jsonl"
+    path.write_text(
+        "\n".join([
+            _user_line("u1", "bookmark the next answer", session_id),
+            _assistant_line("a1", "m1", "This is the message to keep.", session_id),
+            _user_line("u2", "and this is the latest turn", session_id),
+        ]) + "\n"
+    )
+    return path
+
+
+def _run_threadhop(home: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    return subprocess.run(
+        [str(THREADHOP), *args],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _write_fake_ps(bin_dir: Path, session_id: str) -> None:
+    script = bin_dir / "ps"
+    script.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '  PID  PPID ARGS\\n'
+printf '%s %s %s\\n' "$PPID" "9000" "python {THREADHOP}"
+printf '%s %s %s\\n' "9000" "1" "claude --resume {session_id}"
+"""
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def test_bookmark_cli_defaults_to_latest_message(tmp_path: Path):
+    home = tmp_path / "home"
+    sid = "11111111-1111-1111-1111-111111111111"
+    _write_session(home, "-Users-alice-alpha", sid)
+
+    result = _run_threadhop(home, "bookmark", "--session", sid)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+    assert f"kind=bookmark session={sid} message=u2" in result.stdout
+    assert 'text="and this is the latest turn"' in result.stdout
+
+    conn = db.init_db(home / ".config" / "threadhop" / "sessions.db")
+    try:
+        row = db.get_bookmark(conn, "u2")
+        assert row is not None
+        assert row["kind"] == "bookmark"
+        assert row["note"] is None
+    finally:
+        conn.close()
+
+
+def test_bookmark_cli_supports_research_kind_and_explicit_message_note(
+    tmp_path: Path,
+):
+    home = tmp_path / "home"
+    sid = "22222222-2222-2222-2222-222222222222"
+    _write_session(home, "-Users-alice-beta", sid)
+
+    result = _run_threadhop(
+        home,
+        "bookmark",
+        "research",
+        "--session",
+        sid,
+        "--message",
+        "a1",
+        "--note",
+        "compare later",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"kind=research session={sid} message=a1" in result.stdout
+    assert 'note="compare later"' in result.stdout
+
+    conn = db.init_db(home / ".config" / "threadhop" / "sessions.db")
+    try:
+        row = db.get_bookmark(conn, "a1")
+        assert row is not None
+        assert row["kind"] == "research"
+        assert row["note"] == "compare later"
+    finally:
+        conn.close()
+
+
+def test_bookmark_cli_auto_detects_session_when_omitted(tmp_path: Path):
+    home = tmp_path / "home"
+    sid = "33333333-3333-3333-3333-333333333333"
+    _write_session(home, "-Users-alice-gamma", sid)
+    fake_bin = home / "bin"
+    fake_bin.mkdir(parents=True)
+    _write_fake_ps(fake_bin, sid)
+
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    result = subprocess.run(
+        [str(THREADHOP), "bookmark", "research", "--note", "auto detected"],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"kind=research session={sid} message=u2" in result.stdout
+
+    conn = db.init_db(home / ".config" / "threadhop" / "sessions.db")
+    try:
+        row = db.get_bookmark(conn, "u2")
+        assert row is not None
+        assert row["kind"] == "research"
+        assert row["note"] == "auto detected"
+    finally:
+        conn.close()

--- a/threadhop
+++ b/threadhop
@@ -315,7 +315,7 @@ COMMAND_REGISTRY: list[Command] = [
     Command(("y",), "Copy selection", SCOPE_SELECTION, footer=True),
     Command(("e",), "Export to /tmp", SCOPE_SELECTION, footer=True),
     Command(("space",), "Toggle bookmark", SCOPE_SELECTION, footer=True),
-    Command(("L",), "Label bookmark", SCOPE_SELECTION),
+    Command(("L",), "Edit bookmark note", SCOPE_SELECTION),
     Command(("m", "escape"), "Exit selection", SCOPE_SELECTION, footer=True),
 
     # --- Reply input ---
@@ -343,7 +343,7 @@ COMMAND_REGISTRY: list[Command] = [
     # --- Bookmark browser modal (widget-local; BookmarkBrowserScreen.on_key) ---
     Command(("up", "down", "ctrl+n", "ctrl+p"), "Navigate bookmarks", SCOPE_BOOKMARKS, footer=True),
     Command(("enter",), "Jump to message", SCOPE_BOOKMARKS, footer=True),
-    Command(("L",), "Edit label", SCOPE_BOOKMARKS, footer=True),
+    Command(("L",), "Edit note", SCOPE_BOOKMARKS, footer=True),
     Command(("d",), "Delete bookmark", SCOPE_BOOKMARKS, footer=True),
     Command(("escape",), "Close", SCOPE_BOOKMARKS, footer=True),
 ]
@@ -634,7 +634,7 @@ class TranscriptView(VerticalScroll):
         self._update_selection(messages)
         self.app.notify(
             "Selection mode: j/k move, v range, y copy, e export, "
-            "space bookmark, L label, m/Esc exit"
+            "space bookmark, L note, m/Esc exit"
         )
         # Nudge the contextual footer — selection mode has its own scope.
         try:
@@ -730,7 +730,7 @@ class TranscriptView(VerticalScroll):
                 f"({pos}/{total}) (j/k extend, v/Esc cancel)"
             )
         else:
-            self.border_title = f"Transcript ── SELECT {pos}/{total} (j/k move, v range, y/e copy/export, space bookmark, L label, m/Esc exit)"
+            self.border_title = f"Transcript ── SELECT {pos}/{total} (j/k move, v range, y/e copy/export, space bookmark, L note, m/Esc exit)"
 
     def _clear_selection(self):
         for widget in self._get_message_widgets():
@@ -1951,8 +1951,8 @@ class BookmarkItem(ListItem):
     """One row in the bookmark browser.
 
     Layout mirrors SearchResultItem so the two modals feel like siblings:
-    label / role marker + snippet, then session · project · timestamp.
-    Bookmarks without a label fall back to the message role marker alone.
+    note / kind / role marker + snippet, then session · project · timestamp.
+    Bookmarks without a note fall back to the kind + role marker alone.
     """
 
     def __init__(self, row: dict):
@@ -1963,12 +1963,15 @@ class BookmarkItem(ListItem):
         role = self.row.get("role", "")
         role_icon = "▶" if role == "user" else "●"
         role_style = "bold cyan" if role == "user" else "bold green"
-        label = (self.row.get("label") or "").strip()
+        note = (self.row.get("note") or "").strip()
+        kind = self.row.get("kind") or "bookmark"
+        kind_style = "bold magenta" if kind == "research" else "bold yellow"
 
         first_line = Text()
         first_line.append("★ ", style="bold yellow")
-        if label:
-            first_line.append(label, style="bold")
+        first_line.append(f"[{kind}] ", style=kind_style)
+        if note:
+            first_line.append(note, style="bold")
             first_line.append("  ", style="dim")
         first_line.append(f"{role_icon} ", style=role_style)
         # Trim the stored text to a single-line snippet — the full body
@@ -2009,7 +2012,7 @@ class BookmarkBrowserScreen(ModalScreen):
     Shares the SearchScreen layout — filter Input on top, ListView of
     results, status + hint lines at the bottom — so keyboard muscle
     memory carries over. Filter runs case-insensitive substring matches
-    over label / message body / project / custom name via
+    over note / kind / message body / project / custom name via
     ``db.list_bookmarks``.
 
     Dismiss payload:
@@ -2092,13 +2095,13 @@ class BookmarkBrowserScreen(ModalScreen):
         with Vertical(id="bookmark-container") as container:
             container.border_title = "Bookmarks"
             yield Input(
-                placeholder="Filter bookmarks by label, text, or session…",
+                placeholder="Filter bookmarks by note, kind, text, or session…",
                 id="bookmark-input",
             )
             yield Static("", id="bookmark-status")
             yield ListView(id="bookmark-results")
             yield Static(
-                "↑/↓ navigate • Enter jump • L label • d delete • Esc close",
+                "↑/↓ navigate • Enter jump • L note • d delete • Esc close",
                 id="bookmark-help",
             )
 
@@ -2124,7 +2127,7 @@ class BookmarkBrowserScreen(ModalScreen):
 
     def _refresh_results(self, raw_query: str) -> None:
         """Reload the results list from the DB. Preserves cursor position
-        when possible so in-place edits (label / delete) don't jump the
+        when possible so in-place edits (note / delete) don't jump the
         user back to the top."""
         results_list = self.query_one("#bookmark-results", ListView)
         status = self.query_one("#bookmark-status", Static)
@@ -2175,7 +2178,7 @@ class BookmarkBrowserScreen(ModalScreen):
         elif key == "L":
             event.stop()
             event.prevent_default()
-            self._edit_label_selected()
+            self._edit_note_selected()
         elif key == "d":
             event.stop()
             event.prevent_default()
@@ -2221,26 +2224,26 @@ class BookmarkBrowserScreen(ModalScreen):
             return
         self.dismiss((row["session_id"], row["message_uuid"]))
 
-    def _edit_label_selected(self) -> None:
+    def _edit_note_selected(self) -> None:
         row = self._current_row()
         if row is None:
             return
         bookmark_id = row["id"]
-        current = row.get("label") or ""
+        current = row.get("note") or ""
 
-        def _apply(new_label: str | None) -> None:
-            if new_label is None:
+        def _apply(new_note: str | None) -> None:
+            if new_note is None:
                 return
             try:
-                db.set_bookmark_label(self.conn, bookmark_id, new_label)
+                db.set_bookmark_note(self.conn, bookmark_id, new_note)
             except Exception as e:  # noqa: BLE001
-                self.app.notify(f"Label update failed: {e}", severity="error")
+                self.app.notify(f"Note update failed: {e}", severity="error")
                 return
-            # Refresh in place so the edited label renders immediately.
+            # Refresh in place so the edited note renders immediately.
             raw = self.query_one("#bookmark-input", Input).value or ""
             self._refresh_results(raw)
-            shown = new_label.strip() or "(no label)"
-            self.app.notify(f"Label: {shown}")
+            shown = new_note.strip() or "(no note)"
+            self.app.notify(f"Bookmark note: {shown}")
 
         self.app.push_screen(LabelPromptScreen(current), _apply)
 
@@ -2261,11 +2264,11 @@ class BookmarkBrowserScreen(ModalScreen):
 class LabelPromptScreen(ModalScreen):
     """Tiny modal that captures a single line of text.
 
-    Used both when setting a label from selection mode and when editing
-    one from the browser. Returns the submitted string on Enter, or
-    ``None`` on Escape — caller decides whether an empty submission
-    means "clear" (bookmark browser does that via set_bookmark_label's
-    blank-collapses-to-NULL behaviour).
+    Used both when setting a note from selection mode and when editing one from
+    the browser. Returns the submitted string on Enter, or ``None`` on Escape.
+    The caller decides whether an empty submission means "clear" (bookmark
+    browser does that via ``set_bookmark_note``'s blank-collapses-to-NULL
+    behaviour).
     """
 
     BINDINGS = [
@@ -2314,10 +2317,10 @@ class LabelPromptScreen(ModalScreen):
 
     def compose(self) -> ComposeResult:
         with Vertical(id="label-container"):
-            yield Static("Bookmark label", id="label-title")
+            yield Static("Bookmark note", id="label-title")
             yield Input(
                 value=self._initial,
-                placeholder="Label (blank = clear)",
+                placeholder="Note (blank = clear)",
                 id="label-input",
             )
             yield Static("Enter to save • Esc to cancel", id="label-hint")
@@ -3573,6 +3576,10 @@ class ClaudeSessions(App):
         pre-index) are silently skipped; the rest flip independently so
         a range with mixed state ends up consistent with the user's
         intent per message."""
+        # TODO: when the TUI grows a bookmark/research picker, route that flow
+        # through ``db.upsert_bookmark`` so chat commands and the TUI share one
+        # deterministic ingest path. Selection-mode space intentionally keeps
+        # the legacy toggle semantics for the plain built-in bookmark kind.
         transcript = self.query_one("#transcript-scroll", TranscriptView)
         selected = transcript.get_selected_messages()
         if not selected:
@@ -3601,9 +3608,9 @@ class ClaudeSessions(App):
         self.notify(", ".join(parts) if parts else "No bookmarks changed")
 
     def bookmark_prompt_label(self) -> None:
-        """Selection-mode `L`: prompt for a label on the (single) focused
-        message. For range selections we label the cursor message only —
-        bulk labeling is an anti-pattern for a short free-text field."""
+        """Selection-mode `L`: prompt for a note on the (single) focused
+        message. For range selections we note the cursor message only —
+        bulk note editing is an anti-pattern for a short free-text field."""
         transcript = self.query_one("#transcript-scroll", TranscriptView)
         messages = transcript._get_message_widgets()
         if not transcript._selection_mode or not messages:
@@ -3618,14 +3625,14 @@ class ClaudeSessions(App):
             return
 
         existing = db.get_bookmark(self.conn, uuid)
-        current = existing["label"] if existing and existing.get("label") else ""
+        current = existing["note"] if existing and existing.get("note") else ""
 
-        def _apply(new_label: str | None) -> None:
-            if new_label is None:
+        def _apply(new_note: str | None) -> None:
+            if new_note is None:
                 return
-            # If the message isn't bookmarked yet, create one first so
-            # we have an id to label. This makes `L` on an unbookmarked
-            # message behave like "bookmark + label in one step".
+            # If the message isn't bookmarked yet, create one first so we have
+            # an id to annotate. This makes `L` on an unbookmarked message
+            # behave like "bookmark + note in one step".
             row = db.get_bookmark(self.conn, uuid)
             if row is None:
                 row = db.toggle_bookmark(self.conn, uuid)
@@ -3633,9 +3640,9 @@ class ClaudeSessions(App):
                     # Extremely unlikely — the toggle raced a delete.
                     self.notify("Could not create bookmark", severity="error")
                     return
-            db.set_bookmark_label(self.conn, row["id"], new_label)
-            shown = (new_label or "").strip() or "(no label)"
-            self.notify(f"Bookmark label: {shown}")
+            db.set_bookmark_note(self.conn, row["id"], new_note)
+            shown = (new_note or "").strip() or "(no note)"
+            self.notify(f"Bookmark note: {shown}")
 
         self.push_screen(LabelPromptScreen(current), _apply)
 
@@ -4674,7 +4681,7 @@ def build_parser():
         description=(
             "ThreadHop — Claude Code session browser.\n"
             "  No subcommand  → launch the TUI.\n"
-            "  Subcommand     → CLI mode (tag, todos, decisions, observations, conflicts)."
+            "  Subcommand     → CLI mode (tag, bookmark, todos, decisions, observations, conflicts)."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -4729,6 +4736,38 @@ def build_parser():
         "status",
         choices=db.SESSION_STATUS_ORDER,
         help="Status value to set",
+    )
+
+    bookmark_p = subparsers.add_parser(
+        "bookmark",
+        parents=[shared],
+        help="Bookmark the latest message in a session, or a specific message",
+        description=(
+            "Create or update a bookmark against a session/message target. "
+            "Without --message, the target is the latest indexed message in "
+            "the current Claude Code session. `kind` stays intentionally "
+            "narrow for now: bookmark (general keep-for-later) or research "
+            "(deferred research follow-up)."
+        ),
+    )
+    bookmark_p.add_argument(
+        "kind",
+        nargs="?",
+        default="bookmark",
+        choices=db.BOOKMARK_KIND_ORDER,
+        help="Built-in bookmark class (default: bookmark)",
+    )
+    bookmark_p.add_argument(
+        "--message",
+        type=str,
+        default=None,
+        help="Explicit message uuid inside the target session (defaults to the latest message)",
+    )
+    bookmark_p.add_argument(
+        "--note",
+        type=str,
+        default=None,
+        help="Optional short note to store alongside the bookmark",
     )
 
     subparsers.add_parser(
@@ -5277,6 +5316,101 @@ def cmd_handoff(args) -> int:
     return 0
 
 
+def _ensure_cli_messages_indexed(
+    conn: sqlite3.Connection,
+    session_id: str,
+) -> dict | None:
+    """Seed the session row from disk and incrementally index its transcript."""
+    session_path = find_session_path(session_id)
+    if session_path is not None:
+        db.upsert_session(
+            conn,
+            session_id,
+            str(session_path),
+            project=session_path.parent.name,
+        )
+    row = db.get_session(conn, session_id) or _ensure_cli_session_row(conn, session_id)
+    if row is None:
+        return None
+    try:
+        indexer.index_session_incremental(conn, session_id, row["session_path"])
+    except Exception as e:  # noqa: BLE001
+        raise RuntimeError(f"failed to index session {session_id}: {e}") from e
+    return db.get_session(conn, session_id)
+
+
+def _format_bookmark_confirmation(
+    target: dict,
+    bookmark: dict,
+) -> str:
+    """Return one deterministic success line for bookmark ingest."""
+    text = " ".join((target.get("text") or "").split())
+    if len(text) > 100:
+        text = text[:99] + "…"
+    note = bookmark.get("note")
+    note_part = f" note={json.dumps(note)}" if note is not None else ""
+    return (
+        "✓ bookmarked "
+        f"kind={bookmark['kind']} "
+        f"session={target['session_id']} "
+        f"message={target['uuid']} "
+        f"role={target.get('role') or 'unknown'} "
+        f"text={json.dumps(text)}"
+        f"{note_part}"
+    )
+
+
+def cmd_bookmark(args) -> int:
+    """Create or update a bookmark against a session/message target.
+
+    Chat ergonomics default to the newest indexed message in the current Claude
+    session. Callers may override the target with ``--session`` and
+    ``--message`` when bookmarking from outside that live terminal.
+    """
+    rc = _resolve_cli_session(args)
+    if rc != 0:
+        return rc
+
+    conn = db.init_db()
+    try:
+        session = _ensure_cli_messages_indexed(conn, args.session)
+        if session is None:
+            print(
+                f"threadhop bookmark: no transcript found for session {args.session} "
+                f"under {CLAUDE_PROJECTS}.",
+                file=sys.stderr,
+            )
+            return 1
+        target = db.resolve_bookmark_target(
+            conn,
+            session_id=args.session,
+            message_uuid=args.message,
+        )
+        if target is None:
+            detail = (
+                f"message {args.message!r} in session {args.session}"
+                if args.message
+                else f"latest message in session {args.session}"
+            )
+            print(
+                f"threadhop bookmark: could not resolve {detail}.",
+                file=sys.stderr,
+            )
+            return 1
+        kwargs = {"kind": args.kind}
+        if args.note is not None:
+            kwargs["note"] = args.note
+        bookmark = db.upsert_bookmark(conn, target["uuid"], **kwargs)
+    except RuntimeError as e:
+        print(f"threadhop bookmark: {e}", file=sys.stderr)
+        return 1
+    finally:
+        conn.close()
+
+    print(_format_bookmark_confirmation(target, bookmark))
+    return 0
+
+
 def main():
     parser = build_parser()
     args = parser.parse_args()
@@ -5308,6 +5442,8 @@ def main():
         return cmd_todos(args)
     if args.command == "decisions":
         return cmd_decisions(args)
+    if args.command == "bookmark":
+        return cmd_bookmark(args)
     if args.command == "observe":
         return cmd_observe(args)
     if args.command == "conflicts":


### PR DESCRIPTION
## Summary
- add a scriptable `threadhop bookmark` entrypoint for chat-side bookmark ingest
- introduce the shared bookmark primitive and narrow built-in `bookmark`/`research` classes
- align README, CLAUDE, TASKS, and ADR docs with the new bookmark contract

## Verification
- `uv run --with pytest pytest tests/test_bookmarks.py tests/test_cli_bookmark.py tests/test_incremental_index.py -q`