### PR TITLE
Merge docs/adr: kanban mode + ADR-027 update lifecycle

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "threadhop",
       "source": "./plugin",
       "description": "Persistent, searchable, cross-session memory for Claude Code — browse sessions, extract TODOs/decisions, produce handoff briefs.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "author": {
         "name": "parzival1l"
       },

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ Thumbs.db
 
 # Claude local config
 .claude/
+
+# Local-only docs/scripts
+AGENTS.md
+INSTALL-MACOS.md
+migration.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to ThreadHop are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions
+follow `major.minor.patch`.
+
+## [0.2.0] — 2026-04-22
+
+### Added
+- `threadhop update [--to <ref>] [--check]` — refresh the installed
+  checkout in place. With no flags, runs `git fetch` + `git reset --hard
+  origin/main`. `--to <ref>` pins to a tag, branch, or SHA for rollback.
+  `--check` reports without pulling.
+- `threadhop changelog` — print this file, paginated through `less -R`
+  when stdout is a TTY. Falls back to fetching
+  `raw.githubusercontent.com/.../main/CHANGELOG.md` on installs that
+  predate the file.
+- `threadhop future` — print the top five entries from `ROADMAP.md`.
+- 24-hour startup version check. The first CLI command of the day and
+  each TUI launch compares the installed `__version__` against the
+  latest GitHub release tag; if newer, the CLI prints a three-line
+  stderr nudge and the TUI raises a transient toast. Suppressed inside
+  Claude Code sessions (context gate), in pipelines (TTY gate), and
+  when `THREADHOP_NO_UPDATE_CHECK` is set (env gate).
+- `CHANGELOG.md`, `ROADMAP.md`, `RELEASE.md` at the repo root.
+
+### Changed
+- Plugin manifests (`.claude-plugin/marketplace.json`,
+  `plugin/.claude-plugin/plugin.json`) bumped to `0.2.0` to stay in
+  lockstep with the CLI. See `RELEASE.md` for the release discipline.
+
+## [0.1.0] — 2026-04-20
+
+### Added
+- Initial public release.
+- Textual TUI over `~/.claude/projects/**/*.jsonl` with FTS5 search,
+  bookmarks, status tags, archive toggle, message-range selection, and
+  AI-generated session titles.
+- CLI subcommands (`tag`, `bookmark`, `todos`, `decisions`,
+  `observations`, `conflicts`, `observe`, `handoff`, `config`) with
+  parent-process session auto-detection for use inside live `claude`
+  chats.
+- Observer + reflector sidecars that append typed observations and
+  cross-session decision conflicts per session (ADR-018 – ADR-020).
+- Claude Code plugin with the `/threadhop:handoff` skill plus
+  `/threadhop:observe`, `/threadhop:tag`, `/threadhop:bookmark`
+  commands.
+- `--version` flag, did-you-mean suggestions on unknown subcommands or
+  enum values, `curl | bash` installer, plugin marketplace manifest.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,25 @@ npx skills add parzival1l/threadhop
 
 **Dev / local-testing path**: if you've cloned the repo and want to load the plugin against a working-tree copy for one session, `claude --plugin-dir ~/.local/share/threadhop/plugin` loads it for that invocation only (no persistence).
 
+## Updating ThreadHop
+
+Once installed you can refresh the CLI in place, without re-running the curl installer:
+
+```bash
+threadhop update               # pull latest origin/main (git fetch + reset --hard)
+threadhop update --check       # just report, don't pull
+threadhop update --to v0.1.0   # pin to a tag, branch, or SHA (rollback)
+threadhop update --force       # override the dirty-tree safety guard
+threadhop changelog            # what's new
+threadhop future               # top 5 roadmap entries
+```
+
+`threadhop update` refuses to run if the installed checkout has uncommitted changes or is on a branch other than `main`, because `git reset --hard` would silently discard that work. Use `--force` to override once you're sure.
+
+ThreadHop also checks once per 24 hours for a newer release and nudges you on the next CLI invocation (three-line stderr message) or TUI launch (transient toast). The check is suppressed inside Claude Code sessions (`!threadhop …` or `/threadhop:*`), in pipelines (`threadhop observations | jq`), and when `THREADHOP_NO_UPDATE_CHECK=1` is set in your shell environment.
+
+The Claude Code plugin has its own update channel — run `/plugin update threadhop` from inside any `claude` session to refresh the skill prompts.
+
 ## Usage
 
 ### TUI

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,52 @@
+# Release Discipline
+
+ThreadHop ships as a git checkout. `threadhop update` and the 24-hour
+startup version check both compare `__version__` in the `threadhop`
+script against the newest tag on the GitHub repo. Without a tag, the
+check silently no-ops — not a false positive, just nothing at all. Keep
+tags in lockstep with `__version__` so users see the nudge.
+
+## Six-step release flow
+
+Per [ADR-027](docs/DESIGN-DECISIONS.md#adr-027-update-lifecycle--threadhop-update-changelog-future-and-24h-startup-check):
+
+1. Update `CHANGELOG.md` with a new `## [X.Y.Z] — YYYY-MM-DD` header and
+   a bullet list of user-visible changes (Keep-a-Changelog style).
+2. Bump `__version__` in `threadhop`.
+3. Bump the `version` field in both
+   `.claude-plugin/marketplace.json` and
+   `plugin/.claude-plugin/plugin.json` to match.
+4. Commit everything together so the version, changelog, and plugin
+   manifests move as one unit.
+5. Cut and push the tag:
+   ```bash
+   git tag v0.2.0
+   git push --tags
+   ```
+6. (Optional later) Draft GitHub Release notes from the new CHANGELOG
+   entry.
+
+Steps 1–3 are reviewable in-PR. Step 5 is what arms the startup check;
+don't skip it.
+
+## When to bump which component
+
+| Change | Bump |
+|---|---|
+| New subcommand, new TUI surface, new skill | minor (`0.1.0 → 0.2.0`) |
+| Bug fix that users would notice | patch |
+| Breaking change to the DB schema or CLI grammar (pre-1.0) | minor |
+
+Pre-release suffixes (`-rc1`, etc.) are not wired into `_parse_version`,
+so don't tag them — the startup check will treat the tag as malformed
+and fall back silently. If pre-releases ever become useful, widen the
+parser first.
+
+## Plugin vs CLI lifecycle
+
+The Claude Code plugin is distributed via `/plugin` and has its own
+update channel owned by Claude Code. ThreadHop's CLI does not push
+plugin updates. The plugin `version` field is bumped here so a user
+inspecting the manifest sees a version that matches the CLI they just
+updated — they still have to run `/plugin update threadhop` inside a
+`claude` session to pull the new skill prompts.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,32 @@
+# ThreadHop Roadmap
+
+What's coming up. Tracked as narrow deliverables; anything bigger lives
+in `docs/DESIGN-DECISIONS.md` as an ADR. The top five entries also
+surface via `threadhop future` — keep that subset meaningful.
+
+Format contract (parsed by `threadhop future`):
+
+```
+- #NN — Short description line that renders well in CLI.
+```
+
+Lines that don't match the `- #NN — …` shape are ignored by the parser.
+Headers and prose are free to evolve without breaking the CLI output.
+
+## Next up
+
+- #50 — Event-driven session discovery via fsevents (retire the 5s poll).
+- #51 — Lazy tail-load transcript parsing for instant session focus.
+- #42 — Context-aware help overlay with a shared command registry.
+- #32 — Trigram-based fuzzy search for typo tolerance on top of FTS5.
+- #38 — TUI conflict notifications when the reflector flags a contradiction.
+- #52 — Row-window virtualisation of TranscriptView for very long sessions.
+- #39 — Observation condensation: merge related decisions, archive done TODOs.
+- #53 — Migrate data-heavy DataTables to textual-fastdatatable.
+
+## Later
+
+- Codex session support (currently Claude Code only).
+- Broader bookmark categories beyond the `bookmark` / `research` split.
+- GitHub Releases automation — auto-populate release notes from
+  `CHANGELOG.md` on tag push.

--- a/docs/DESIGN-DECISIONS.md
+++ b/docs/DESIGN-DECISIONS.md
@@ -1292,6 +1292,250 @@ Press O (shift) → "Resume observing? (y/n)"
 
 ---
 
+### ADR-027: Update lifecycle — `threadhop update`, `changelog`, `future`, and 24h startup check
+
+**Context:** ThreadHop is distributed as a git checkout (via `install.sh`
+curl-bash or manual clone) with no package manager brokering versions.
+Once installed, nothing tells the user that new commits exist on `main`,
+and there is no built-in command to pull them — the only path today is
+re-running the curl-bash installer, which is undiscoverable and relies
+on the user remembering the URL. The Claude Code plugin surface has its
+own update channel (owned by Claude Code's `/plugin` subsystem, out of
+scope here). This ADR defines the CLI-side update story only.
+
+**Decision:** Introduce three CLI subcommands plus a startup version
+check:
+
+1. **`threadhop update [--to <ref>] [--check]`** — pull latest `main` by
+   default, or roll back to a specific git ref with `--to`, or report
+   without pulling with `--check`.
+2. **`threadhop changelog`** — print the repo's `CHANGELOG.md`, falling
+   back to fetching `raw.githubusercontent.com/.../main/CHANGELOG.md` if
+   the local file is missing (e.g. the user is on a version that
+   predates the changelog surface).
+3. **`threadhop future`** — print the top five entries from a new
+   `ROADMAP.md` at repo root. Unconditional top-5; no tagging, filtering,
+   or priority scoring.
+4. **Startup version check** — at `main()` entry (CLI) and `on_mount`
+   (TUI), cheaply compare the installed `__version__` against the latest
+   GitHub release tag. If newer, print a nudge (CLI) or toast (TUI).
+
+The mechanism is entirely explicit: no background auto-update, no daemon.
+Users only get new code by running `threadhop update` (or re-running the
+installer), and they only see version nudges when they're actively
+invoking the tool.
+
+**Subcommand shapes:**
+
+```bash
+threadhop update                   # git fetch && git reset --hard origin/main
+threadhop update --check           # compare versions, print, exit 0
+threadhop update --to v0.1.0       # roll back to a tag, branch, or SHA
+threadhop changelog                # print CHANGELOG.md (paginated via less if TTY)
+threadhop future                   # print top 5 ROADMAP.md entries
+```
+
+No flag-form alias (`threadhop --update`) — the subcommand shape is
+required because `--to <ref>` needs an argument, and flag-with-argument
+grammar is awkward.
+
+**Startup check semantics — four gates before printing anything:**
+
+```
+1. TTY gate       stdout.isatty() AND stderr.isatty() must be True.
+                  Protects pipelines (threadhop observations | jq).
+2. Context gate   Must NOT be running inside a Claude Code session.
+                  Detected via parent-process walk (same helper as
+                  `_resolve_cli_session` from task #17). Protects plugin
+                  invocations and `!threadhop` bash passthrough.
+3. Cache gate     ~/.cache/threadhop/last_check mtime must be older than
+                  24 hours. On pass, touch the file.
+4. Env gate       $THREADHOP_NO_UPDATE_CHECK must not be set (opt-out).
+```
+
+Only when all four pass does the tool perform a 1-second-timeout HTTP
+GET against `api.github.com/repos/parzival1l/threadhop/releases/latest`.
+Any network error, JSON error, or unparseable tag format is swallowed
+silently — a version check must never break the CLI.
+
+**Notification shape — CLI:**
+
+```
+ThreadHop 0.2.0 is available (you have 0.1.0).
+  What's new:  threadhop changelog
+  Update:      threadhop update
+```
+
+Three lines, stderr, printed exactly once per session (first CLI command
+of the day after cache expiry). No plugin-update hint — plugin lifecycle
+is Claude Code's responsibility.
+
+**Notification shape — TUI:**
+
+```python
+# In ClaudeSessions.on_mount():
+if info := _check_for_update():
+    self.notify(
+        f"ThreadHop {info.latest} available — run `threadhop update`.",
+        title="Update available",
+        severity="information",
+        timeout=10,
+    )
+```
+
+Transient toast in the top-right corner (Textual's native `notify`
+pattern). Auto-dismiss after 10 seconds. Does not resize the layout or
+steal focus.
+
+**Where the notification does NOT appear:**
+
+- Inside Claude Code plugin commands (`/threadhop:tag`, etc.) — context
+  gate suppresses it, because a plugin user may fire many commands
+  within a session and the 24h cache only arms once per session.
+- Inside `!threadhop …` bash passthrough in Claude Code — same gate.
+- In non-TTY contexts (CI, `threadhop ... | jq`, etc.) — TTY gate.
+- When `$THREADHOP_NO_UPDATE_CHECK=1` — env gate.
+
+**`threadhop future` — format contract:**
+
+`ROADMAP.md` at repo root, format:
+
+```markdown
+# ThreadHop Roadmap
+
+- #NN — Short description line that renders well in CLI.
+- #NN — Another item.
+...
+```
+
+Parser rules:
+- Lines matching `^- #(\d+) — (.+)$` become roadmap entries.
+- The first five matching lines are printed, in file order.
+- Everything else (headers, prose, blank lines) is ignored.
+
+Output shape:
+
+```
+ThreadHop — what's coming up:
+
+  #NN  Short description line that renders well in CLI.
+  #NN  Another item.
+  ...
+
+Full roadmap:
+  https://github.com/parzival1l/threadhop/blob/main/ROADMAP.md
+```
+
+Implementation: read from the installed repo's `ROADMAP.md`. No network
+call. Users on pinned old versions see that version's roadmap; that's
+acceptable because `threadhop update` brings the roadmap forward.
+
+**`threadhop changelog` — format contract:**
+
+`CHANGELOG.md` at repo root, Keep-a-Changelog style:
+
+```markdown
+# Changelog
+
+## [0.2.0] — 2026-05-01
+### Added
+- `threadhop update` subcommand
+- 24h startup version check
+
+## [0.1.0] — 2026-04-20
+- Initial release.
+```
+
+No parsing — the file is printed verbatim through `less -R` if stdout
+is a TTY, raw otherwise. Users can read per-version sections by
+scrolling.
+
+**Version comparison — simple tuple compare:**
+
+```python
+def _parse_version(v: str) -> tuple[int, ...]:
+    return tuple(int(x) for x in v.lstrip("v").split("."))
+```
+
+Assumes `major.minor.patch` with integer components. Tag names with
+suffixes (`v0.2.0-rc1`) will raise; the caller treats that as "check
+failed" and falls back silently. Acceptable until the project actually
+ships pre-releases.
+
+**Plugin updates — explicitly out of scope:**
+
+Claude Code's `/plugin` subsystem owns plugin lifecycle. Users update
+the plugin via `/plugin update threadhop` (or whatever Claude Code's
+equivalent is). ThreadHop's CLI does not try to push plugin updates,
+does not warn plugin users about CLI updates (they see the notice when
+they next run the CLI directly), and does not synchronize the two
+surfaces' versions. The plugin's own `version` field in
+`.claude-plugin/marketplace.json` is bumped manually on each release as
+part of the CLI release discipline.
+
+**Release discipline — what the maintainer does on each release:**
+
+1. Update `CHANGELOG.md` with a new version header and bullet list.
+2. Bump `__version__` in `threadhop`.
+3. Bump the plugin `version` field in `.claude-plugin/marketplace.json`
+   and `plugin/.claude-plugin/plugin.json`.
+4. Commit everything.
+5. Cut a git tag: `git tag v0.2.0 && git push --tags`.
+6. (Optional later) GitHub Releases auto-populate from tags.
+
+Without step 5, the startup check has nothing to compare against and
+silently degrades to no-op. This is acceptable: missing tags means no
+false-positive "update available" notifications, just no notifications
+at all.
+
+**Rationale:**
+- **Re-running curl-bash works but is undiscoverable** — users install
+  once, never see the URL again. A `threadhop update` surface gives
+  them an ergonomic second update path without replacing the first.
+- **Startup check is the ambient discovery channel** — users don't have
+  to remember to check for updates; the tool reminds them once per day,
+  unobtrusively. 24h cooldown bounds network traffic and prevents
+  notification fatigue.
+- **Suppress inside Claude Code** because plugin users may invoke
+  commands dozens of times per day; a 24h cache still means dozens of
+  plugin messages per year get an unsolicited upgrade nudge. Cleaner to
+  only nudge when they're deliberately at the CLI.
+- **Rollback via `--to`** honors the user's stated "users can go back
+  to older versions if they want" requirement. Covers bug-regression
+  scenarios at zero extra cost.
+- **Top-5 roadmap with simple format** is intentionally dumb — it's a
+  view into an existing file, not a ranking engine. If the format ever
+  needs to get smarter (priorities, categories), it can grow later.
+  Keeping the contract narrow means `ROADMAP.md` stays maintainable by
+  hand.
+- **Plugin updates delegated to Claude Code** because cross-tool
+  lifecycle coordination is a rat-hole. Claude Code has first-party
+  update machinery; ThreadHop should not try to replicate or wrap it.
+
+**Rejected:**
+- **Background auto-update** — reputation-shredding antipattern; users
+  hate when their CLI version silently changes.
+- **Flag form `threadhop --update`** — can't carry `--to <ref>` cleanly.
+- **Notification inside Claude Code plugin invocations** — would pollute
+  hundreds of plugin messages per week for active users.
+- **Preemptive plugin-update hint in the CLI notification** — two
+  surfaces, two update channels; co-mixing them in one message adds
+  noise more than clarity.
+- **Using `docs/TASKS.md` as the roadmap source** — `TASKS.md` is being
+  removed from `main` (maintained out-of-band going forward). A
+  dedicated `ROADMAP.md` with a narrow format contract is more stable.
+- **SHA-based "did main change?" comparison** — loses semantic
+  versioning and gives no changelog anchor. Requires users to trust
+  that any commit is a valid "update."
+- **Notification in a persistent footer badge** — competes with
+  `ContextualFooter` (ADR-017) and stays visible forever. A transient
+  toast is temporally scoped to the session it actually matters for.
+- **Updating CLI and plugin in lockstep via `threadhop update`** —
+  reaches across to Claude Code's plugin cache, which is not ours to
+  touch.
+
+---
+
 ## Implementation Plan
 
 ### Phase 1: SQLite Foundation + Session Tags + Archive

--- a/docs/task-027-update-mechanism.md
+++ b/docs/task-027-update-mechanism.md
@@ -1,0 +1,231 @@
+# Task 027 — Implement `threadhop update`, `changelog`, `future`, and the 24h startup check
+
+**Reference:** [ADR-027 in `DESIGN-DECISIONS.md`](./DESIGN-DECISIONS.md#adr-027-update-lifecycle--threadhop-update-changelog-future-and-24h-startup-check)
+
+Read ADR-027 end-to-end before starting. The ADR captures every design
+decision and the rationale behind each one. This doc only adds the
+concrete "what to build and how to verify it" layer.
+
+---
+
+## Objective
+
+Give ThreadHop users a discoverable CLI-side update mechanism with an
+ambient notification channel, plus a lightweight roadmap surface. No
+code change to the Claude Code plugin — plugin lifecycle stays owned by
+`/plugin`.
+
+End state: a user who ran `curl ... install.sh | bash` a week ago runs
+any `threadhop` command from their shell and sees a 3-line "update
+available" notice once per 24 hours. They run `threadhop update` and
+their install refreshes to `origin/main`. They run `threadhop
+changelog` to see what changed and `threadhop future` to see what's
+coming next.
+
+---
+
+## Deliverables (checklist for the picking-up chat)
+
+### New files at repo root
+
+- [ ] `ROADMAP.md` — top of the roadmap + a list of entries in the format
+      `- #NN — description`. Seed with 5-8 items from existing internal
+      task lists.
+- [ ] `CHANGELOG.md` — Keep-a-Changelog style. Seed with `0.1.0 — current
+      date` and an entry noting initial release (--version flag,
+      did-you-mean, curl-bash installer, marketplace.json).
+
+### New subcommands in `threadhop`
+
+All three live behind new `subparsers.add_parser(...)` entries in
+`build_parser()`. Follow the epilog/Examples pattern already established
+for existing subcommands.
+
+- [ ] `threadhop update` with flags `--to <ref>` and `--check`.
+- [ ] `threadhop changelog` — no flags.
+- [ ] `threadhop future` — no flags.
+
+### Startup check
+
+- [ ] New helper `_check_for_update()` in `threadhop`. Returns an object
+      (or None) with `.latest` and `.current` fields.
+- [ ] Called once at `main()` entry, before dispatch. Prints the 3-line
+      notice to stderr if a newer version is available AND all four
+      gates pass (see ADR-027 "Startup check semantics").
+- [ ] Called once at `ClaudeSessions.on_mount()` in `tui.py`. On hit,
+      fires `self.notify(...)` with the TUI toast shape from the ADR.
+
+### Opt-out surface
+
+- [ ] Respect `$THREADHOP_NO_UPDATE_CHECK`. If set to any non-empty
+      value, skip the network call entirely.
+- [ ] Document it in README.
+
+### Version and release discipline (one-time scaffolding)
+
+- [ ] Bump `__version__` in `threadhop` from `0.1.0` to `0.2.0` as part
+      of this PR (new version = new feature set).
+- [ ] Bump the `version` field in `.claude-plugin/marketplace.json` and
+      `plugin/.claude-plugin/plugin.json` to `0.2.0` to match.
+- [ ] Add a `CHANGELOG.md` entry for `0.2.0` listing the new commands.
+- [ ] Add a short "Release discipline" section to `CLAUDE.md` (or a new
+      `RELEASE.md`) capturing the six-step release flow from ADR-027 so
+      future releases don't skip the tag.
+
+### README updates
+
+- [ ] New section under `## Install` or just below it titled "Updating
+      ThreadHop" with the three commands and the opt-out env var.
+
+---
+
+## Files likely to change
+
+| File | Scope |
+|---|---|
+| `threadhop` | ~150 lines: new subcommands, startup check, version bump, argparse wiring |
+| `tui.py` | ~10 lines: `on_mount()` hook + import of `_check_for_update` |
+| `README.md` | new "Updating ThreadHop" section |
+| `CHANGELOG.md` | new file |
+| `ROADMAP.md` | new file |
+| `.claude-plugin/marketplace.json` | version bump |
+| `plugin/.claude-plugin/plugin.json` | version bump |
+| `CLAUDE.md` or `RELEASE.md` | release discipline note |
+
+No changes to `install.sh` (already idempotent and unaffected).
+
+---
+
+## Acceptance criteria
+
+Each item here should be a one-command verification.
+
+### `threadhop update`
+- [ ] `threadhop update --check` prints `ThreadHop X.Y.Z is up to date.`
+      when on latest, or the 3-line "update available" notice when not.
+      Exits 0 either way.
+- [ ] `threadhop update` (no flags) runs `git fetch` + `git reset --hard
+      origin/main` on the installed repo (`Path(__file__).resolve().parent`
+      inside the script). Exits 0. Prints "Updated to `<new-version>`."
+- [ ] `threadhop update --to v0.1.0` checks out the tag. Prints "Pinned
+      to v0.1.0." Exits 0.
+- [ ] `threadhop update --to <nonexistent-ref>` exits 1 with a clean
+      error message mentioning the ref.
+- [ ] When run against a non-git install (someone copied the script
+      standalone), exits 1 with "Not a git checkout; re-run the
+      installer instead."
+
+### `threadhop changelog`
+- [ ] `threadhop changelog` on an install with `CHANGELOG.md` present
+      prints the file. Through `less -R` when stdout is a TTY; raw
+      otherwise.
+- [ ] `threadhop changelog` on an install without the file fetches from
+      `raw.githubusercontent.com/.../main/CHANGELOG.md` (1s timeout).
+      On network failure, prints "CHANGELOG not available offline. See
+      https://github.com/parzival1l/threadhop/blob/main/CHANGELOG.md" to
+      stderr and exits 1.
+
+### `threadhop future`
+- [ ] `threadhop future` prints the first five roadmap entries from
+      `ROADMAP.md`. Output matches the shape in ADR-027.
+- [ ] Fewer than 5 entries in the file: prints what's there, no error.
+- [ ] Missing `ROADMAP.md`: prints a friendly message + the GitHub URL,
+      exits 0 (not an error — just unavailable).
+
+### Startup check (CLI)
+- [ ] `threadhop todos` on a stale install (older `__version__` than
+      latest tag) prints the 3-line notice once, then the normal output.
+- [ ] Running it again within 24h: notice does not reprint.
+- [ ] `touch -d '25 hours ago' ~/.cache/threadhop/last_check && threadhop
+      todos`: notice reprints.
+- [ ] `THREADHOP_NO_UPDATE_CHECK=1 threadhop todos`: no notice, no
+      network call.
+- [ ] `threadhop todos | cat`: no notice (stdout is not a TTY).
+- [ ] From inside a Claude Code session (`!threadhop tag ...` or
+      `/threadhop:tag`): no notice. Verified by running the command in
+      a live session and confirming no update line appears.
+
+### Startup check (TUI)
+- [ ] Launch TUI on a stale install: toast appears in the top-right,
+      fades after ~10s, does not resize the layout or steal focus.
+- [ ] Relaunch TUI within 24h: toast does not reappear.
+
+---
+
+## Implementation hints
+
+- **Context gate reuses existing helper.** The `_resolve_cli_session`
+  function in `threadhop` (from task #17, per `CLAUDE.md`) already walks
+  the parent-process tree to detect whether the caller is running inside
+  a Claude Code session. Extract the "are we inside claude?" logic into
+  a small `_invoked_from_claude_code() -> bool` helper and gate the
+  notification on `not _invoked_from_claude_code()`.
+- **Cache directory.** Use `~/.cache/threadhop/` (XDG-ish). Create it
+  lazily on first check. The cache file contents don't matter — only
+  mtime is consulted.
+- **GitHub API.** Use `urllib.request` (stdlib). No new dependency. The
+  URL is
+  `https://api.github.com/repos/parzival1l/threadhop/releases/latest`.
+  Send `Accept: application/vnd.github+json`. Parse `tag_name` (string
+  like `"v0.2.0"`).
+- **Version parsing.** See ADR-027 for the `_parse_version` helper.
+  Wrap the comparison in a try/except so malformed tags silently skip.
+- **Self-replacement gotcha.** `threadhop update` replaces `threadhop`
+  on disk while it's running. On macOS/Linux this is safe (the running
+  process's file has already been mmap'd), but only complete the git
+  operations and exit immediately afterwards. Do not run further Python
+  logic after the git reset — call `os._exit(0)` or just `return` from
+  the function that dispatched it.
+- **TUI notify timeout.** Textual's `notify` accepts `timeout=<seconds>`.
+  10 seconds is right.
+- **Pager for changelog.** `subprocess.run(["less", "-R"], input=content,
+  text=True)` with a fallback to raw `print(content)` if `less` isn't
+  on PATH.
+
+---
+
+## Out of scope
+
+- **Auto-generated CHANGELOG** (e.g. via `git-cliff`) — manual entries
+  are fine for now.
+- **Signed releases / checksum verification** — pre-1.0, no threat model
+  warrants it.
+- **GitHub Releases automation** — a separate follow-up task. Initial
+  tags can be cut manually with `git tag` + `git push --tags`.
+- **Plugin update mechanism** — Claude Code owns this. See ADR-027
+  "Plugin updates — explicitly out of scope."
+- **Notification inside Claude Code plugin / `!bash` invocations** —
+  explicitly suppressed by the context gate.
+- **`threadhop update --all`** (update CLI + plugin in one step) —
+  rejected in ADR-027 because plugin cache is Claude Code's surface.
+
+---
+
+## Open questions (for the picking-up chat to resolve)
+
+1. **Changelog rendering fallback.** If `less` isn't on PATH, should we
+   fall back to raw print, or try `more`, or exit with a friendly
+   error? Recommend: raw print, always work.
+2. **TUI toast placement customization.** Textual's default is
+   top-right. Verify this looks right given ThreadHop's 2-column
+   layout. If not, consider passing a `severity` that positions
+   differently.
+3. **Roadmap file location.** ADR-027 proposes repo root
+   (`ROADMAP.md`). If the picking-up chat finds repo-root clutter, it
+   can move to `docs/ROADMAP.md` and update the parser path.
+
+---
+
+## Rough effort estimate
+
+| Chunk | Estimate |
+|---|---|
+| New subcommands + argparse wiring | 45 min |
+| Startup check + all four gates | 45 min |
+| TUI notify integration | 20 min |
+| README + CHANGELOG + ROADMAP seeding | 30 min |
+| Version bumps + release discipline doc | 15 min |
+| Tests (unit for parsing, manual for end-to-end) | 60 min |
+| **Total** | **~3.5 hours** |
+
+Expect ~200 lines of diff when done. Single PR, single commit fine.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "threadhop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Browse, search, and carry context across Claude Code sessions. Exposes /threadhop:handoff, /threadhop:observe, /threadhop:tag.",
   "author": {
     "name": "ThreadHop",

--- a/threadhop
+++ b/threadhop
@@ -17,6 +17,7 @@ import signal
 import sqlite3
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -38,7 +39,28 @@ import search_queries  # noqa: E402
 sys.modules.setdefault("threadhop", sys.modules[__name__])
 
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
+
+
+# Update-check surface (ADR-027). Cache only holds mtime — contents are
+# unused — so a single `touch` per run bounds GitHub API traffic to at
+# most one call per machine per 24h, even on network failure.
+UPDATE_REPO = "parzival1l/threadhop"
+UPDATE_REPO_URL = f"https://github.com/{UPDATE_REPO}"
+UPDATE_RELEASES_API = f"https://api.github.com/repos/{UPDATE_REPO}/releases/latest"
+UPDATE_RAW_CHANGELOG = f"https://raw.githubusercontent.com/{UPDATE_REPO}/main/CHANGELOG.md"
+UPDATE_CACHE_DIR = Path.home() / ".cache" / "threadhop"
+UPDATE_CACHE_FILE = UPDATE_CACHE_DIR / "last_check"
+UPDATE_CHECK_INTERVAL_S = 24 * 60 * 60
+UPDATE_FETCH_TIMEOUT_S = 1.0
+
+
+@dataclass(frozen=True)
+class UpdateInfo:
+    """Result of the version check — only constructed when latest > current."""
+
+    latest: str   # already stripped of a leading `v`
+    current: str
 
 
 def get_available_themes():
@@ -833,6 +855,134 @@ def detect_project_from_cwd() -> str | None:
     return None
 
 
+def _invoked_from_claude_code() -> bool:
+    """True if a `claude` CLI process is an ancestor of this one.
+
+    Shares the ``ps``-based parent-chain walk with
+    ``detect_current_session_id`` but only cares about *presence* — we
+    don't need to resolve a session id, just gate the update-check
+    notice so plugin invocations (``/threadhop:tag``) and
+    ``!threadhop …`` bash passthroughs stay quiet (ADR-027).
+    """
+    try:
+        result = subprocess.run(
+            ["ps", "-eo", "pid,ppid,args"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except Exception:
+        return False
+
+    procs: dict[int, tuple[int, str]] = {}
+    for line in result.stdout.strip().split("\n")[1:]:  # skip header
+        parts = line.strip().split(None, 2)
+        if len(parts) < 3:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+        except ValueError:
+            continue
+        procs[pid] = (ppid, parts[2])
+
+    pid = os.getpid()
+    visited: set[int] = set()
+    while pid and pid > 0 and pid not in visited:
+        visited.add(pid)
+        entry = procs.get(pid)
+        if not entry:
+            break
+        ppid, args = entry
+        is_claude, _ = _parse_claude_process_args(args)
+        if is_claude:
+            return True
+        pid = ppid
+    return False
+
+
+def _parse_version(v: str) -> tuple[int, ...]:
+    """Parse ``v0.2.0`` / ``0.2.0`` into ``(0, 2, 0)``. Raises on bad input."""
+    return tuple(int(x) for x in v.lstrip("v").split("."))
+
+
+def _fetch_latest_release_tag() -> str | None:
+    """GET the latest release tag, or None on any failure. 1s timeout."""
+    import urllib.request  # local import keeps CLI cold-start cheap
+    req = urllib.request.Request(
+        UPDATE_RELEASES_API,
+        headers={"Accept": "application/vnd.github+json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=UPDATE_FETCH_TIMEOUT_S) as resp:
+            data = json.load(resp)
+    except Exception:
+        return None
+    tag = data.get("tag_name")
+    return tag if isinstance(tag, str) and tag else None
+
+
+def _check_for_update(*, force: bool = False) -> "UpdateInfo | None":
+    """Return ``UpdateInfo`` if a newer release is out; ``None`` otherwise.
+
+    Four gates (ADR-027) — env, TTY, context, cache — stop the check
+    early when ``force`` is False. ``force=True`` is reserved for
+    ``threadhop update --check`` where the user explicitly asked for
+    the check and we should ignore all four.
+    Any failure path returns ``None`` silently; a version check must
+    never break the CLI.
+    """
+    if not force:
+        # Env / TTY / context / cache gates apply only to the ambient
+        # startup check. `threadhop update --check` is an explicit user
+        # request and should always hit the network, so it passes
+        # `force=True` and skips all four.
+        if os.environ.get("THREADHOP_NO_UPDATE_CHECK"):
+            return None
+        if not (sys.stdout.isatty() and sys.stderr.isatty()):
+            return None
+        if _invoked_from_claude_code():
+            return None
+        try:
+            last = UPDATE_CACHE_FILE.stat().st_mtime
+            if time.time() - last < UPDATE_CHECK_INTERVAL_S:
+                return None
+        except FileNotFoundError:
+            pass
+        except OSError:
+            return None
+
+    tag = _fetch_latest_release_tag()
+
+    # Touch cache even on fetch failure: we're caching the attempt, not
+    # the result. Prevents a network outage from re-trying GitHub on
+    # every single CLI invocation for the next 24h.
+    try:
+        UPDATE_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        UPDATE_CACHE_FILE.touch()
+    except OSError:
+        pass
+
+    if not tag:
+        return None
+    try:
+        latest_v = _parse_version(tag)
+        current_v = _parse_version(__version__)
+    except (ValueError, AttributeError):
+        return None
+    if latest_v <= current_v:
+        return None
+    return UpdateInfo(latest=tag.lstrip("v"), current=__version__)
+
+
+def _print_cli_update_notice(info: UpdateInfo) -> None:
+    """Three-line stderr nudge (ADR-027 notification shape — CLI)."""
+    print(
+        f"\nThreadHop {info.latest} is available (you have {info.current}).\n"
+        f"  What's new:  threadhop changelog\n"
+        f"  Update:      threadhop update\n",
+        file=sys.stderr,
+    )
+
+
 def _cli_stub(command):
     """Print a stub notice and exit 0. Real implementation lands in later tasks."""
     print(f"threadhop {command}: not yet implemented (stub)", file=sys.stderr)
@@ -1425,6 +1575,85 @@ def build_parser():
         ),
     )
 
+    update_p = subparsers.add_parser(
+        "update",
+        help="Update the installed ThreadHop checkout",
+        description=(
+            "Refresh the installed ThreadHop checkout in place. With no "
+            "flags, runs `git fetch` + `git reset --hard origin/main` "
+            "inside the repo that contains the running script. "
+            "`--to <ref>` pins to any git ref (tag, branch, SHA) for "
+            "rollback. `--check` reports without pulling. Refuses to "
+            "run against a dirty working tree unless `--force` is "
+            "passed, because `reset --hard` would silently discard "
+            "uncommitted work. The Claude Code plugin is updated "
+            "separately via `/plugin update threadhop` — ADR-027."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  threadhop update                 # pull latest origin/main\n"
+            "  threadhop update --check         # report without pulling\n"
+            "  threadhop update --to v0.1.0     # pin to a tag\n"
+            "  threadhop update --to 1efdcf5    # pin to a specific SHA\n"
+            "  threadhop update --force         # override the dirty-tree guard"
+        ),
+    )
+    update_p.add_argument(
+        "--to",
+        type=str,
+        default=None,
+        metavar="<ref>",
+        help="Git ref to check out (tag, branch, or SHA). Defaults to origin/main.",
+    )
+    update_p.add_argument(
+        "--check",
+        action="store_true",
+        default=False,
+        help="Only report whether an update is available; do not pull.",
+    )
+    update_p.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+        help=(
+            "Override the dirty-tree / non-main-branch safety guard. "
+            "Only use this if you're sure you want to discard "
+            "uncommitted changes in the installed checkout."
+        ),
+    )
+
+    subparsers.add_parser(
+        "changelog",
+        help="Print the ThreadHop changelog",
+        description=(
+            "Print CHANGELOG.md. Paginated through `less -R` when stdout "
+            "is a TTY; raw otherwise. On installs that predate the file, "
+            "falls back to fetching it from GitHub (1s timeout)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  threadhop changelog\n"
+            "  threadhop changelog | head -40"
+        ),
+    )
+
+    subparsers.add_parser(
+        "future",
+        help="Show the top 5 roadmap entries",
+        description=(
+            "Print the top five entries from ROADMAP.md in file order. "
+            "No network call — the roadmap travels with the checkout, "
+            "so `threadhop update` is what brings it forward."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  threadhop future"
+        ),
+    )
+
     return parser
 
 
@@ -1933,9 +2162,240 @@ def cmd_bookmark(args) -> int:
     return 0
 
 
+ROADMAP_ENTRY_RE = re.compile(r"^- #(\d+) — (.+)$")
+
+
+def _repo_root() -> Path:
+    """Directory the installed `threadhop` script lives in."""
+    return Path(__file__).resolve().parent
+
+
+def _read_version_from_script(path: Path) -> str | None:
+    """Read ``__version__`` from an on-disk copy of the `threadhop` script.
+
+    Used by `threadhop update` after a git reset: the running process
+    still has the pre-update string cached in memory, so we re-parse
+    the file on disk to report the new version back to the user.
+    """
+    try:
+        text = path.read_text()
+    except OSError:
+        return None
+    m = re.search(r'^__version__\s*=\s*"([^"]+)"', text, flags=re.MULTILINE)
+    return m.group(1) if m else None
+
+
+def _run_git(cwd: Path, *args: str) -> tuple[int, str, str]:
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True,
+    )
+    return result.returncode, result.stdout.strip(), result.stderr.strip()
+
+
+def _dirty_tree_refusal(repo: Path) -> str | None:
+    """Return a formatted refusal message if the working tree isn't safe
+    to ``git reset --hard`` against, else None.
+
+    Guards two scenarios we learned about the hard way:
+      1. Uncommitted changes (tracked modifications, staged blobs) —
+         ``git reset --hard`` silently discards them.
+      2. Current branch differs from `main` — a reset would move the
+         current branch's tip, abandoning commits that weren't on main.
+
+    ``--force`` skips this check entirely; the caller handles that.
+    """
+    rc, porcelain, _ = _run_git(repo, "status", "--porcelain")
+    if rc != 0:
+        # If `git status` itself fails, don't block — `git reset` will
+        # surface its own error and we'd rather that than a spurious
+        # refusal.
+        return None
+    rc, branch, _ = _run_git(repo, "rev-parse", "--abbrev-ref", "HEAD")
+    if rc != 0:
+        branch = "(unknown)"
+
+    problems: list[str] = []
+    if porcelain.strip():
+        count = sum(1 for line in porcelain.splitlines() if line.strip())
+        problems.append(
+            f"  {count} uncommitted change(s) in the working tree."
+        )
+    if branch not in ("main", "HEAD"):
+        problems.append(
+            f"  current branch is '{branch}', not 'main'."
+        )
+
+    if not problems:
+        return None
+
+    return (
+        "threadhop update: refusing to run against a non-clean "
+        "checkout:\n"
+        + "\n".join(problems)
+        + "\n\n"
+        "A `git reset --hard` here would discard uncommitted work or "
+        "abandon unmerged commits. Commit/stash first, or pass "
+        "`--force` to override (you'll lose the listed state)."
+    )
+
+
+def cmd_update(args) -> int:
+    """Refresh the installed checkout in place (ADR-027).
+
+    Safety rail: refuses to proceed when the working tree is dirty or
+    the current branch isn't `main`. Override with `--force`. (Learned
+    from task-027's own debut: running the first implementation against
+    the development checkout silently wiped an afternoon of
+    uncommitted work.)
+    """
+    repo = _repo_root()
+    if not (repo / ".git").exists():
+        print(
+            "threadhop update: not a git checkout; re-run the installer instead:\n"
+            f"  curl -LsSf https://raw.githubusercontent.com/{UPDATE_REPO}/main/install.sh | bash",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.check:
+        info = _check_for_update(force=True)
+        if info is None:
+            print(f"ThreadHop {__version__} is up to date.")
+            return 0
+        _print_cli_update_notice(info)
+        return 0
+
+    if not args.force:
+        refusal = _dirty_tree_refusal(repo)
+        if refusal is not None:
+            print(refusal, file=sys.stderr)
+            return 1
+
+    rc, out, err = _run_git(repo, "fetch", "--tags", "origin")
+    if rc != 0:
+        print(
+            f"threadhop update: git fetch failed:\n{err or out}",
+            file=sys.stderr,
+        )
+        return 1
+
+    ref = args.to or "origin/main"
+    rc, _, _ = _run_git(repo, "rev-parse", "--verify", ref)
+    if rc != 0:
+        print(
+            f"threadhop update: ref '{ref}' not found. "
+            "Try `git -C <repo> fetch --tags` or pick a different --to value.",
+            file=sys.stderr,
+        )
+        return 1
+
+    rc, _, err = _run_git(repo, "reset", "--hard", ref)
+    if rc != 0:
+        print(f"threadhop update: git reset failed:\n{err}", file=sys.stderr)
+        return 1
+
+    # `threadhop` was replaced on disk while we were running. mmap'd
+    # process text is safe on macOS/Linux, but we intentionally do no
+    # further Python work past this point (ADR-027 self-replacement
+    # note) — just report and return.
+    if args.to:
+        print(f"Pinned to {args.to}.")
+    else:
+        new_version = _read_version_from_script(repo / "threadhop") or "unknown"
+        print(f"Updated to {new_version}.")
+    return 0
+
+
+def cmd_changelog(args) -> int:
+    """Print CHANGELOG.md, paging through ``less -R`` on TTY (ADR-027)."""
+    del args  # no flags
+    repo = _repo_root()
+    local = repo / "CHANGELOG.md"
+    content: str | None = None
+
+    if local.exists():
+        try:
+            content = local.read_text()
+        except OSError as e:
+            print(f"threadhop changelog: {e}", file=sys.stderr)
+            return 1
+    else:
+        import urllib.request
+        try:
+            with urllib.request.urlopen(
+                UPDATE_RAW_CHANGELOG, timeout=UPDATE_FETCH_TIMEOUT_S,
+            ) as resp:
+                content = resp.read().decode("utf-8", errors="replace")
+        except Exception:
+            print(
+                "CHANGELOG not available offline. See "
+                f"{UPDATE_REPO_URL}/blob/main/CHANGELOG.md",
+                file=sys.stderr,
+            )
+            return 1
+
+    if sys.stdout.isatty():
+        try:
+            subprocess.run(["less", "-R"], input=content, text=True)
+            return 0
+        except FileNotFoundError:
+            pass  # fall through to raw print
+    print(content)
+    return 0
+
+
+def cmd_future(args) -> int:
+    """Print the top 5 ROADMAP.md entries (ADR-027)."""
+    del args
+    repo = _repo_root()
+    roadmap = repo / "ROADMAP.md"
+    full_url = f"{UPDATE_REPO_URL}/blob/main/ROADMAP.md"
+
+    if not roadmap.exists():
+        print(
+            "Roadmap is not available on this install.\n"
+            f"See {full_url}"
+        )
+        return 0
+
+    entries: list[tuple[str, str]] = []
+    try:
+        for line in roadmap.read_text().splitlines():
+            m = ROADMAP_ENTRY_RE.match(line)
+            if m:
+                entries.append((m.group(1), m.group(2)))
+                if len(entries) >= 5:
+                    break
+    except OSError as e:
+        print(f"threadhop future: {e}", file=sys.stderr)
+        return 1
+
+    if not entries:
+        print(
+            "Roadmap is empty on this install.\n"
+            f"See {full_url}"
+        )
+        return 0
+
+    print("ThreadHop — what's coming up:\n")
+    for num, desc in entries:
+        print(f"  #{num}  {desc}")
+    print(f"\nFull roadmap:\n  {full_url}")
+    return 0
+
+
 def main():
     parser = build_parser()
     args = parser.parse_args()
+
+    # Startup update-check (ADR-027). CLI mode only — the TUI runs its
+    # own check in `ClaudeSessions.on_mount()` and surfaces the result
+    # as a toast. `update` is skipped because it has its own --check
+    # flag and already talks to GitHub.
+    if args.command not in (None, "update"):
+        info = _check_for_update()
+        if info is not None:
+            _print_cli_update_notice(info)
 
     if args.command is None:
         from tui import run_tui
@@ -1982,6 +2442,12 @@ def main():
         return cmd_observations(args)
     if args.command == "handoff":
         return cmd_handoff(args)
+    if args.command == "update":
+        return cmd_update(args)
+    if args.command == "changelog":
+        return cmd_changelog(args)
+    if args.command == "future":
+        return cmd_future(args)
     return _cli_stub(args.command)
 
 

--- a/threadhop
+++ b/threadhop
@@ -430,6 +430,16 @@ LOCAL_COMMAND_RE = re.compile(
 # inner text so the title stays meaningful (e.g. "/reload-plugins").
 COMMAND_TAG_RE = re.compile(r"</?(?:command-name|command-message|command-args)>")
 
+# Every `claude -p` invocation by the observer/reflector pipelines opens its
+# own Claude Code session — which then shows up as a JSONL file under
+# ~/.claude/projects/. Filter those out of the session list by matching the
+# distinctive first-line header of the prompt templates (prompts/observer.md,
+# prompts/reflector.md). Keep in sync with those prompt templates.
+OBSERVER_SUBPROCESS_SIGNATURES: tuple[str, ...] = (
+    "# ThreadHop Observer Prompt",
+    "# ThreadHop Reflector Prompt",
+)
+
 
 # --- Command metadata registry (ADR-017, task #42) ---
 #

--- a/tui.py
+++ b/tui.py
@@ -2959,6 +2959,422 @@ class FindBar(Horizontal):
             pass
 
 
+def _kanban_card_title(session: dict, custom_name: str | None) -> str:
+    """Title line for a Kanban card.
+
+    Priority chain mirrors what ``claude -r`` shows in Claude Code's
+    own session picker — the invariant the user wants is "a card's
+    title is the same thing Claude surfaces when you resume the
+    session":
+
+      1. ``custom_name``   — ThreadHop's local rename (SQLite).
+      2. ``custom_title``  — /rename written into JSONL as
+         ``{"type": "custom-title", ...}`` (either side writes this).
+      3. ``ai_title``      — Claude's auto-generated title.
+      4. ``first_user_msg`` — last-resort.
+      5. ``Session <short_id>`` — guarantees a unique label.
+
+    The ``project`` fallback the sidebar uses is still skipped — on a
+    board scoped to one project every untitled card would otherwise
+    show the same directory name.
+    """
+    if custom_name:
+        return custom_name
+    custom_title = (session.get("custom_title") or "").strip()
+    if custom_title:
+        return custom_title
+    ai_title = (session.get("ai_title") or "").strip()
+    if ai_title:
+        return ai_title
+    msg = (session.get("first_user_msg") or "").strip()
+    if msg:
+        return msg
+    sid = session.get("session_id") or ""
+    return f"Session {sid[:8]}" if sid else "(untitled)"
+
+
+class KanbanCard(Static):
+    """A session card on the Kanban board.
+
+    Subclassed from ``Static`` so the content renders like any text
+    block, but carries the ``session_id`` and handles ``on_click`` —
+    single-click opens the session's transcript (same contract as
+    pressing enter on the keyboard cursor). Without this, cards were
+    inert ``Static`` instances and the mouse path was dead.
+    """
+
+    def __init__(
+        self,
+        session: dict,
+        *,
+        custom_name: str | None,
+        selected: bool,
+    ) -> None:
+        title_text = _kanban_card_title(session, custom_name)
+        turns = session.get("turn_count", 0)
+        age = format_age(session["modified"])
+
+        # Cap title length as a safety net against a pathologically
+        # long custom rename pushing the meta line out of the fixed
+        # card height. At typical column widths (~20-30 chars) 80
+        # chars wraps to ~3 lines max, which the card height clips
+        # gracefully without hiding the meta row.
+        if len(title_text) > 80:
+            title_text = title_text[:79] + "…"
+        # Title is allowed to WRAP (no ``no_wrap``) so the full rename
+        # is visible when it fits in two lines. Sidebar keeps single-
+        # line ellipsis because rows there are 1 cell tall.
+        title = Text(title_text, style="bold")
+
+        meta = Text()
+        meta.append(age, style="dim")
+        meta.append("  ·  ", style="dim")
+        meta.append(f"{turns}t", style="dim")
+        if session.get("is_working"):
+            meta.append("  ·  ", style="dim")
+            meta.append("◐ working", style="bold yellow")
+        elif session.get("is_active"):
+            meta.append("  ·  ", style="dim")
+            meta.append("● active", style="green")
+
+        content = Group(title, meta)
+
+        classes = "kanban-card"
+        if selected:
+            classes += " -selected"
+        super().__init__(content, classes=classes)
+        self.session_id: str = session.get("session_id", "")
+
+    def on_click(self) -> None:
+        """Single-click selects and opens — matches enter on the keyboard
+        cursor. We route through the screen so the cursor lands on this
+        card first (keeps the 2D cursor state coherent for any live
+        refresh that happens mid-dismiss) and then dismiss."""
+        screen = self.screen
+        if isinstance(screen, KanbanScreen) and self.session_id:
+            screen._focus_session_id(self.session_id)
+            screen._render_board()
+            screen.dismiss(self.session_id)
+
+
+class KanbanScreen(ModalScreen):
+    """Full-screen Kanban view: sessions bucketed by status with 2D nav.
+
+    The CSS layout reset is deliberate — the app's top-level
+    ``Screen { layout: grid; grid-columns: 36 1fr; ... }`` rule
+    cascades to ``ModalScreen`` subclasses and would otherwise squeeze
+    the board into the 36-col sidebar slot. Same workaround as
+    ``SearchScreen``.
+
+    Navigation model: the screen owns a 2D cursor (col_idx +
+    row_idx_per_col). Arrow keys move the cursor; shift+arrows reassign
+    the selected session's status via ``db.set_session_status`` and
+    follow the card to its new column. Enter dismisses with the
+    selected ``session_id`` so the host app can load that transcript.
+
+    Live updates: the host app calls ``update_sessions`` from
+    ``_apply_session_data`` on each 5-second refresh. Selection is
+    preserved across rebuilds by session_id — a card whose status
+    changed elsewhere pulls the cursor with it to the new column.
+    """
+
+    CSS = """
+    KanbanScreen {
+        layout: vertical;
+        align: center middle;
+        background: $background 70%;
+    }
+    #kanban-container {
+        width: 95%;
+        height: 90%;
+        background: $surface;
+        border: round $primary;
+        padding: 1 2;
+        layout: vertical;
+    }
+    #kanban-title {
+        height: 1;
+        content-align: center middle;
+        text-style: bold;
+        color: $accent;
+    }
+    #kanban-columns {
+        height: 1fr;
+        layout: horizontal;
+    }
+    .kanban-column {
+        width: 1fr;
+        min-width: 18;
+        height: 100%;
+        margin: 0 1;
+        layout: vertical;
+    }
+    .kanban-column-header {
+        height: 2;
+        content-align: center middle;
+        text-style: bold;
+        background: $boost;
+        color: $accent;
+    }
+    .kanban-column-scroll {
+        height: 1fr;
+        border: round $primary-darken-2;
+        padding: 0 1;
+    }
+    .kanban-card {
+        height: 5;
+        padding: 0 1;
+        margin-top: 1;
+        border: tall $primary-darken-2;
+    }
+    /* Three-layer selection highlight mirrors the transcript
+       message-selected rule (tui.py:3470) so the selected state looks
+       like "selected" across every theme. $warning is reserved and
+       always contrasts strongly against $surface/$background, so the
+       cursor stays visible whether the user is on dracula, nord,
+       monokai, or one of the light variants. */
+    .kanban-card.-selected {
+        border: heavy $warning;
+        background: $warning 25%;
+        tint: $warning 8%;
+    }
+    .kanban-card:hover {
+        border: tall $accent;
+    }
+    .kanban-empty {
+        color: $text-muted;
+        text-style: italic;
+        padding: 1;
+    }
+    #kanban-hint {
+        height: 1;
+        content-align: center middle;
+        color: $text-muted;
+    }
+    """
+
+    # priority=True is load-bearing for the arrow keys: without it the
+    # focused VerticalScroll column consumes up/down to scroll itself
+    # before the Screen binding ever sees the key, which made the 2D
+    # cursor feel unresponsive. Priority bindings fire before
+    # widget-local ones regardless of focus.
+    BINDINGS = [
+        Binding("escape", "close", "Close", show=False),
+        Binding("left", "cursor_col(-1)", "Prev column", show=False, priority=True),
+        Binding("right", "cursor_col(1)", "Next column", show=False, priority=True),
+        Binding("up", "cursor_row(-1)", "Prev card", show=False, priority=True),
+        Binding("down", "cursor_row(1)", "Next card", show=False, priority=True),
+        Binding("shift+left", "move_card(-1)", "Move card left",
+                show=False, priority=True),
+        Binding("shift+right", "move_card(1)", "Move card right",
+                show=False, priority=True),
+        Binding("enter", "open_card", "Open session", show=False),
+    ]
+
+    def __init__(self, sessions: list[dict], custom_names: dict[str, str]) -> None:
+        super().__init__()
+        self._sessions: list[dict] = list(sessions)
+        self._custom_names: dict[str, str] = dict(custom_names)
+        self._columns: dict[str, list[dict]] = {s: [] for s in STATUS_ORDER}
+        self._col_idx: int = 0
+        # Per-column row cursor — moving between columns lands on the
+        # last row you visited in the destination column, which feels
+        # more natural than always snapping back to row 0.
+        self._row_idx_per_col: dict[int, int] = {
+            i: 0 for i in range(len(STATUS_ORDER))
+        }
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="kanban-container"):
+            yield Static("ThreadHop — Kanban", id="kanban-title")
+            with Horizontal(id="kanban-columns"):
+                for status in STATUS_ORDER:
+                    with Vertical(classes="kanban-column"):
+                        yield Static(
+                            "",
+                            classes="kanban-column-header",
+                            id=f"khdr-{status}",
+                        )
+                        # can_focus=False so the Screen keeps key focus —
+                        # otherwise the scroll container grabs up/down
+                        # and the 2D cursor never moves. Mouse wheel
+                        # still works because that's a different event.
+                        scroll = VerticalScroll(
+                            id=f"kscroll-{status}",
+                            classes="kanban-column-scroll",
+                        )
+                        scroll.can_focus = False
+                        yield scroll
+            yield Static(
+                "←/→ column   ↑/↓ card   ⇧←/⇧→ move card   "
+                "enter/click open   esc close",
+                id="kanban-hint",
+            )
+
+    def on_mount(self) -> None:
+        self._bucket()
+        self._render_board()
+
+    # --- data -----------------------------------------------------------
+
+    def _bucket(self) -> None:
+        """Group sessions by status, preserving input order within each bucket.
+
+        The host app's ``_apply_stable_ordering`` already sorts sessions
+        by (status_rank, manual_sort_order), so iterating in order here
+        gives us columns that match the sidebar's within-status ordering
+        — no surprise jumps when a user toggles between the two views.
+        """
+        self._columns = {s: [] for s in STATUS_ORDER}
+        for s in self._sessions:
+            status = s.get("status", "active")
+            if status not in self._columns:
+                status = "active"
+            self._columns[status].append(s)
+
+    def update_sessions(
+        self,
+        sessions: list[dict],
+        custom_names: dict[str, str],
+    ) -> None:
+        """Called by the host app every 5s with fresh session data.
+
+        Preserves the user's current selection by session_id — if the
+        selected session's status changed (e.g. another process updated
+        the DB), the cursor follows the card to its new column rather
+        than resetting to (0, 0) and disorienting the user.
+        """
+        current = self._current_session()
+        selected_id = current.get("session_id") if current else None
+        self._sessions = list(sessions)
+        self._custom_names = dict(custom_names)
+        self._bucket()
+        if selected_id is not None:
+            self._focus_session_id(selected_id)
+        self._render_board()
+
+    def _current_status(self) -> str:
+        return STATUS_ORDER[self._col_idx]
+
+    def _current_column(self) -> list[dict]:
+        return self._columns[self._current_status()]
+
+    def _current_session(self) -> dict | None:
+        col = self._current_column()
+        if not col:
+            return None
+        row = min(self._row_idx_per_col[self._col_idx], len(col) - 1)
+        return col[row]
+
+    def _focus_session_id(self, session_id: str) -> bool:
+        for i, status in enumerate(STATUS_ORDER):
+            for r, s in enumerate(self._columns[status]):
+                if s.get("session_id") == session_id:
+                    self._col_idx = i
+                    self._row_idx_per_col[i] = r
+                    return True
+        return False
+
+    # --- render ---------------------------------------------------------
+
+    def _render_board(self) -> None:
+        for i, status in enumerate(STATUS_ORDER):
+            cards = self._columns[status]
+            header = self.query_one(f"#khdr-{status}", Static)
+            header.update(f"{STATUS_LABELS[status]}  ({len(cards)})")
+
+            scroll = self.query_one(f"#kscroll-{status}", VerticalScroll)
+            scroll.remove_children()
+            if not cards:
+                scroll.mount(Static("— empty —", classes="kanban-empty"))
+                continue
+
+            row_sel = min(self._row_idx_per_col[i], len(cards) - 1)
+            self._row_idx_per_col[i] = row_sel
+            for r, s in enumerate(cards):
+                is_selected = (i == self._col_idx and r == row_sel)
+                card = KanbanCard(
+                    s,
+                    custom_name=self._custom_names.get(s.get("session_id")),
+                    selected=is_selected,
+                )
+                scroll.mount(card)
+
+        # Defer scroll-into-view so the mounted cards exist before we
+        # try to address them — mount is async from the renderer's
+        # perspective and scroll_to_widget needs a real widget handle.
+        self.call_after_refresh(self._scroll_selected_into_view)
+
+    def _scroll_selected_into_view(self) -> None:
+        status = self._current_status()
+        row = self._row_idx_per_col[self._col_idx]
+        try:
+            scroll = self.query_one(f"#kscroll-{status}", VerticalScroll)
+        except Exception:
+            return
+        cards = [c for c in scroll.children if isinstance(c, KanbanCard)]
+        if 0 <= row < len(cards):
+            scroll.scroll_to_widget(cards[row], animate=False)
+
+    # --- actions --------------------------------------------------------
+
+    def action_close(self) -> None:
+        self.dismiss(None)
+
+    def action_cursor_col(self, delta: int) -> None:
+        self._col_idx = (self._col_idx + delta) % len(STATUS_ORDER)
+        self._render_board()
+
+    def action_cursor_row(self, delta: int) -> None:
+        col = self._current_column()
+        if not col:
+            return
+        cur = self._row_idx_per_col[self._col_idx]
+        self._row_idx_per_col[self._col_idx] = max(
+            0, min(cur + delta, len(col) - 1)
+        )
+        self._render_board()
+
+    def action_move_card(self, delta: int) -> None:
+        """Reassign the selected session's status by ``delta`` columns.
+
+        Writes to the DB first so the next refresh won't resurrect the
+        old status; updates the in-memory dict so the re-render moves
+        the card immediately (optimistic, but the write is synchronous
+        SQLite so latency is sub-ms).
+        """
+        session = self._current_session()
+        if session is None:
+            return
+        new_col_idx = self._col_idx + delta
+        if not (0 <= new_col_idx < len(STATUS_ORDER)):
+            return
+        new_status = STATUS_ORDER[new_col_idx]
+        if new_status == session.get("status"):
+            return
+        session_id = session["session_id"]
+        try:
+            db.set_session_status(self.app.conn, session_id, new_status)
+        except Exception:
+            # A failed write shouldn't crash the view; the next live
+            # refresh will reconcile the display with the real DB state.
+            return
+        session["status"] = new_status
+        self._bucket()
+        self._col_idx = new_col_idx
+        for r, s in enumerate(self._columns[new_status]):
+            if s.get("session_id") == session_id:
+                self._row_idx_per_col[new_col_idx] = r
+                break
+        self._render_board()
+
+    def action_open_card(self) -> None:
+        session = self._current_session()
+        if session is None:
+            return
+        self.dismiss(session.get("session_id"))
+
+
 class ClaudeSessions(App):
     """Cross-session context manager for Claude Code"""
 
@@ -3172,7 +3588,13 @@ class ClaudeSessions(App):
     # Bindings come from the shared command registry (ADR-017). Add new
     # App-level commands to COMMAND_REGISTRY above, not here — footer and
     # help overlay both read from the same list.
-    BINDINGS = app_bindings_from_registry()
+    #
+    # Kanban is a mockup binding deliberately left out of COMMAND_REGISTRY
+    # so the help overlay + footer don't advertise an unvalidated feature.
+    # Promote to the registry once the view earns its keep.
+    BINDINGS = app_bindings_from_registry() + [
+        Binding("B", "open_kanban", "Kanban board", show=False, priority=True),
+    ]
 
     SIDEBAR_MIN = 20
     SIDEBAR_MAX = 60
@@ -3343,6 +3765,7 @@ class ClaudeSessions(App):
                     is_working = False
                     last_msg_type = None
                     has_pending_tool = False
+                    user_turn_count = 0
 
                     try:
                         with open(jsonl) as f:
@@ -3392,6 +3815,12 @@ class ClaudeSessions(App):
                                             last_msg_type = "tool_result"
                                         else:
                                             last_msg_type = "user"
+                                            # Count only genuine user prompts
+                                            # (tool results also have type=user;
+                                            # ADR-003 assistant chunks share a
+                                            # message.id so counting assistant
+                                            # lines would massively inflate).
+                                            user_turn_count += 1
                                 except:
                                     pass
                         # Session is "active" if a claude process is running for it
@@ -3408,6 +3837,16 @@ class ClaudeSessions(App):
                     except:
                         pass
 
+                    # Skip observer/reflector subprocess sessions. Every
+                    # `claude -p` call spawned by the observation pipeline
+                    # opens a fresh Claude Code session whose first user
+                    # message is the prompt template itself — they are
+                    # extractor traffic, not user-facing conversations.
+                    if first_user_msg and first_user_msg.startswith(
+                        OBSERVER_SUBPROCESS_SIGNATURES
+                    ):
+                        continue
+
                     # Title priority: custom > ai > first message
                     session_title = custom_title or ai_title or first_user_msg
                     if session_cwd:
@@ -3422,9 +3861,27 @@ class ClaudeSessions(App):
                             "created": stat.st_ctime,
                             "modified": stat.st_mtime,
                             "title": session_title,
+                            # Kept separate from ``title`` so surfaces
+                            # that deliberately avoid ai-titles (e.g.
+                            # the Kanban) can pick just the user-authored
+                            # rename without the AI-auto-summarize line
+                            # slipping in as a fallback.
+                            "custom_title": custom_title or "",
+                            # ai-title kept alongside so the Kanban can
+                            # mirror what `claude -r` shows in Claude
+                            # Code's own session picker: user-rename
+                            # wins, then AI-generated title, then the
+                            # first user message. Sidebar continues to
+                            # use the `title` composite for backward
+                            # compat.
+                            "ai_title": ai_title or "",
                             "first_user_msg": first_user_msg,
                             "is_active": has_process,
                             "is_working": is_working,
+                            # user prompts × 2 ≈ exchange count (one
+                            # user msg + one assistant reply per turn);
+                            # see KanbanScreen meta line.
+                            "turn_count": user_turn_count * 2,
                         }
                     )
         except:
@@ -3493,6 +3950,27 @@ class ClaudeSessions(App):
         self._apply_stable_ordering()
         self._update_session_list(force_rebuild)
         self.refresh_transcript()
+
+        # If the Kanban modal is open, push the same fresh data into it
+        # so board cards stay in step with the sidebar. The screen stack
+        # is a list; the top is the active screen. We check the type
+        # rather than storing a reference so the screen is fully owned
+        # by Textual's screen stack and GC'd on dismiss without extra
+        # cleanup on our side.
+        try:
+            top = self.screen
+        except Exception:
+            top = None
+        if isinstance(top, KanbanScreen):
+            try:
+                top.update_sessions(
+                    self.sessions,
+                    self.config.get("session_names", {}) or {},
+                )
+            except Exception:
+                # A render hiccup in the modal must not break the 5s
+                # refresh loop for the rest of the app.
+                pass
 
     def _apply_stable_ordering(self) -> None:
         if "session_order" not in self.config:
@@ -3760,6 +4238,59 @@ class ClaudeSessions(App):
         # Theme stays in config.json (app-level setting per ADR-001).
         save_app_config(self.config)
         self.notify(f"Theme: {self.theme}")
+
+    def _mirror_custom_title_to_jsonl(
+        self, session_id: str, new_name: str
+    ) -> None:
+        """Append a ``custom-title`` line to the session's JSONL.
+
+        Same shape Claude Code's ``/rename`` produces, so all JSONL
+        readers (including Claude Code itself and the next ThreadHop
+        refresh tick at tui.py:3776) see the rename. Safe to call
+        concurrently with Claude Code's own writes — POSIX guarantees
+        single-write appends are atomic, and JSONL is line-addressable,
+        so an interleaved Claude Code append lands on a separate line.
+
+        Best-effort: a missing file, permissions hiccup, or unusual
+        filesystem state must not take the TUI down. SQLite remains
+        the authoritative store for ThreadHop's sidebar rendering.
+        """
+        session = next(
+            (s for s in self.sessions if s.get("session_id") == session_id),
+            None,
+        )
+        if session is None:
+            return
+        session_path = session.get("path")
+        if not session_path:
+            return
+        try:
+            path = Path(session_path)
+        except Exception:
+            return
+        if not path.is_file():
+            return
+        entry = {
+            "type": "custom-title",
+            "customTitle": new_name,
+            "sessionId": session_id,
+            "timestamp": (
+                datetime.now(timezone.utc)
+                .isoformat(timespec="milliseconds")
+                .replace("+00:00", "Z")
+            ),
+        }
+        try:
+            with path.open("a") as f:
+                f.write(json.dumps(entry) + "\n")
+        except OSError:
+            # Filesystem errors are surfaced via notify so the user
+            # knows the JSONL mirror didn't land, but SQLite has the
+            # rename either way.
+            self.notify(
+                "Rename saved locally but not mirrored to JSONL",
+                severity="warning",
+            )
 
     def action_rename_session(self) -> None:
         if self._input_has_focus():
@@ -4088,6 +4619,42 @@ class ClaudeSessions(App):
         except (TypeError, ValueError):
             return
         self._jump_to_search_result(session_id, message_uuid, search_terms=None)
+
+    def action_open_kanban(self) -> None:
+        """Open the Kanban board modal (mockup).
+
+        Skips while a text input holds focus so `B` still types when the
+        user is composing a reply. Hands the current sessions list + the
+        custom-name map to the screen so it renders consistently with the
+        sidebar from the very first frame.
+        """
+        if self._input_has_focus():
+            return
+        custom_names = self.config.get("session_names", {}) or {}
+        self.push_screen(
+            KanbanScreen(self.sessions, custom_names),
+            self._on_kanban_dismissed,
+        )
+
+    def _on_kanban_dismissed(self, session_id) -> None:
+        """Enter on a Kanban card dismisses with the picked session_id.
+
+        We reload the sidebar selection to that session and let the
+        normal ListView.Highlighted handler drive the transcript load —
+        that path also stamps last_viewed and clears the unread flag,
+        which we'd otherwise have to duplicate here.
+        """
+        if not session_id:
+            return
+        list_view = self.query_one("#session-list", ListView)
+        for idx, item in enumerate(list_view.children):
+            if (
+                isinstance(item, SessionItem)
+                and item.session_data.get("session_id") == session_id
+            ):
+                list_view.index = idx
+                list_view.focus()
+                return
 
     def bookmark_toggle_selection(self) -> None:
         """Selection-mode `space`: toggle a bookmark on each selected
@@ -4522,6 +5089,17 @@ class ClaudeSessions(App):
                 db.set_custom_name(self.conn, session_id, input_text or None)
             except Exception:
                 pass
+            # Mirror SET (not CLEAR) into the session JSONL as a
+            # `custom-title` line — same shape Claude Code's /rename
+            # writes, which `_gather_session_data` already reads at
+            # tui.py:3776. This closes the loop so a name set here
+            # shows up in Claude Code's own session surfaces too. On
+            # CLEAR we deliberately DO NOT write — that lets the user
+            # "drop my local override" without clobbering whatever
+            # name Claude Code has on its side (last-write-wins means
+            # an empty string would win, which is never what you want).
+            if input_text:
+                self._mirror_custom_title_to_jsonl(session_id, input_text)
             text_area.clear()
             self.query_one("#session-list", ListView).focus()
             self.load_sessions(force_rebuild=True)

--- a/tui.py
+++ b/tui.py
@@ -2993,14 +2993,18 @@ def _kanban_card_title(session: dict, custom_name: str | None) -> str:
     return f"Session {sid[:8]}" if sid else "(untitled)"
 
 
-class KanbanCard(Static):
+class KanbanCard(Vertical):
     """A session card on the Kanban board.
 
-    Subclassed from ``Static`` so the content renders like any text
-    block, but carries the ``session_id`` and handles ``on_click`` —
-    single-click opens the session's transcript (same contract as
-    pressing enter on the keyboard cursor). Without this, cards were
-    inert ``Static`` instances and the mouse path was dead.
+    Structured as a ``Vertical`` container with **two** children — a
+    title Static that flexes, and a meta Static pinned to a single row
+    at the bottom — rather than a monolithic Static. The two-widget
+    layout is load-bearing: when the title wraps to multiple lines the
+    meta row stays visible because it has its own guaranteed row in
+    the layout rather than flowing after the title inside a single
+    Rich Group (which was pushing meta off the bottom of the fixed-
+    height card on long titles). Pattern is the same as docking a
+    footer inside a panel.
     """
 
     def __init__(
@@ -3014,16 +3018,13 @@ class KanbanCard(Static):
         turns = session.get("turn_count", 0)
         age = format_age(session["modified"])
 
-        # Cap title length as a safety net against a pathologically
-        # long custom rename pushing the meta line out of the fixed
-        # card height. At typical column widths (~20-30 chars) 80
-        # chars wraps to ~3 lines max, which the card height clips
-        # gracefully without hiding the meta row.
+        # Defensive cap against pathologically long custom renames.
+        # The layout can handle wrap naturally, but a 200-char title
+        # at column width 22 would still wrap to 10 rows and clip
+        # most of itself — truncating keeps the first meaningful
+        # portion visible.
         if len(title_text) > 80:
             title_text = title_text[:79] + "…"
-        # Title is allowed to WRAP (no ``no_wrap``) so the full rename
-        # is visible when it fits in two lines. Sidebar keeps single-
-        # line ellipsis because rows there are 1 cell tall.
         title = Text(title_text, style="bold")
 
         meta = Text()
@@ -3037,19 +3038,25 @@ class KanbanCard(Static):
             meta.append("  ·  ", style="dim")
             meta.append("● active", style="green")
 
-        content = Group(title, meta)
-
         classes = "kanban-card"
         if selected:
             classes += " -selected"
-        super().__init__(content, classes=classes)
+        super().__init__(classes=classes)
+        self._title_text = title
+        self._meta_text = meta
         self.session_id: str = session.get("session_id", "")
+
+    def compose(self) -> ComposeResult:
+        yield Static(self._title_text, classes="kanban-card-title")
+        yield Static(self._meta_text, classes="kanban-card-meta")
 
     def on_click(self) -> None:
         """Single-click selects and opens — matches enter on the keyboard
         cursor. We route through the screen so the cursor lands on this
         card first (keeps the 2D cursor state coherent for any live
-        refresh that happens mid-dismiss) and then dismiss."""
+        refresh that happens mid-dismiss) and then dismiss. Click events
+        from the two child Statics bubble up to us here because Textual
+        propagates events unless a handler calls ``event.stop()``."""
         screen = self.screen
         if isinstance(screen, KanbanScreen) and self.session_id:
             screen._focus_session_id(self.session_id)
@@ -3126,6 +3133,20 @@ class KanbanScreen(ModalScreen):
         padding: 0 1;
         margin-top: 1;
         border: tall $primary-darken-2;
+        layout: vertical;
+    }
+    /* Title fills any rows left over after the meta row; wrapping
+       is allowed but excess rows clip here, so a freakishly long
+       title can't push meta out of the card. */
+    .kanban-card-title {
+        height: 1fr;
+        overflow-y: hidden;
+    }
+    /* Meta is always exactly one row at the bottom — the guarantee
+       that turns / age / activity stay visible regardless of title
+       length. */
+    .kanban-card-meta {
+        height: 1;
     }
     /* Three-layer selection highlight mirrors the transcript
        message-selected rule (tui.py:3470) so the selected state looks
@@ -3183,6 +3204,12 @@ class KanbanScreen(ModalScreen):
         self._row_idx_per_col: dict[int, int] = {
             i: 0 for i in range(len(STATUS_ORDER))
         }
+        # Signature of the last rendered board — structural fields
+        # only, not the modified mtime (which ticks every write on
+        # an active session and would cause a rebuild every refresh).
+        # update_sessions skips rebuild when this hasn't changed,
+        # which is the 5s-refresh flicker fix.
+        self._last_sig: tuple | None = None
 
     def compose(self) -> ComposeResult:
         with Vertical(id="kanban-container"):
@@ -3213,6 +3240,11 @@ class KanbanScreen(ModalScreen):
 
     def on_mount(self) -> None:
         self._bucket()
+        # Seed the signature so the very first 5s tick can early-return
+        # when nothing has actually changed since open.
+        self._last_sig = tuple(
+            self._session_signature(s) for s in self._sessions
+        )
         self._render_board()
 
     # --- data -----------------------------------------------------------
@@ -3232,6 +3264,28 @@ class KanbanScreen(ModalScreen):
                 status = "active"
             self._columns[status].append(s)
 
+    @staticmethod
+    def _session_signature(session: dict) -> tuple:
+        """Structural fingerprint of a single session for rebuild-dedup.
+
+        Deliberately **excludes** ``modified`` (file mtime) — it ticks
+        on every write during an active Claude session, which would
+        flip the signature every refresh and force a rebuild every 5s
+        even when nothing visible to the user changed. Age displays
+        drift between structural changes; that's the tradeoff for not
+        flickering.
+        """
+        return (
+            session.get("session_id") or "",
+            session.get("status") or "active",
+            session.get("turn_count", 0),
+            bool(session.get("is_working")),
+            bool(session.get("is_active")),
+            session.get("custom_title") or "",
+            session.get("ai_title") or "",
+            (session.get("first_user_msg") or "")[:60],
+        )
+
     def update_sessions(
         self,
         sessions: list[dict],
@@ -3239,15 +3293,25 @@ class KanbanScreen(ModalScreen):
     ) -> None:
         """Called by the host app every 5s with fresh session data.
 
-        Preserves the user's current selection by session_id — if the
-        selected session's status changed (e.g. another process updated
-        the DB), the cursor follows the card to its new column rather
-        than resetting to (0, 0) and disorienting the user.
+        Early-returns when the board signature is unchanged so the
+        refresh tick doesn't flicker the cards. Preserves the user's
+        current selection by session_id — if the selected session's
+        status changed (e.g. another process updated the DB), the
+        cursor follows the card to its new column.
         """
+        new_sig = tuple(self._session_signature(s) for s in sessions)
+        new_names = dict(custom_names)
+        if new_sig == self._last_sig and new_names == self._custom_names:
+            # Nothing structurally changed — skip the tear-down /
+            # remount that would otherwise fire every 5 seconds.
+            # Always-visible in-session edits (age ticks, new messages
+            # landing) are not visible on cards anyway.
+            return
         current = self._current_session()
         selected_id = current.get("session_id") if current else None
         self._sessions = list(sessions)
-        self._custom_names = dict(custom_names)
+        self._custom_names = new_names
+        self._last_sig = new_sig
         self._bucket()
         if selected_id is not None:
             self._focus_session_id(selected_id)
@@ -3316,6 +3380,31 @@ class KanbanScreen(ModalScreen):
         if 0 <= row < len(cards):
             scroll.scroll_to_widget(cards[row], animate=False)
 
+    def _update_selection(self) -> None:
+        """Toggle the ``-selected`` CSS class on whichever card the
+        cursor is on — **without** re-mounting any cards. This is the
+        cursor-move flicker fix: arrow keys used to call
+        ``_render_board``, which tears down and re-creates every card
+        in every column on every keystroke. Now cursor nav is a pure
+        class-flip, which Textual repaints in place.
+        """
+        cur_status = STATUS_ORDER[self._col_idx]
+        cur_row = self._row_idx_per_col[self._col_idx]
+        for status in STATUS_ORDER:
+            try:
+                scroll = self.query_one(f"#kscroll-{status}", VerticalScroll)
+            except Exception:
+                continue
+            cards = [c for c in scroll.children if isinstance(c, KanbanCard)]
+            for r, card in enumerate(cards):
+                should = (status == cur_status and r == cur_row)
+                has = card.has_class("-selected")
+                if should and not has:
+                    card.add_class("-selected")
+                elif not should and has:
+                    card.remove_class("-selected")
+        self.call_after_refresh(self._scroll_selected_into_view)
+
     # --- actions --------------------------------------------------------
 
     def action_close(self) -> None:
@@ -3323,7 +3412,8 @@ class KanbanScreen(ModalScreen):
 
     def action_cursor_col(self, delta: int) -> None:
         self._col_idx = (self._col_idx + delta) % len(STATUS_ORDER)
-        self._render_board()
+        # Class-flip only — no tear-down / remount. See _update_selection.
+        self._update_selection()
 
     def action_cursor_row(self, delta: int) -> None:
         col = self._current_column()
@@ -3333,7 +3423,7 @@ class KanbanScreen(ModalScreen):
         self._row_idx_per_col[self._col_idx] = max(
             0, min(cur + delta, len(col) - 1)
         )
-        self._render_board()
+        self._update_selection()
 
     def action_move_card(self, delta: int) -> None:
         """Reassign the selected session's status by ``delta`` columns.
@@ -3367,6 +3457,13 @@ class KanbanScreen(ModalScreen):
                 self._row_idx_per_col[new_col_idx] = r
                 break
         self._render_board()
+        # Refresh the dedup signature so the next 5s refresh tick
+        # (which will see the same post-move state from the DB via
+        # _gather_session_data) early-returns instead of triggering
+        # a second, wasted rebuild.
+        self._last_sig = tuple(
+            self._session_signature(s) for s in self._sessions
+        )
 
     def action_open_card(self) -> None:
         session = self._current_session()

--- a/tui.py
+++ b/tui.py
@@ -3260,6 +3260,25 @@ class ClaudeSessions(App):
         # deterministic in tests that don't emit focus events.
         self.refresh_footer()
 
+        # 24h startup update check (ADR-027). Gates (env / TTY / cache /
+        # not-inside-claude) run inside `_check_for_update`; if a newer
+        # release is out, surface it as a transient toast. Wrapped in a
+        # broad try/except because a version check must never break the
+        # TUI — the helper already swallows network errors, this catches
+        # anything else.
+        try:
+            update_info = _check_for_update()
+        except Exception:
+            update_info = None
+        if update_info is not None:
+            self.notify(
+                f"ThreadHop {update_info.latest} available — "
+                "run `threadhop update`.",
+                title="Update available",
+                severity="information",
+                timeout=10,
+            )
+
     def update_titles(self) -> None:
         filter_info = ""
         if self.project_filter:


### PR DESCRIPTION
Combines two feature tracks into the v0.2.0 release:

- Kanban mode in the TUI (commits f52de92, 1efdcf5)
- ADR-027 update lifecycle: \`threadhop update\`, \`changelog\`, \`future\`, and 24h startup check (#64)

See CHANGELOG.md's 0.2.0 entry for the full list.