### PR TITLE
Add CI: automated release + PR validation workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Release
+
+# Fires on every push to main. If `__version__` changed vs the previous
+# commit, cut a git tag `vX.Y.Z` and create a matching GitHub Release
+# whose body is auto-extracted from the matching CHANGELOG.md section.
+# No-ops silently when the version is unchanged.
+#
+# Why key off `__version__` (not commit messages or manual tags)?
+# Because the bump is already visible in PR review — reviewers see it
+# in the diff alongside the CHANGELOG entry, so we never accidentally
+# release something unreviewed. See RELEASE.md.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write   # needed to create tags + releases via GITHUB_TOKEN
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need HEAD~1 to diff __version__ against the previous state.
+          fetch-depth: 2
+
+      - name: Detect version change
+        id: ver
+        run: |
+          set -euo pipefail
+          NEW=$(grep -oE '^__version__ = "[^"]+"' threadhop | head -1 | cut -d'"' -f2)
+          OLD=$(git show HEAD~1:threadhop 2>/dev/null \
+                | grep -oE '^__version__ = "[^"]+"' | head -1 | cut -d'"' -f2 \
+                || echo "")
+          echo "new=$NEW" >> "$GITHUB_OUTPUT"
+          echo "old=$OLD" >> "$GITHUB_OUTPUT"
+          if [ -n "$NEW" ] && [ "$NEW" != "$OLD" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Version changed $OLD -> $NEW; proceeding to release."
+          else
+            echo "::notice::No version change (current=$NEW); skipping release."
+          fi
+
+      - name: Refuse if tag already exists
+        if: steps.ver.outputs.changed == 'true'
+        run: |
+          V="${{ steps.ver.outputs.new }}"
+          if git ls-remote --tags origin | grep -qE "refs/tags/v${V}$"; then
+            echo "::error::Tag v${V} already exists. Aborting to avoid overwrite."
+            exit 1
+          fi
+
+      - name: Extract CHANGELOG section for this version
+        if: steps.ver.outputs.changed == 'true'
+        id: notes
+        run: |
+          set -euo pipefail
+          V="${{ steps.ver.outputs.new }}"
+          # Grab the block between `## [V]` and the next `## [` header.
+          NOTES=$(awk -v v="$V" '
+            $0 ~ "^## \\[" v "\\]" { p=1; next }
+            p && $0 ~ "^## \\[" { exit }
+            p { print }
+          ' CHANGELOG.md)
+          if [ -z "$(echo "$NOTES" | tr -d '[:space:]')" ]; then
+            echo "::error::CHANGELOG.md has no '## [${V}]' entry. Add one before bumping __version__."
+            exit 1
+          fi
+          {
+            echo "body<<CHANGELOG_EOF"
+            echo "$NOTES"
+            echo "CHANGELOG_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create tag and release
+        if: steps.ver.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          V="${{ steps.ver.outputs.new }}"
+          gh release create "v${V}" \
+            --target "${{ github.sha }}" \
+            --title "v${V}" \
+            --notes "${{ steps.notes.outputs.body }}"
+          echo "::notice::Released v${V}"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,63 @@
+name: Validate
+
+# Runs on every PR targeting main or docs/adr. Exposes a `validate`
+# status check that branch protection can require before merge.
+#
+# Checks (fast — no real test runtime yet):
+#   1. Python syntax of threadhop + tui.py
+#   2. Version parity across threadhop / marketplace.json / plugin.json
+#   3. CHANGELOG.md has a matching entry for the current __version__
+#   4. pytest, if tests/ exists
+#
+# These catch exactly the classes of bugs we've hit in practice:
+# version mismatches between the script and plugin manifests, and
+# version bumps without a paired CHANGELOG entry.
+
+on:
+  pull_request:
+    branches: [main, docs/adr]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Python syntax (threadhop, tui.py)
+        run: |
+          python3 -c "import ast; ast.parse(open('threadhop').read())"
+          python3 -c "import ast; ast.parse(open('tui.py').read())"
+
+      - name: Version parity (threadhop / marketplace.json / plugin.json)
+        run: |
+          set -euo pipefail
+          TH=$(grep -oE '^__version__ = "[^"]+"' threadhop | head -1 | cut -d'"' -f2)
+          MP=$(python3 -c "import json; print(json.load(open('.claude-plugin/marketplace.json'))['plugins'][0]['version'])")
+          PL=$(python3 -c "import json; print(json.load(open('plugin/.claude-plugin/plugin.json'))['version'])")
+          echo "threadhop=$TH  marketplace.json=$MP  plugin.json=$PL"
+          if [ "$TH" != "$MP" ] || [ "$TH" != "$PL" ]; then
+            echo "::error::Version mismatch — all three must agree (see RELEASE.md)."
+            exit 1
+          fi
+
+      - name: CHANGELOG entry exists for current __version__
+        run: |
+          set -euo pipefail
+          V=$(grep -oE '^__version__ = "[^"]+"' threadhop | head -1 | cut -d'"' -f2)
+          if ! grep -qE "^## \[$V\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md is missing a '## [$V]' entry."
+            exit 1
+          fi
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Run pytest if tests/ exists
+        run: |
+          if [ -d tests ] && [ -n "$(ls -A tests 2>/dev/null)" ]; then
+            uv run --with pytest --with rich --with textual \
+                   --with watchdog --with pydantic \
+                   python -m pytest -q tests/
+          else
+            echo "::notice::No tests/ directory with contents — skipping pytest."
+          fi

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,45 +2,115 @@
 
 ThreadHop ships as a git checkout. `threadhop update` and the 24-hour
 startup version check both compare `__version__` in the `threadhop`
-script against the newest tag on the GitHub repo. Without a tag, the
-check silently no-ops — not a false positive, just nothing at all. Keep
-tags in lockstep with `__version__` so users see the nudge.
+script against the latest GitHub **Release** (not a bare tag — see note
+below) on the repo. Without a matching Release, the check silently
+no-ops. Keep Releases and `__version__` in lockstep so users actually
+see the nudge.
 
-## Six-step release flow
+## Automated flow (default)
 
-Per [ADR-027](docs/DESIGN-DECISIONS.md#adr-027-update-lifecycle--threadhop-update-changelog-future-and-24h-startup-check):
+Releases are cut automatically by `.github/workflows/release.yml`
+whenever `__version__` changes on `main`. You don't run `git tag` or
+`gh release create` by hand — the workflow does both, using the
+matching `CHANGELOG.md` section as the release body.
 
-1. Update `CHANGELOG.md` with a new `## [X.Y.Z] — YYYY-MM-DD` header and
-   a bullet list of user-visible changes (Keep-a-Changelog style).
-2. Bump `__version__` in `threadhop`.
-3. Bump the `version` field in both
-   `.claude-plugin/marketplace.json` and
-   `plugin/.claude-plugin/plugin.json` to match.
-4. Commit everything together so the version, changelog, and plugin
-   manifests move as one unit.
-5. Cut and push the tag:
+A regular release PR looks like this:
+
+1. Branch from `main`:
    ```bash
-   git tag v0.2.0
-   git push --tags
+   git checkout main && git pull
+   git checkout -b release/0.3.0
    ```
-6. (Optional later) Draft GitHub Release notes from the new CHANGELOG
-   entry.
+2. Bump the three version fields together:
+   - `__version__` in `threadhop`
+   - `.plugins[0].version` in `.claude-plugin/marketplace.json`
+   - `.version` in `plugin/.claude-plugin/plugin.json`
+3. Add a new `## [0.3.0] — YYYY-MM-DD` section at the top of
+   `CHANGELOG.md` (Keep-a-Changelog style — Added / Changed /
+   Fixed / Removed). This becomes the Release body verbatim.
+4. Commit and open a PR to `main`:
+   ```bash
+   git add -u CHANGELOG.md
+   git commit -m "Bump to 0.3.0"
+   gh pr create --base main --title "Release 0.3.0"
+   ```
+5. Merge once `validate` is green. The `release` workflow fires on
+   push-to-main, detects the version change, refuses if `v0.3.0`
+   already exists, extracts the CHANGELOG section, and creates the
+   tag + GitHub Release.
 
-Steps 1–3 are reviewable in-PR. Step 5 is what arms the startup check;
-don't skip it.
+That's it. No manual tag step. No forgotten GitHub Release creation.
+
+### What `validate` catches on each PR
+
+`.github/workflows/validate.yml` provides the `validate` status check
+that branch protection requires before any PR can merge to `main`:
+
+- Python syntax for `threadhop` and `tui.py`
+- Version parity — `threadhop` / `marketplace.json` / `plugin.json`
+  must all report the same version
+- `CHANGELOG.md` must have a `## [X.Y.Z]` entry matching the current
+  `__version__`
+- `pytest` runs if `tests/` has content
+
+Failure on any one of these blocks the merge.
+
+### What `release` catches on push to main
+
+- Duplicate tag — refuses to overwrite an existing `vX.Y.Z`
+- Missing CHANGELOG section — refuses to cut a release without
+  notes for that version
+
+Both failures surface as a red workflow badge on the commit; they do
+not re-introduce the bad state on main (the merge already happened),
+but they make the release visibly broken so you notice.
 
 ## When to bump which component
 
 | Change | Bump |
 |---|---|
-| New subcommand, new TUI surface, new skill | minor (`0.1.0 → 0.2.0`) |
+| New subcommand, new TUI surface, new skill | minor (`0.2.0 → 0.3.0`) |
 | Bug fix that users would notice | patch |
 | Breaking change to the DB schema or CLI grammar (pre-1.0) | minor |
 
 Pre-release suffixes (`-rc1`, etc.) are not wired into `_parse_version`,
 so don't tag them — the startup check will treat the tag as malformed
-and fall back silently. If pre-releases ever become useful, widen the
-parser first.
+and silently fall back. Widen the parser first if pre-releases become
+useful later.
+
+## Manual release (fallback)
+
+If the workflow breaks or you need to release offline, the manual
+steps are:
+
+```bash
+# 1-4 as above (bump versions, update CHANGELOG, merge PR).
+# Then, manually:
+git fetch origin main
+git tag v0.3.0 origin/main
+git push origin v0.3.0
+
+# Critical: create the Release, not just the tag. /releases/latest
+# serves only Releases, so a bare tag is invisible to the update check.
+gh release create v0.3.0 \
+  --title "v0.3.0" \
+  --notes "$(awk '/## \[0.3.0\]/,/^## \[0\./{if(!/^## \[0\.[^3]/)print}' CHANGELOG.md)"
+```
+
+## Tag vs Release — why both matter
+
+A **git tag** is a ref in the repo (`git tag`). A **GitHub Release** is
+a higher-level object GitHub attaches to a tag (release notes, optional
+assets, a timestamp). The two are independent — creating a tag does
+**not** auto-create a Release.
+
+The startup check calls `/repos/:owner/:repo/releases/latest`, which
+only returns Release objects. A bare tag returns 404 at that endpoint.
+The automation in `release.yml` creates both in one step
+(`gh release create vX.Y.Z …` behind the scenes creates the tag if it
+doesn't exist and attaches the Release), so the distinction is
+invisible in the default flow. It only matters when debugging or doing
+a manual release.
 
 ## Plugin vs CLI lifecycle
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml`: on push to `main`, if `__version__` changed vs `HEAD~1`, cuts a git tag `vX.Y.Z` and creates a matching GitHub Release whose body is the verbatim `## [X.Y.Z]` section from `CHANGELOG.md`. No-ops when the version hasn't changed. Refuses to overwrite an existing tag.
- Adds `.github/workflows/validate.yml`: on PRs to `main` or `docs/adr`, runs Python syntax checks, version parity across `threadhop` / `marketplace.json` / `plugin.json`, a required `CHANGELOG.md` entry for the current `__version__`, and `pytest` if `tests/` has content. Exposes a `validate` status check that branch protection on `main` can require.
- Rewrites `RELEASE.md` around the automated flow (bump version + CHANGELOG → PR → merge → workflow tags + releases). Keeps a "Manual release (fallback)" section. Adds a "Tag vs Release" note that documents the `/releases/latest`-only-serves-Releases gotcha we hit during the v0.1.0 cut.

## Notes for review

- **Why key off `__version__`, not commit messages or manual tags.** A version bump is already visible in PR review — reviewers see it in the diff alongside the CHANGELOG entry, so we never accidentally release something unreviewed. Commit-message triggers (`release:` prefix etc.) hide the intent outside the diff; manual tag triggers skip the diff entirely. See `release.yml`'s opening comment.
- **The `release` workflow refuses duplicate tags deliberately.** If someone reverts a release and re-pushes the same `__version__`, the workflow fails loudly rather than silently overwriting. You'd have to bump to the next version number to recover — the correct behavior for semver hygiene.
- **`validate` runs on PRs to both `main` and `docs/adr`.** This matches the repo's current integration pattern (feature branches → `docs/adr` → `main`). Branch protection will only require the check on `main`, but contributors still see it pass on `docs/adr` PRs for free.
- **CHANGELOG parsing is brittle by design.** The awk script matches `^## \[X.Y.Z\]` exactly and stops at the next `^## \[` header. That mirrors the Keep-a-Changelog format the repo already uses — if you ever switch formats, both workflows will start failing loudly rather than producing malformed releases.
- **The `pytest` step is conditional** (`if [ -d tests ] && [ -n "$(ls -A tests 2>/dev/null)" ]`) so the workflow lands cleanly even though task-027 deferred writing unit tests. It'll start exercising whatever tests land in future PRs without needing a workflow edit.
- **`GITHUB_TOKEN` is sufficient for tag + release creation.** No PAT needed. The `permissions: contents: write` block on `release.yml` gives the job-scoped token what it needs and nothing more.

## Test plan

- [x] `uv run --with pyyaml python3 -c "import yaml; yaml.safe_load(...)"` on both workflow files — parse clean
- [x] Python syntax check mirrors what `validate.yml` runs: `python3 -c "import ast; ast.parse(open('threadhop').read())"` — clean
- [x] Local version parity: `threadhop` / `marketplace.json` / `plugin.json` all report `0.2.0` — would pass `validate`
- [x] `CHANGELOG.md` has `## [0.2.0]` entry matching current `__version__` — would pass `validate`
- [ ] **After merge to `main`**: `release.yml` should fire but no-op (no version change in this PR). Confirm by checking the Actions tab — the "Detect version change" step should log `"No version change (current=0.2.0); skipping release."` with exit 0.
- [ ] **After branch protection is applied**: open a throwaway PR that breaks version parity (e.g. bump only `threadhop`'s `__version__` without the plugin JSONs). `validate` should fail with a red ❌ on the PR, blocking merge. Close the PR without merging.
- [ ] **First real release test**: the next feature PR that bumps to `0.3.0`. Confirm on merge that the tag is cut, the Release appears at https://github.com/parzival1l/threadhop/releases, and `gh api /repos/parzival1l/threadhop/releases/latest --jq '.tag_name'` returns `v0.3.0`.

## Follow-ups

- **Apply branch protection on `main` after merge.** One command, in the PR description below. Not in this PR because the `validate` check doesn't exist on `main` yet until this PR merges — requiring it immediately would block its own merge.
- **Add unit tests to `tests/`** (still outstanding from task-027). Once tests land, `validate` will start exercising them automatically — no workflow edit needed.
- **Consider adding a "version change is worthy of a release" gate** — a pre-release heuristic that fails the PR if `__version__` was bumped but no actual code changes landed (e.g. only docs or CHANGELOG modified). User flagged this as a small follow-up.
- **Eventually**: GitHub Releases could get generated artifacts (a `.tar.gz` of the checkout, or a signed checksum). Not in scope — pre-1.0 project doesn't warrant it yet.

## After this PR merges — enable branch protection

One command to gate `main` behind the `validate` check:

```bash
gh api -X PUT /repos/parzival1l/threadhop/branches/main/protection --input - <<'JSON'
{
  "required_status_checks": {
    "strict": true,
    "contexts": ["validate"]
  },
  "enforce_admins": false,
  "required_pull_request_reviews": {
    "required_approving_review_count": 0,
    "dismiss_stale_reviews": false,
    "require_code_owner_reviews": false
  },
  "restrictions": null,
  "allow_force_pushes": false,
  "allow_deletions": false,
  "required_conversation_resolution": true,
  "required_linear_history": false
}
JSON
```

After that, every PR to `main` waits for `validate` to pass before the merge button turns green, and direct force-pushes to `main` are blocked (which would have prevented the work-wiping incident that produced this PR's sibling, #64).

## References

- PR #64 — task-027 update lifecycle (the feature this automates the release of)
- ADR-027 — Update lifecycle (`docs/DESIGN-DECISIONS.md`)
- `RELEASE.md` — now the authoritative release-process doc
- GitHub Actions docs: [`github.token` permissions model](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)