### PR TITLE
Release 0.2.1 — /threadhop:copy skill + test fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "threadhop",
       "source": "./plugin",
       "description": "Persistent, searchable, cross-session memory for Claude Code — browse sessions, extract TODOs/decisions, produce handoff briefs.",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "author": {
         "name": "parzival1l"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to ThreadHop are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions
 follow `major.minor.patch`.
 
+## [0.2.1] — 2026-04-22
+
+### Added
+- `threadhop copy [N|all]` — copy the last N rendered turns (default
+  `1`, `all` for the whole session) of the current session to the
+  macOS clipboard as markdown. Sidechains, tool calls, tool results,
+  thinking blocks, `<system-reminder>` tags, and Claude Code harness
+  wrappers (`<bash-input>`, `<bash-stdout>`, `<bash-stderr>`,
+  `<local-command-caveat>`, `<command-name>`, `<command-message>`,
+  `<command-args>`) are stripped so the paste reads as conversation.
+  Uses `indexer.parse_messages(include_tool_calls=False)` — the same
+  cleaning pipeline the TUI renders — so the output is deterministic
+  and byte-reproducible across invocations. Prints only a one-line
+  `✓ copied N turns (≈W words) to clipboard.` confirmation; the
+  payload is never echoed to stdout (defeats the point of reducing
+  context). Falls back to dumping to
+  `/tmp/threadhop/<sid>-copy-<ts>.md` and copying the *path* if
+  `pbcopy` is unavailable.
+- `/threadhop:copy [N|all]` plugin command — one-line bash passthrough
+  into `threadhop copy`, matching the existing `/threadhop:tag` /
+  `/threadhop:bookmark` pattern. Auto-detects the host session via
+  the same parent-process resolver the other plugin commands use.
+
+### Notes
+- Python module is `copier.py`, not `copy.py`, to avoid losing the
+  import race against stdlib `copy` (pytest and anything transitive
+  through `copy.deepcopy` preload `sys.modules['copy']`). The CLI
+  subcommand and plugin command are still spelled `copy`.
+
 ## [0.2.0] — 2026-04-22
 
 ### Added

--- a/copier.py
+++ b/copier.py
@@ -1,0 +1,228 @@
+"""Copy a cleaned session transcript to the macOS clipboard.
+
+Backs both ``threadhop copy [N|all]`` (CLI) and ``/threadhop:copy`` (plugin
+command). The plugin file is a one-line bash passthrough into this CLI,
+matching the existing ``/threadhop:tag`` / ``/threadhop:bookmark`` pattern.
+
+Design anchors:
+
+* **Filter-then-count.** The CLI arg counts *rendered* turns (user +
+  assistant prose, sidechains dropped, tool calls/results stripped), not
+  raw JSONL lines. Counting what the user sees in the TUI keeps the
+  mental model consistent.
+* **Clipboard-only.** No stdout echo of the copied markdown — the whole
+  point of this command is context reduction for paste into another
+  session, so printing would defeat the purpose. A one-line status
+  ("Copied N turns (≈W words) to clipboard.") confirms success without
+  leaking the payload back into the source conversation.
+* **Cleaning runs deterministically in code.** The transform reuses
+  ``indexer.parse_messages(include_tool_calls=False)`` — the same
+  cleaning pipeline the TUI renders — so paste recipients and search
+  indices see a canonical form. See issue #63 for promoting the knob
+  to ``config.json``.
+
+Module name: ``copier`` rather than ``copy`` on purpose — pytest and
+any transitive consumer of ``copy.deepcopy`` preload stdlib ``copy``
+into ``sys.modules``, so a project-level ``copy.py`` loses the
+import race. Naming also matches the existing noun-form convention
+(``indexer``, ``observer``, ``reflector``). The CLI subcommand is
+still ``threadhop copy``; only the Python module differs.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Iterator
+
+import indexer
+
+
+# Claude Code surfaces several harness-tooling wrappers as plain-text
+# content inside user JSONL turns: ``!cmd`` passthroughs wrap their input
+# and captured stdout/stderr in ``<bash-input>`` / ``<bash-stdout>`` /
+# ``<bash-stderr>``; each of those chunks is also prefixed with a
+# ``<local-command-caveat>`` telling the assistant not to respond; and
+# slash-command invocations emit ``<command-name>`` / ``<command-message>``
+# / ``<command-args>``. None of this is conversation — it's plumbing the
+# user saw as UI chrome, not as words they typed. Strip on the way out
+# so a pasted transcript reads like a chat, not a shell transcript.
+#
+# Scoped to this module — the indexer, TUI, search, and observer keep
+# seeing the unfiltered bytes so session exploration still shows "you
+# ran `!threadhop tag` here" as context.
+HARNESS_TAG_RE = re.compile(
+    r"<(bash-input|bash-stdout|bash-stderr"
+    r"|local-command-caveat"
+    r"|command-name|command-message|command-args)>"
+    r".*?"
+    r"</\1>",
+    re.DOTALL,
+)
+
+# Fallback dump location when ``pbcopy`` fails. Matches
+# ``EXPORT_DIR`` in the ``threadhop`` script (threadhop:85) so
+# copy-fallback files live alongside intentional TUI exports.
+EXPORT_DIR = Path("/tmp/threadhop")
+
+
+# --- Argument parsing ----------------------------------------------------
+
+
+def parse_count_arg(raw: str | None) -> int | None:
+    """Translate the raw CLI arg to a count.
+
+    ``None`` or empty string → 1 (default: last one turn).
+    ``"all"`` / ``"ALL"`` / ``"All"`` → ``None`` sentinel (entire session).
+    Positive integer → int.
+    Everything else raises ``ValueError`` with a usage hint.
+
+    A count larger than the session's turn total is handled by
+    ``build_copy_markdown`` (silently caps at what's available) rather
+    than here, so the CLI error path stays narrow.
+    """
+    if raw is None or raw == "":
+        return 1
+    normalized = raw.strip().lower()
+    if normalized == "all":
+        return None
+    try:
+        n = int(normalized)
+    except ValueError:
+        raise ValueError(
+            f"expected a positive integer or 'all', got {raw!r}"
+        )
+    if n < 1:
+        raise ValueError(
+            f"count must be >= 1 (got {n}); use 'all' for the whole session"
+        )
+    return n
+
+
+# --- Rendering -----------------------------------------------------------
+
+
+def _iter_rendered_turns(session_path: Path) -> Iterator[tuple[str, str]]:
+    """Yield ``(role_label, text)`` pairs in file order.
+
+    Pipeline:
+    1. ``indexer.parse_messages(include_tool_calls=False)`` — merges
+       streaming chunks by ``message.id``, strips system reminders,
+       skips ``toolUseResult`` user lines, drops thinking blocks,
+       *omits* ``tool_use`` blocks entirely (not abbreviated).
+    2. Drop ``is_sidechain`` rows — sub-agent exploration isn't what the
+       human-visible conversation is about.
+    3. Drop rows that reduced to empty text after cleaning.
+    """
+    for row in indexer.parse_messages(session_path, include_tool_calls=False):
+        if row.get("is_sidechain"):
+            continue
+        text = (row.get("text") or "").strip()
+        # Strip `!cmd` passthrough wrappers. If a turn was *only* bash
+        # tooling (e.g. a bash-stdout echo from a prior `!threadhop copy`
+        # invocation), it collapses to empty here and the turn is dropped
+        # entirely — which is what we want.
+        text = HARNESS_TAG_RE.sub("", text).strip()
+        if not text:
+            continue
+        label = "User" if row["role"] == "user" else "Assistant"
+        yield label, text
+
+
+def build_copy_markdown(
+    session_path: Path,
+    count: int | None,
+) -> tuple[str, int]:
+    """Return ``(markdown, turn_count)``.
+
+    ``count=None`` → every rendered turn in the session.
+    ``count=N`` → last ``N`` rendered turns; silently capped at the
+    session total if ``N`` exceeds what's available.
+    """
+    turns = list(_iter_rendered_turns(session_path))
+    if count is not None:
+        turns = turns[-count:]
+    md = "\n\n".join(f"### {label}\n{text}" for label, text in turns)
+    return md, len(turns)
+
+
+def _word_count(s: str) -> int:
+    return len(s.split())
+
+
+# --- Clipboard + fallback ------------------------------------------------
+
+
+def _try_pbcopy(text: str) -> bool:
+    """Pipe ``text`` into ``pbcopy``. Return ``True`` on success."""
+    try:
+        subprocess.run(["pbcopy"], input=text.encode(), check=True)
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return False
+
+
+def _dump_to_file(markdown: str, session_id: str) -> Path:
+    """Write ``markdown`` to ``EXPORT_DIR`` and return the path.
+
+    Mirrors the TUI's ``e`` export fallback (threadhop:699-711): same
+    directory, similar naming shape so a user cleaning up ``/tmp/threadhop``
+    sees copy-fallback files next to intentional exports.
+    """
+    os.makedirs(EXPORT_DIR, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    path = EXPORT_DIR / f"{session_id}-copy-{ts}.md"
+    path.write_text(markdown)
+    return path
+
+
+# --- Entry point ---------------------------------------------------------
+
+
+def run_copy(
+    count_arg: str | None,
+    session_id: str,
+    session_path: Path,
+) -> int:
+    """CLI entry. Caller resolves ``session_id``/``session_path`` first
+    (via the ``threadhop`` script's ``_resolve_cli_session`` +
+    ``find_session_path`` helpers) so session discovery isn't duplicated.
+    """
+    try:
+        count = parse_count_arg(count_arg)
+    except ValueError as e:
+        print(f"threadhop copy: {e}", file=sys.stderr)
+        return 2
+
+    markdown, turn_count = build_copy_markdown(session_path, count)
+
+    if turn_count == 0:
+        print(
+            "threadhop copy: no user/assistant turns to copy "
+            "(session may be empty or contain only tool output).",
+            file=sys.stderr,
+        )
+        return 1
+
+    noun = "turn" if turn_count == 1 else "turns"
+    words = _word_count(markdown)
+
+    if _try_pbcopy(markdown):
+        print(f"✓ copied {turn_count} {noun} (≈{words} words) to clipboard.")
+        return 0
+
+    # pbcopy path failed — fall back to the TUI export UX: dump to
+    # EXPORT_DIR and copy *the path* so the user still has something
+    # actionable on the clipboard.
+    dump_path = _dump_to_file(markdown, session_id)
+    path_copied = _try_pbcopy(str(dump_path))
+    path_note = " (path copied)" if path_copied else ""
+    print(
+        f"⚠ pbcopy unavailable; dumped {turn_count} {noun} → {dump_path}{path_note}",
+        file=sys.stderr,
+    )
+    return 0

--- a/indexer.py
+++ b/indexer.py
@@ -128,12 +128,22 @@ def _extract_user_text(msg: dict) -> str | None:
     return text or None
 
 
-def _extract_assistant_blocks(msg: dict) -> list[str]:
+def _extract_assistant_blocks(
+    msg: dict,
+    *,
+    include_tool_calls: bool = True,
+) -> list[str]:
     """Return the text + abbreviated-tool-call snippets for one assistant line.
 
     ``thinking`` blocks are intentionally dropped — they aren't rendered
     in the TUI and wouldn't help keyword search. The resulting list is
     joined by the caller into the final indexed text.
+
+    ``include_tool_calls=False`` drops ``tool_use`` blocks entirely
+    rather than abbreviating them — used by the ``copy`` command so
+    pasted transcripts contain only human-visible prose. Default
+    preserves the indexer/TUI/observer behaviour. Config-driven control
+    over this knob is tracked in issue #63.
     """
     content = msg.get("message", {}).get("content", [])
     if not isinstance(content, list):
@@ -147,7 +157,7 @@ def _extract_assistant_blocks(msg: dict) -> list[str]:
             t = strip_system_reminders(block.get("text", ""))
             if t:
                 out.append(t)
-        elif btype == "tool_use":
+        elif btype == "tool_use" and include_tool_calls:
             out.append(
                 abbreviate_tool_use(
                     block.get("name", "Unknown"),
@@ -161,7 +171,11 @@ def _extract_assistant_blocks(msg: dict) -> list[str]:
 # --- Streaming parse -----------------------------------------------------
 
 
-def parse_messages(jsonl_path: Path) -> Iterator[dict]:
+def parse_messages(
+    jsonl_path: Path,
+    *,
+    include_tool_calls: bool = True,
+) -> Iterator[dict]:
     """Yield rows ready for insertion into the ``messages`` table.
 
     Consecutive assistant lines sharing the same ``message.id`` are
@@ -172,6 +186,11 @@ def parse_messages(jsonl_path: Path) -> Iterator[dict]:
 
     Malformed JSON lines are silently skipped — one corrupt line should
     not abort indexing the rest of the file.
+
+    ``include_tool_calls`` is forwarded to ``_extract_assistant_blocks``.
+    Defaults to ``True`` so indexer/TUI/observer callers are unaffected;
+    ``copy.py`` passes ``False`` for clean-prose-only rendering (see
+    issue #63 for config-driven evolution).
     """
     # Buffer state for in-flight assistant message merging.
     buf_mid: str | None = None
@@ -240,7 +259,9 @@ def parse_messages(jsonl_path: Path) -> Iterator[dict]:
 
             # --- assistant line ---
             mid = msg.get("message", {}).get("id")
-            parts = _extract_assistant_blocks(msg)
+            parts = _extract_assistant_blocks(
+                msg, include_tool_calls=include_tool_calls,
+            )
 
             # Streaming chunk of the current logical message → append.
             if mid is not None and buf_mid == mid and buf_row is not None:

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "threadhop",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Browse, search, and carry context across Claude Code sessions. Exposes /threadhop:handoff, /threadhop:observe, /threadhop:tag.",
   "author": {
     "name": "ThreadHop",

--- a/plugin/commands/copy.md
+++ b/plugin/commands/copy.md
@@ -1,0 +1,8 @@
+---
+description: Copy the cleaned session transcript to the clipboard as markdown. No argument copies the last turn; a number copies the last N turns; `all` copies the whole session. Tool calls, sidechains, and system reminders are stripped.
+argument-hint: "[N|all]"
+disable-model-invocation: true
+allowed-tools: Bash(threadhop:*)
+---
+
+!`threadhop copy $ARGUMENTS`

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,0 +1,275 @@
+"""Unit tests for the ``copy`` module.
+
+Covers the deterministic core: argument parsing, turn counting after
+filtering, tool-call / sidechain exclusion, markdown shape, and the
+byte-for-byte reproducibility contract that the "deterministic cleaning"
+thesis rests on (see issue #63 context).
+
+The clipboard / pbcopy path is not exercised here — ``_try_pbcopy`` is a
+thin subprocess wrapper, and the deterministic work happens in
+``build_copy_markdown``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import copier as copy_mod
+
+
+# --- Fixture builders ----------------------------------------------------
+
+
+def _user_line(uuid: str, text: str, sid: str) -> str:
+    return json.dumps({
+        "type": "user",
+        "uuid": uuid,
+        "sessionId": sid,
+        "timestamp": "2026-04-22T10:00:00Z",
+        "message": {"id": f"umsg_{uuid}", "content": [{"type": "text", "text": text}]},
+    })
+
+
+def _assistant_line(
+    uuid: str,
+    mid: str,
+    text: str,
+    sid: str,
+    *,
+    sidechain: bool = False,
+    extra_blocks: list[dict] | None = None,
+) -> str:
+    blocks: list[dict] = [{"type": "text", "text": text}]
+    if extra_blocks:
+        blocks.extend(extra_blocks)
+    return json.dumps({
+        "type": "assistant",
+        "uuid": uuid,
+        "sessionId": sid,
+        "timestamp": "2026-04-22T10:00:01Z",
+        "isSidechain": sidechain,
+        "message": {"id": mid, "content": blocks},
+    })
+
+
+def _tool_use_block(name: str, inp: dict) -> dict:
+    return {"type": "tool_use", "name": name, "input": inp, "id": "tu_x"}
+
+
+def _tool_result_user_line(uuid: str, result_text: str, sid: str) -> str:
+    """User-role JSONL line carrying tool output — gets stripped by the indexer."""
+    return json.dumps({
+        "type": "user",
+        "uuid": uuid,
+        "sessionId": sid,
+        "timestamp": "2026-04-22T10:00:02Z",
+        "toolUseResult": {"stdout": result_text},
+        "message": {"content": [{"type": "tool_result", "content": result_text}]},
+    })
+
+
+@pytest.fixture
+def session_path(tmp_path: Path) -> Path:
+    """Three-turn session with interleaved tool noise and one sidechain."""
+    sid = "sess1"
+    path = tmp_path / f"{sid}.jsonl"
+    path.write_text("\n".join([
+        _user_line("u1", "first question", sid),
+        _assistant_line(
+            "a1", "m1", "first answer",
+            sid,
+            extra_blocks=[_tool_use_block("Read", {"file_path": "/x/foo.py"})],
+        ),
+        _tool_result_user_line("u2", "found 12 files", sid),
+        _user_line("u3", "second question", sid),
+        _assistant_line("a2", "m2", "second answer", sid),
+        _assistant_line(
+            "a3", "m3", "sidechain chatter", sid, sidechain=True,
+        ),
+        _user_line("u4", "third question", sid),
+        _assistant_line("a4", "m4", "third answer", sid),
+    ]) + "\n")
+    return path
+
+
+# --- parse_count_arg -----------------------------------------------------
+
+
+class TestParseCountArg:
+    def test_none_defaults_to_one(self):
+        assert copy_mod.parse_count_arg(None) == 1
+
+    def test_empty_string_defaults_to_one(self):
+        assert copy_mod.parse_count_arg("") == 1
+
+    def test_numeric(self):
+        assert copy_mod.parse_count_arg("3") == 3
+
+    @pytest.mark.parametrize("raw", ["all", "ALL", "All", "  all  "])
+    def test_all_case_insensitive(self, raw):
+        assert copy_mod.parse_count_arg(raw) is None
+
+    @pytest.mark.parametrize("raw", ["0", "-1", "-99"])
+    def test_zero_and_negative_rejected(self, raw):
+        with pytest.raises(ValueError, match="count must be >= 1"):
+            copy_mod.parse_count_arg(raw)
+
+    @pytest.mark.parametrize("raw", ["foo", "1.5", "one", "all the things"])
+    def test_non_numeric_non_all_rejected(self, raw):
+        with pytest.raises(ValueError, match="positive integer or 'all'"):
+            copy_mod.parse_count_arg(raw)
+
+
+# --- build_copy_markdown -------------------------------------------------
+
+
+class TestBuildCopyMarkdown:
+    def test_default_returns_last_one_turn(self, session_path):
+        md, count = copy_mod.build_copy_markdown(session_path, 1)
+        assert count == 1
+        assert md.endswith("third answer")
+        assert md.startswith("### Assistant")
+
+    def test_last_two_turns(self, session_path):
+        md, count = copy_mod.build_copy_markdown(session_path, 2)
+        assert count == 2
+        # Last two rendered turns are (user: "third question", assistant: "third answer").
+        assert "third question" in md
+        assert "third answer" in md
+        # Second answer must NOT be in the last-2 slice.
+        assert "second answer" not in md
+
+    def test_all_returns_every_rendered_turn(self, session_path):
+        md, count = copy_mod.build_copy_markdown(session_path, None)
+        # 3 user turns + 3 assistant turns = 6 rendered turns
+        # (the tool-result user line and the sidechain assistant are dropped).
+        assert count == 6
+        for snippet in [
+            "first question", "first answer",
+            "second question", "second answer",
+            "third question", "third answer",
+        ]:
+            assert snippet in md
+
+    def test_n_larger_than_total_caps_to_available(self, session_path):
+        md, count = copy_mod.build_copy_markdown(session_path, 9999)
+        assert count == 6  # same as "all" on this fixture
+
+    def test_tool_calls_are_dropped_not_abbreviated(self, session_path):
+        md, _ = copy_mod.build_copy_markdown(session_path, None)
+        # The indexer's abbreviation for Read is "Reading foo.py" —
+        # copy must NOT contain that, since include_tool_calls=False.
+        assert "Reading foo.py" not in md
+        assert "Read(" not in md
+
+    def test_tool_results_are_dropped(self, session_path):
+        md, _ = copy_mod.build_copy_markdown(session_path, None)
+        # The toolUseResult user line ("found 12 files") is filtered by
+        # the indexer's _extract_user_text — copy inherits that.
+        assert "found 12 files" not in md
+
+    def test_sidechains_are_dropped(self, session_path):
+        md, _ = copy_mod.build_copy_markdown(session_path, None)
+        assert "sidechain chatter" not in md
+
+    def test_format_uses_role_headers(self, session_path):
+        md, _ = copy_mod.build_copy_markdown(session_path, None)
+        assert "### User" in md
+        assert "### Assistant" in md
+        # Blank-line separation between turns.
+        assert "\n\n### " in md
+
+    def test_determinism(self, session_path):
+        """Same session bytes → same markdown bytes, across invocations.
+
+        This is the contract that justifies the whole "cleaning in code,
+        not in the LLM" architecture — see issue #63. If this test ever
+        fails, the cleaning pipeline has gained a non-deterministic
+        dependency (time, iteration order, uncached regex) and the
+        cross-session comparability story is broken.
+        """
+        md1, c1 = copy_mod.build_copy_markdown(session_path, None)
+        md2, c2 = copy_mod.build_copy_markdown(session_path, None)
+        assert md1 == md2
+        assert c1 == c2
+
+    def test_empty_session_returns_zero_turns(self, tmp_path):
+        path = tmp_path / "empty.jsonl"
+        path.write_text("")
+        md, count = copy_mod.build_copy_markdown(path, None)
+        assert md == ""
+        assert count == 0
+
+    def test_harness_wrapper_only_turns_are_dropped(self, tmp_path):
+        """Claude Code `!cmd` passthroughs and slash-command invocations
+        leak harness tags (`<bash-input>`, `<bash-stdout>`, `<bash-stderr>`,
+        `<local-command-caveat>`, `<command-name>` etc.) into JSONL as
+        plain-text user turns. Turns that collapse to *only* these
+        wrappers are tooling, not conversation, and must be dropped —
+        otherwise copying a session that ran `!threadhop copy 1` before
+        returns an empty-looking last turn.
+        """
+        sid = "sess2"
+        path = tmp_path / f"{sid}.jsonl"
+        path.write_text("\n".join([
+            _user_line("u1", "real user question", sid),
+            _assistant_line("a1", "m1", "real assistant reply", sid),
+            _user_line("u2", "<bash-input>threadhop copy 1</bash-input>", sid),
+            _user_line(
+                "u3",
+                "<bash-stdout>✓ copied 1 turn</bash-stdout>"
+                "<bash-stderr></bash-stderr>",
+                sid,
+            ),
+            _user_line(
+                "u4",
+                "<local-command-caveat>Caveat: the messages below were "
+                "generated by the user while running local commands. DO "
+                "NOT respond to these.</local-command-caveat>",
+                sid,
+            ),
+            _user_line(
+                "u5",
+                "<command-name>/threadhop:tag</command-name>"
+                "<command-args>in_progress</command-args>",
+                sid,
+            ),
+        ]) + "\n")
+        md, count = copy_mod.build_copy_markdown(path, None)
+        # Only the two substantive turns survive; every harness-wrapper-only
+        # turn collapsed to empty and was dropped.
+        assert count == 2
+        assert "real user question" in md
+        assert "real assistant reply" in md
+        for tag in [
+            "<bash-input>", "<bash-stdout>", "<bash-stderr>",
+            "<local-command-caveat>", "<command-name>", "<command-args>",
+        ]:
+            assert tag not in md
+        assert "threadhop copy 1" not in md
+        assert "DO NOT respond" not in md
+
+    def test_bash_wrapper_mixed_with_prose_keeps_prose(self, tmp_path):
+        """A turn carrying both a `<bash-input>` block *and* real prose
+        must keep the prose — only the wrapper is removed.
+        """
+        sid = "sess3"
+        path = tmp_path / f"{sid}.jsonl"
+        path.write_text("\n".join([
+            _user_line(
+                "u1",
+                "here's what I tried:\n"
+                "<bash-input>ls -la</bash-input>\n"
+                "and it looked wrong",
+                sid,
+            ),
+            _assistant_line("a1", "m1", "let me check", sid),
+        ]) + "\n")
+        md, _ = copy_mod.build_copy_markdown(path, None)
+        assert "here's what I tried" in md
+        assert "and it looked wrong" in md
+        assert "<bash-input>" not in md
+        assert "ls -la" not in md

--- a/tests/test_search_panel.py
+++ b/tests/test_search_panel.py
@@ -11,6 +11,11 @@ import db
 
 
 def _load_threadhop_module():
+    # Load the script so its line-39 `sys.modules.setdefault("threadhop", …)`
+    # fires and `import tui` can resolve its `from threadhop import *`.
+    # Keep the script reference (`threadhop`) for monkeypatching CLI-side
+    # helpers like `save_app_config` — their callers' `__globals__` point
+    # at the script's dict, so patching through `tui` would miss.
     root = Path(__file__).resolve().parents[1]
     path = root / "threadhop"
     module_name = "threadhop_script_test"
@@ -24,6 +29,7 @@ def _load_threadhop_module():
 
 
 threadhop = _load_threadhop_module()
+import tui  # noqa: E402  — TUI surface (`_build_fts_query`, `search_messages`).
 
 
 def _seed_message(
@@ -56,7 +62,7 @@ def _seed_message(
 
 
 def test_build_fts_query_supports_scope_and_date_filters():
-    spec = threadhop._build_fts_query(
+    spec = tui._build_fts_query(
         "project:atlas session:current since:2026-04-01 until:2026-04-10 "
         "user: rate-limit retries",
         current_session_id="sess-current",
@@ -102,14 +108,14 @@ def test_search_messages_pages_current_session_results(conn):
         timestamp="2026-04-18T13:00:00Z",
     )
 
-    page1 = threadhop.search_messages(
+    page1 = tui.search_messages(
         conn,
         "session:current alpha",
         limit=2,
         offset=0,
         current_session_id="sess-a",
     )
-    page2 = threadhop.search_messages(
+    page2 = tui.search_messages(
         conn,
         "session:current alpha",
         limit=2,
@@ -143,7 +149,7 @@ def test_search_messages_boosts_exact_phrase_over_recent_prefix_match(conn):
         timestamp="2026-04-19T12:00:00Z",
     )
 
-    page = threadhop.search_messages(conn, "rate limit", limit=10)
+    page = tui.search_messages(conn, "rate limit", limit=10)
 
     assert page.total_count == 2
     assert [row["uuid"] for row in page.rows[:2]] == ["old-exact", "new-prefix"]

--- a/tests/test_transcript_observation_header.py
+++ b/tests/test_transcript_observation_header.py
@@ -9,12 +9,19 @@ import db
 
 
 def _load_threadhop_module():
+    # See test_tui_observation_indicator._load_threadhop_module for why this
+    # returns `tui` rather than the executed script: `TranscriptView` lives
+    # in tui.py, and loading the script file merely primes `sys.modules` so
+    # `import tui` can resolve its `from threadhop import *`.
+    import sys as _sys
     path = Path(__file__).resolve().parent.parent / "threadhop"
     loader = importlib.machinery.SourceFileLoader("threadhop_app", str(path))
     spec = importlib.util.spec_from_loader(loader.name, loader)
     module = importlib.util.module_from_spec(spec)
+    _sys.modules.setdefault(loader.name, module)
     loader.exec_module(module)
-    return module
+    import tui  # noqa: PLC0415 — deferred until the script is registered.
+    return tui
 
 
 def _dummy_transcript_view(module, conn):

--- a/tests/test_tui_observation_actions.py
+++ b/tests/test_tui_observation_actions.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-import runpy
+import importlib.util
+import sys
 import time
+from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 import db
@@ -14,7 +16,22 @@ THREADHOP = ROOT / "threadhop"
 
 
 def _load_threadhop_ns() -> dict:
-    return runpy.run_path(str(THREADHOP))
+    # Symbols this suite touches (`build_observe_command`,
+    # `render_session_label_text`, `ClaudeSessions`, `OBSERVATION_MARKER`,
+    # `_supports_observation_emoji`, `OBSERVATION_MARKER_FALLBACK`) all
+    # live in tui.py or are re-exported into it. Loading the script
+    # primes `sys.modules["threadhop"]` via its own setdefault, then
+    # `import tui` resolves and returns a namespace that covers every
+    # symbol the tests reach for.
+    module_name = "threadhop_app"
+    if module_name not in sys.modules:
+        loader = SourceFileLoader(module_name, str(THREADHOP))
+        spec = importlib.util.spec_from_loader(module_name, loader)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        loader.exec_module(module)
+    import tui  # noqa: PLC0415 — deferred until the script is registered.
+    return tui.__dict__
 
 
 class _FakeItem:

--- a/tests/test_tui_observation_indicator.py
+++ b/tests/test_tui_observation_indicator.py
@@ -9,6 +9,12 @@ import db
 
 
 def _load_threadhop_module():
+    # Load the `threadhop` script so its line-39 `sys.modules.setdefault`
+    # registers it under the plain name "threadhop". That makes `import tui`
+    # (whose first line is `import threadhop as _core`) resolve — tui.py
+    # then re-exports script symbols *and* adds TUI-only functions like
+    # `render_session_label_text`. Returning `tui` gives the tests one
+    # reference that covers both surfaces.
     path = Path(__file__).resolve().parent.parent / "threadhop"
     loader = SourceFileLoader("threadhop_app", str(path))
     spec = importlib.util.spec_from_loader("threadhop_app", loader)
@@ -17,7 +23,8 @@ def _load_threadhop_module():
     sys.modules.setdefault("threadhop_app", module)
     assert spec.loader is not None
     spec.loader.exec_module(module)
-    return module
+    import tui  # noqa: PLC0415 — deferred until the script is registered.
+    return tui
 
 
 def test_get_session_sidebar_metadata_marks_observed_sessions(conn):

--- a/threadhop
+++ b/threadhop
@@ -1325,6 +1325,37 @@ def build_parser():
         help="Optional short note to store alongside the bookmark",
     )
 
+    copy_p = subparsers.add_parser(
+        "copy",
+        parents=[shared],
+        help="Copy cleaned session transcript to the clipboard",
+        description=(
+            "Copy a session's cleaned transcript to the macOS clipboard "
+            "as markdown. Tool calls, tool results, sidechains, system "
+            "reminders, and assistant thinking blocks are stripped — "
+            "only user and assistant prose turns survive. Backs both "
+            "the CLI and the /threadhop:copy plugin command."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  threadhop copy            # last turn\n"
+            "  threadhop copy 3          # last 3 turns\n"
+            "  threadhop copy all        # entire session\n"
+            "  !threadhop copy 2         # from inside a Claude Code session"
+        ),
+    )
+    copy_p.add_argument(
+        "count",
+        nargs="?",
+        default=None,
+        help=(
+            "Number of recent turns to copy (default: 1), or 'all' for "
+            "the whole session. Counts rendered turns after filtering, "
+            "not raw JSONL lines."
+        ),
+    )
+
     subparsers.add_parser(
         "todos",
         parents=[shared],
@@ -2172,6 +2203,32 @@ def cmd_bookmark(args) -> int:
     return 0
 
 
+def cmd_copy(args) -> int:
+    """Copy the cleaned last-N-turns (or full session) to the clipboard.
+
+    Auto-detects the current session via ``_resolve_cli_session`` so
+    both plugin invocations (``/threadhop:copy`` → ``!threadhop copy``)
+    and bare CLI calls from inside a ``claude`` terminal work without
+    ``--session``. Delegates to ``copy.run_copy`` for the actual work;
+    this wrapper only handles session discovery + path resolution.
+    """
+    rc = _resolve_cli_session(args)
+    if rc != 0:
+        return rc
+    session_path = find_session_path(args.session)
+    if session_path is None:
+        print(
+            f"threadhop copy: no transcript found for session {args.session} "
+            f"under {CLAUDE_PROJECTS}.",
+            file=sys.stderr,
+        )
+        return 1
+    # Lazy import — keeps CLI startup fast for other subcommands.
+    # Module is named ``copier`` to avoid shadowing stdlib ``copy``.
+    from copier import run_copy  # noqa: PLC0415
+    return run_copy(args.count, args.session, session_path)
+
+
 ROADMAP_ENTRY_RE = re.compile(r"^- #(\d+) — (.+)$")
 
 
@@ -2442,6 +2499,8 @@ def main():
         return cmd_decisions(args)
     if args.command == "bookmark":
         return cmd_bookmark(args)
+    if args.command == "copy":
+        return cmd_copy(args)
     if args.command == "config":
         return cmd_config(args)
     if args.command == "observe":

--- a/threadhop
+++ b/threadhop
@@ -39,7 +39,7 @@ import search_queries  # noqa: E402
 sys.modules.setdefault("threadhop", sys.modules[__name__])
 
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 
 # Update-check surface (ADR-027). Cache only holds mtime — contents are


### PR DESCRIPTION
## Summary

- Ships `threadhop copy [N|all]` plus the `/threadhop:copy` plugin command — copies the last N rendered conversation turns of the current session to the macOS clipboard as markdown, stripping tool calls, tool results, thinking blocks, `<system-reminder>` tags, and Claude Code harness wrappers. Uses `indexer.parse_messages(include_tool_calls=False)` so the output matches exactly what the TUI renders. See `copier.py` + `plugin/commands/copy.md`.
- Aligns test paths with the lazy-TUI split (`threadhop` script ↔ `tui.py`) after PR #65 moved those internals. Four test files updated so the suite discovers them correctly.
- **First PR to exercise the release automation landed in #66.** `__version__`, `marketplace.json`, and `plugin.json` all bump to `0.2.1` in lockstep (commit `7936e91`), and `CHANGELOG.md` gains a matching `## [0.2.1]` section. On merge, `release.yml` should detect the bump, extract the CHANGELOG block, and create tag `v0.2.1` + a GitHub Release with that block as the body.

## Notes for review

- **Module named `copier.py`, not `copy.py`, on purpose.** Python's stdlib `copy` gets imported by pytest and anything transitive through `copy.deepcopy`, so a local `copy.py` loses the import race and collides. The CLI subcommand and plugin command are still spelled `copy` — only the implementation module's filename changes. Noted in the CHANGELOG body too.
- **`copy` never echoes the payload to stdout.** The whole point of the command is to reduce context; dumping the copied text back to the terminal would defeat it. You get a one-line `✓ copied N turns (≈W words) to clipboard.` confirmation and that's it.
- **Clipboard fallback is path-based.** If `pbcopy` isn't on PATH (minimal macOS images, shells with stripped PATH), the command writes to `/tmp/threadhop/<sid>-copy-<ts>.md` and puts the *path* on the clipboard. The fallback prints a distinct message so you know it happened.
- **Version-bump commit is isolated.** Commit `7936e91` touches only the four files `validate.yml` checks (script, two plugin manifests, CHANGELOG). That means if release.yml fails for any reason, a `git revert 7936e91` rolls back the release without touching the feature work.

## Test plan

- [x] Local `validate.yml` equivalents:
  - `python3 -c "import ast; ast.parse(open('threadhop').read()); ast.parse(open('tui.py').read())"` — clean
  - Versions in `threadhop` / `marketplace.json` / `plugin.json` all report `0.2.1`
  - `CHANGELOG.md` has `## [0.2.1]` entry
- [ ] **On PR open:** `validate` workflow runs green. (First live check of branch protection blocking until this completes.)
- [ ] **On merge:** `release.yml` fires on push to main, detects `0.2.0 → 0.2.1`, refuses if tag already exists (it shouldn't), extracts CHANGELOG section, creates tag + GitHub Release.
- [ ] **After release:**
  - `gh api /repos/parzival1l/threadhop/releases/latest --jq .tag_name` returns `"v0.2.1"`
  - `./threadhop update --check` from a local install at `0.2.0` prints the 3-line nudge
  - `./threadhop` (TUI) on a local `0.2.0` install shows the toast in the top-right

## Follow-ups

- **"Version bump worthy of a release" gate** — the next enhancement to `validate.yml`. Currently the workflow passes as long as version parity + CHANGELOG entry are present, but a bump with only trivial changes (whitespace, typo-fix in a comment) technically passes too. A heuristic for "a version bump must ship at least one substantive file change" is the planned follow-up.
- **Enable merge queue** once collaborator count grows. Not needed solo, but would reduce CI churn when multiple PRs are in flight.

## References

- PR #66 — CI release automation that this PR is the first test of
- PR #67 — brought PR #66's workflows onto main
- ADR-027 — the update-lifecycle feature whose own v0.2.0 release arc produced the release discipline that this PR validates
- `RELEASE.md` — the release flow doc this PR follows step-by-step
- `plugin/commands/copy.md` — the skill file registered by the `/threadhop:copy` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)