### PR TITLE
Fix release.yml template-injection bug with CHANGELOG backticks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,31 @@ name: Release
 # Because the bump is already visible in PR review — reviewers see it
 # in the diff alongside the CHANGELOG entry, so we never accidentally
 # release something unreviewed. See RELEASE.md.
+#
+# SECURITY NOTE — template interpolation of CHANGELOG content.
+# CHANGELOG entries contain backticks (e.g. `threadhop copy`),
+# `$(...)` patterns, and other bash-syntactic characters. Pasting
+# those into a shell script via GitHub Actions `${{ ... }}`
+# templating causes bash to re-interpret them as commands, which
+# explodes in production. We route every templated value through
+# the `env:` block so bash only sees them as plain environment
+# variable values — no re-parsing, no command substitution.
+# Triggered this once on 2026-04-22 when the first `release.yml`
+# tried to release v0.2.1; backticks in the /threadhop:copy
+# CHANGELOG entry got executed as commands and the step failed.
 
 on:
   push:
     branches: [main]
+  # Manual re-fire in case a push-triggered run ever fails. Passes
+  # `force: true` to skip the version-change detection (needed because
+  # a retry on the same commit would see "no change" and no-op).
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Release the version at HEAD even if unchanged vs HEAD~1"
+        required: false
+        default: "false"
 
 permissions:
   contents: write   # needed to create tags + releases via GITHUB_TOKEN
@@ -28,6 +49,8 @@ jobs:
 
       - name: Detect version change
         id: ver
+        env:
+          FORCE: ${{ github.event.inputs.force }}
         run: |
           set -euo pipefail
           NEW=$(grep -oE '^__version__ = "[^"]+"' threadhop | head -1 | cut -d'"' -f2)
@@ -36,7 +59,10 @@ jobs:
                 || echo "")
           echo "new=$NEW" >> "$GITHUB_OUTPUT"
           echo "old=$OLD" >> "$GITHUB_OUTPUT"
-          if [ -n "$NEW" ] && [ "$NEW" != "$OLD" ]; then
+          if [ "${FORCE:-false}" = "true" ] && [ -n "$NEW" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Force mode — releasing v$NEW regardless of version change."
+          elif [ -n "$NEW" ] && [ "$NEW" != "$OLD" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
             echo "::notice::Version changed $OLD -> $NEW; proceeding to release."
           else
@@ -45,29 +71,33 @@ jobs:
 
       - name: Refuse if tag already exists
         if: steps.ver.outputs.changed == 'true'
+        env:
+          RELEASE_VERSION: ${{ steps.ver.outputs.new }}
         run: |
-          V="${{ steps.ver.outputs.new }}"
-          if git ls-remote --tags origin | grep -qE "refs/tags/v${V}$"; then
-            echo "::error::Tag v${V} already exists. Aborting to avoid overwrite."
+          if git ls-remote --tags origin | grep -qE "refs/tags/v${RELEASE_VERSION}$"; then
+            echo "::error::Tag v${RELEASE_VERSION} already exists. Aborting to avoid overwrite."
             exit 1
           fi
 
       - name: Extract CHANGELOG section for this version
         if: steps.ver.outputs.changed == 'true'
         id: notes
+        env:
+          RELEASE_VERSION: ${{ steps.ver.outputs.new }}
         run: |
           set -euo pipefail
-          V="${{ steps.ver.outputs.new }}"
           # Grab the block between `## [V]` and the next `## [` header.
-          NOTES=$(awk -v v="$V" '
+          NOTES=$(awk -v v="$RELEASE_VERSION" '
             $0 ~ "^## \\[" v "\\]" { p=1; next }
             p && $0 ~ "^## \\[" { exit }
             p { print }
           ' CHANGELOG.md)
           if [ -z "$(echo "$NOTES" | tr -d '[:space:]')" ]; then
-            echo "::error::CHANGELOG.md has no '## [${V}]' entry. Add one before bumping __version__."
+            echo "::error::CHANGELOG.md has no '## [${RELEASE_VERSION}]' entry. Add one before bumping __version__."
             exit 1
           fi
+          # Multiline output contract:
+          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
           {
             echo "body<<CHANGELOG_EOF"
             echo "$NOTES"
@@ -76,12 +106,17 @@ jobs:
 
       - name: Create tag and release
         if: steps.ver.outputs.changed == 'true'
+        # Route every templated value through `env:` rather than
+        # `${{ ... }}` expansion inside the script. Prevents bash from
+        # re-parsing CHANGELOG backticks / `$(...)` as commands.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.ver.outputs.new }}
+          RELEASE_SHA: ${{ github.sha }}
+          RELEASE_BODY: ${{ steps.notes.outputs.body }}
         run: |
-          V="${{ steps.ver.outputs.new }}"
-          gh release create "v${V}" \
-            --target "${{ github.sha }}" \
-            --title "v${V}" \
-            --notes "${{ steps.notes.outputs.body }}"
-          echo "::notice::Released v${V}"
+          gh release create "v${RELEASE_VERSION}" \
+            --target "${RELEASE_SHA}" \
+            --title "v${RELEASE_VERSION}" \
+            --notes "${RELEASE_BODY}"
+          echo "::notice::Released v${RELEASE_VERSION}"


### PR DESCRIPTION
## Summary

- Fixes the cause of the failed release run for v0.2.1 ([run 24766482138](https://github.com/parzival1l/threadhop/actions/runs/24766482138)). The "Create tag and release" step used `${{ steps.notes.outputs.body }}` template interpolation inside a bash `run:` block. GitHub Actions pastes that value into the script **before** bash sees it, so backticks in the CHANGELOG entry (```threadhop copy```, ```` ```pbcopy``` ````, ```threadhop:tag```, and so on) were interpreted as bash command substitutions. Bash then tried to run `threadhop copy [N|all]` as a shell command, failed, and exit 2.
- Routes every templated value in the workflow (`RELEASE_VERSION`, `RELEASE_SHA`, `RELEASE_BODY`) through the step's `env:` block so bash only sees them as plain env-var values — no re-parsing, no command substitution. Applied to all three shell-using steps, not just the broken one, so the same class of bug can't resurface on a future edit.
- Adds `workflow_dispatch` with a `force` input so the workflow can be manually re-fired if a push-triggered run ever fails again. The release for v0.2.1 itself was created manually via `gh release create v0.2.1` as an out-of-band rescue; the manual tag+release is already live at https://github.com/parzival1l/threadhop/releases/tag/v0.2.1.

## Notes for review

- **Why the `env:` pattern, not `--notes-file -` with stdin.** Both approaches work, but the env-var pattern is more symmetric with the other `RELEASE_*` values in the same step, and keeps the shell script linear (no pipes). Stdin-based approach would have added a second seam where the body could be mis-escaped. See the inline comment above the fixed step.
- **`force` input isn't wired to be strict.** If set to `"true"`, the workflow skips version-change detection and releases whatever `__version__` is at HEAD. That's intentional — it's a rescue lever, and over-engineering it with "verify tag doesn't exist first, prompt for confirmation" would defeat the purpose of an escape hatch. The existing "Refuse if tag already exists" step still protects against accidental overwrites.
- **This PR does not bump `__version__`.** It's a CI-only fix. On merge, `release.yml` will run on the merge commit, detect `0.2.1 == 0.2.1`, log the "no version change; skipping release." notice, and exit 0. That's the expected path.
- **Retroactive audit concern.** The v0.2.1 release was created manually with `gh release create`, not by the automation. Functionally equivalent (same tag, same Release body from CHANGELOG), but the Actions log for that release is the failed run, not a successful one. Acceptable because the next real release (0.2.2, whenever that is) will exercise the fixed workflow end-to-end for the first time.

## Test plan

- [x] `uv run --with pyyaml python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — parses clean
- [x] Local smoke: the three `env:` blocks are correctly positioned; the shell `run:` blocks reference `${RELEASE_VERSION}` / `${RELEASE_BODY}` (env-var syntax) rather than `${{ ... }}` (template syntax)
- [x] v0.2.1 shipped out-of-band via `gh release create`; `gh api /repos/parzival1l/threadhop/releases/latest --jq .tag_name` returns `"v0.2.1"`
- [ ] **On merge:** `validate` passes (no version change, version parity intact, CHANGELOG [0.2.1] entry still present), then `release.yml` runs the "Detect version change" step, logs `"No version change (current=0.2.1); skipping release."`, and exits 0. Confirm by checking the Actions tab of the merge commit.
- [ ] **Next real release:** first PR after this that bumps `__version__` will be the first end-to-end test of the fixed release step. If it still fails on bash interpretation, roll back this PR and investigate.

## Follow-ups

- **Add a workflow test** that runs the extract-CHANGELOG + create-release steps against a fixture CHANGELOG with aggressive special characters (backticks, `$()`, quotes, HTML-like tags). A `test` job gated on branches other than main could shell out to a local `gh release` dry-run. Low priority — one real PR exercising the fix is cheaper evidence.
- **Revisit the `validate` workflow for the same class of bug.** It doesn't interpolate CHANGELOG content into shell, but it does interpolate `__version__` strings — low risk, but worth a scan to make sure there's no other `${{ ... }}`-inside-a-shell-`run:` pattern lurking.

## References

- PR #66 — the PR that introduced `release.yml` (with the bug)
- PR #68 — the PR that triggered the failed run (release 0.2.1)
- Run #24766482138 — the failed release run with the full traceback
- GitHub Actions docs: [workflow commands — multiline strings](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings)
- GitHub Actions security: [using env vars to avoid script injection](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable) — this is essentially the documented mitigation for exactly our case

🤖 Generated with [Claude Code](https://claude.com/claude-code)