### PR TITLE
Release 0.3.0 — OpenCode theme system + threadhop_core refactor

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "threadhop",
       "source": "./plugin",
       "description": "Persistent, searchable, cross-session memory for Claude Code — browse sessions, extract TODOs/decisions, produce handoff briefs.",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "author": {
         "name": "parzival1l"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,51 @@ All notable changes to ThreadHop are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions
 follow `major.minor.patch`.
 
+## [0.3.0] — 2026-04-26
+
+### Added
+- TUI theme system with five vendored themes — `opencode`, `nord`,
+  `gruvbox`, `catppuccin`, `tokyonight`. Themes are JSON files loaded
+  by `threadhop_core/tui/theme/loader.py` and registered as Textual
+  themes at app startup. The default look-and-feel mirrors OpenCode's
+  palette and message-surface treatment so transcripts feel at home
+  next to a Claude Code terminal session.
+- TUI visual updates inspired by OpenCode — refreshed message
+  surfaces, role borders, status pills, sidebar density, and
+  contextual-footer styling. Behavior unchanged; the diff is in the
+  `*.tcss` stylesheets and message-widget rendering.
+
+### Changed
+- Slash-command rendering in the transcript no longer stalls on long
+  sessions. The indexer now streams parsed messages incrementally
+  instead of loading the entire JSONL file before mounting the first
+  widget, so the transcript paints quickly even on multi-megabyte
+  sessions.
+- Session-loading spinner clears as soon as the first batch of
+  messages is mounted rather than waiting for the full parse.
+
+### Notes
+- **Internal repo refactor (no user-visible behavior change).** The
+  monolithic `./threadhop` script (2500+ lines) and `./tui.py`
+  (5900+ lines) have been split into a proper Python package at
+  `threadhop_core/` with submodules for `cli/`, `cli/commands/`,
+  `storage/`, `observation/`, `harness/`, `session/`, `config/`, and
+  `tui/{widgets,screens,css,theme}/`. The `./threadhop` entrypoint is
+  now a ~27-line dispatcher that hands off to
+  `threadhop_core.cli.dispatch.main`. `tui.py` at the repo root
+  remains as a thin backward-compat shim. All 201 tests pass; CLI
+  surface, DB schema, and observation pipeline are unchanged.
+- New `threadhop_core/harness/claude.py` adapter unifies the three
+  near-identical `claude -p` subprocess call sites (`observer`,
+  `reflector`, `handoff`) behind one `run_claude_p()` entrypoint.
+  Documented as ADR-028 in `docs/DESIGN-DECISIONS.md`; prepares the
+  seam for future `codex.py` / `gemini.py` adapters.
+- `RELEASE.md` rewritten as an agent-followable runbook with explicit
+  pre-flight, version-decision, failure-mode, and recovery sections.
+  CI workflows (`validate.yml`, `release.yml`) repointed at the new
+  `threadhop_core/__init__.py` version-of-truth so version detection
+  survives the package refactor.
+
 ## [0.2.1] — 2026-04-22
 
 ### Added

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "threadhop",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Browse, search, and carry context across Claude Code sessions. Exposes /threadhop:handoff, /threadhop:observe, /threadhop:tag.",
   "author": {
     "name": "ThreadHop",

--- a/threadhop_core/__init__.py
+++ b/threadhop_core/__init__.py
@@ -1,3 +1,3 @@
 """ThreadHop core package — version-of-truth and shared imports."""
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"


### PR DESCRIPTION
## Summary

- Releases 0.3.0 covering the new TUI theme system (5 vendored themes, OpenCode default), OpenCode-inspired visual updates across the TUI, slash-command + session-load fixes, and the large internal refactor that split `./threadhop` and `./tui.py` into the `threadhop_core/` package.
- Bumps `__version__`, `marketplace.json`, `plugin.json` to 0.3.0; adds matching CHANGELOG entry.

## What's in this release

- **Theme system** — `threadhop_core/tui/theme/loader.py` + 5 JSON themes (`opencode`, `nord`, `gruvbox`, `catppuccin`, `tokyonight`) registered as Textual themes at app startup.
- **OpenCode-inspired TUI polish** — message surfaces, role borders, status pills, sidebar density, contextual-footer styling.
- **Faster transcript paint** — incremental indexer streaming so multi-MB sessions render quickly; loading spinner clears after the first batch mounts.
- **Internal refactor (no user-visible behavior change)** — `threadhop_core/` package with `cli/`, `cli/commands/`, `storage/`, `observation/`, `harness/`, `session/`, `config/`, `tui/{widgets,screens,css,theme}/`. ADR-028 documents the harness seam. 201/201 tests pass; CLI surface, DB schema, and observation pipeline unchanged.
- **CI + docs** — workflow paths repointed at the new `__version__` location; `RELEASE.md` rewritten as an agent-followable runbook.

## Test plan

- [x] `validate` workflow passes (version parity + CHANGELOG entry)
- [ ] On merge: `release.yml` creates `v0.3.0` tag + GitHub Release
- [ ] After merge: `gh api /repos/parzival1l/threadhop/releases/latest --jq .tag_name` returns `\"v0.3.0\"`
- [ ] After merge: `./threadhop update --check` from a `0.2.1` install prints the 3-line nudge
- [ ] Manual: launch TUI, cycle through the 5 themes, confirm OpenCode is the default and renders correctly
- [ ] Manual: open a multi-MB session, confirm transcript paints incrementally without stalling

## References

- Commits in this release (since `v0.2.1`):
  - `dbd47bd` Opencode theme integrations and tui updates
  - `f170e67` fix: slash-command + kill loading shortened
  - `b9e5ebe` refactor: phase 1 — scaffold threadhop_core package
  - `1d0c4b2` refactor: phase 2 — unify claude -p subprocess into harness/claude.py
  - `cf81cff` refactor: phase 3 — split threadhop entrypoint into cli/commands/*.py
  - `3f2ce41` refactor: phase 4 (partial) — extract CSS, constants, leaf widgets, simple modals
  - `9619961` refactor: phase 4b — finish tui.py extraction
  - `7b4a925` refactor: phase 5 — cleanup tui shim, update CLAUDE.md, document harness ADR
  - `9d830af` ci: fix workflow paths after threadhop_core refactor
  - `0113e8f` Rewrite RELEASE.md as agent-followable release runbook
- Compare: https://github.com/parzival1l/threadhop/compare/v0.2.1...docs/standardize-release-procedure

🤖 Generated with [Claude Code](https://claude.com/claude-code)