### PR TITLE
ci: route release.yml CHANGELOG body through env vars (fix template injection)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,38 @@ name: Release
 # Because the bump is already visible in PR review — reviewers see it
 # in the diff alongside the CHANGELOG entry, so we never accidentally
 # release something unreviewed. See RELEASE.md.
+#
+# SECURITY NOTE — template interpolation of CHANGELOG content.
+# CHANGELOG entries contain backticks (e.g. `threadhop copy`),
+# `$(...)` patterns, and other bash-syntactic characters. Pasting
+# those into a shell script via GitHub Actions `${{ ... }}` templating
+# causes bash to re-interpret them as commands — backticks become
+# command substitutions and `$(foo)` runs `foo` as a shell command.
+# Failure modes seen in production:
+#   - 2026-04-22 (v0.2.1): backticks around `threadhop copy [N|all]`
+#     made bash try to run `threadhop copy` and exit 2.
+#   - 2026-04-26 (v0.3.0): silent — substitutions of unknown commands
+#     returned empty strings, the workflow exited 0 with a Release body
+#     missing every backtick-wrapped identifier.
+# Mitigation: route every templated value through the step's `env:`
+# block so bash only sees them as plain environment variable values
+# (referenced as "$VAR"), not as inline script text. Documented at
+# https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
 
 on:
   push:
     branches: [main]
+  # Manual re-fire in case a push-triggered run ever fails. Passing
+  # `force: true` skips the version-change detection — needed because
+  # a retry on the same commit would otherwise see "no change" and
+  # no-op. The "Refuse if tag already exists" step still protects
+  # against accidental overwrites.
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Release the version at HEAD even if unchanged vs HEAD~1"
+        required: false
+        default: "false"
 
 permissions:
   contents: write   # needed to create tags + releases via GITHUB_TOKEN
@@ -28,6 +56,8 @@ jobs:
 
       - name: Detect version change
         id: ver
+        env:
+          FORCE: ${{ github.event.inputs.force }}
         run: |
           set -euo pipefail
           # __version__ moved from ./threadhop (script) to threadhop_core/__init__.py
@@ -50,7 +80,10 @@ jobs:
           fi
           echo "new=$NEW" >> "$GITHUB_OUTPUT"
           echo "old=$OLD" >> "$GITHUB_OUTPUT"
-          if [ "$NEW" != "$OLD" ]; then
+          if [ "${FORCE:-false}" = "true" ] && [ -n "$NEW" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Force mode — releasing v$NEW regardless of version change."
+          elif [ "$NEW" != "$OLD" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
             echo "::notice::Version changed $OLD -> $NEW; proceeding to release."
           else
@@ -59,27 +92,29 @@ jobs:
 
       - name: Refuse if tag already exists
         if: steps.ver.outputs.changed == 'true'
+        env:
+          RELEASE_VERSION: ${{ steps.ver.outputs.new }}
         run: |
-          V="${{ steps.ver.outputs.new }}"
-          if git ls-remote --tags origin | grep -qE "refs/tags/v${V}$"; then
-            echo "::error::Tag v${V} already exists. Aborting to avoid overwrite."
+          if git ls-remote --tags origin | grep -qE "refs/tags/v${RELEASE_VERSION}$"; then
+            echo "::error::Tag v${RELEASE_VERSION} already exists. Aborting to avoid overwrite."
             exit 1
           fi
 
       - name: Extract CHANGELOG section for this version
         if: steps.ver.outputs.changed == 'true'
         id: notes
+        env:
+          RELEASE_VERSION: ${{ steps.ver.outputs.new }}
         run: |
           set -euo pipefail
-          V="${{ steps.ver.outputs.new }}"
           # Grab the block between `## [V]` and the next `## [` header.
-          NOTES=$(awk -v v="$V" '
+          NOTES=$(awk -v v="$RELEASE_VERSION" '
             $0 ~ "^## \\[" v "\\]" { p=1; next }
             p && $0 ~ "^## \\[" { exit }
             p { print }
           ' CHANGELOG.md)
           if [ -z "$(echo "$NOTES" | tr -d '[:space:]')" ]; then
-            echo "::error::CHANGELOG.md has no '## [${V}]' entry. Add one before bumping __version__."
+            echo "::error::CHANGELOG.md has no '## [${RELEASE_VERSION}]' entry. Add one before bumping __version__."
             exit 1
           fi
           {
@@ -92,10 +127,14 @@ jobs:
         if: steps.ver.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.ver.outputs.new }}
+          RELEASE_SHA: ${{ github.sha }}
+          RELEASE_BODY: ${{ steps.notes.outputs.body }}
         run: |
-          V="${{ steps.ver.outputs.new }}"
-          gh release create "v${V}" \
-            --target "${{ github.sha }}" \
-            --title "v${V}" \
-            --notes "${{ steps.notes.outputs.body }}"
-          echo "::notice::Released v${V}"
+          # Every templated value is referenced as a shell variable, never
+          # interpolated inline — see SECURITY NOTE at the top of this file.
+          gh release create "v${RELEASE_VERSION}" \
+            --target "${RELEASE_SHA}" \
+            --title "v${RELEASE_VERSION}" \
+            --notes "${RELEASE_BODY}"
+          echo "::notice::Released v${RELEASE_VERSION}"


### PR DESCRIPTION
## Summary

- Routes every templated value in `release.yml` (`RELEASE_VERSION`, `RELEASE_SHA`, `RELEASE_BODY`, `FORCE`) through the step's `env:` block so bash sees them as inert env-var content rather than inline script text. Closes the template-injection vector that mangled v0.3.0's Release body and crashed v0.2.1's release run.
- Adds `workflow_dispatch` with a `force: true` input so a failed push-triggered run can be manually re-fired without bumping the version.
- Supersedes #69 (same fix; that PR is now `CONFLICTING` against `9d830af`'s threadhop_core path-fix).

## Why this matters now

The bug has bitten twice in production:

- **2026-04-22 (v0.2.1):** loud failure. Backticks around `` `threadhop copy [N|all]` `` made bash try to run `threadhop copy` and exit 2. v0.2.1 was rescued out-of-band via `gh release create`.
- **2026-04-26 (v0.3.0):** silent failure. Substitutions of unknown commands (`opencode`, `nord`, etc.) returned empty strings, the workflow exited 0, and the published Release body lost every backtick-wrapped identifier. Compare https://github.com/parzival1l/threadhop/releases/tag/v0.3.0 against the CHANGELOG entry — the divergence is the diff.

Without this fix, the next CHANGELOG entry that contains `$(...)` or unbalanced backticks is one push away from re-triggering the loud failure.

## What changed

- Every `${{ ... }}` template reference now lives inside an `env:` block. Inside `run:` blocks, values are referenced as plain shell variables (`\"$RELEASE_BODY\"`).
- `Detect version change` step gained a `FORCE` env var; when `force=true` is passed via `workflow_dispatch`, version-change detection is bypassed (the existing tag-exists guard still prevents accidental overwrites).
- New SECURITY NOTE comment block at the top of the file documents the bug class and the GitHub-recommended mitigation, with links to the failure incidents.

## Test plan

- [x] `uv run --with pyyaml python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/release.yml'))\"` — parses clean
- [x] Audit: `grep -nE '\\\$\\{\\{ |env:' .github/workflows/release.yml` confirms zero `\${{ ... }}` references survive inside any `run:` block — every templated value is in an `env:` block first
- [ ] **On merge:** `release.yml` runs on the merge commit, detects no version change (current=0.3.0), logs `\"No version change (current=0.3.0); skipping release.\"` and exits 0. Confirm in the Actions tab.
- [ ] **First end-to-end test:** the next release PR (0.3.1) will exercise the fixed `Create tag and release` step against a real CHANGELOG body. If the published v0.3.1 Release page shows backticks rendering correctly (e.g. \`code spans\` show as code), the fix worked.
- [ ] **Optional belt-and-suspenders:** before merging this, edit the v0.3.0 Release body in place to recover the mangled content — `awk '/^## \\[0\\.3\\.0\\]/{p=1;next} p && /^## \\[/{exit} p' CHANGELOG.md > /tmp/v0.3.0-notes.md && gh release edit v0.3.0 --notes-file /tmp/v0.3.0-notes.md`

## References

- Closes #69 (same fix, now stale due to merge conflicts).
- Failed run: [Actions run 24766482138](https://github.com/parzival1l/threadhop/actions/runs/24766482138) (v0.2.1 release attempt).
- Mangled release: https://github.com/parzival1l/threadhop/releases/tag/v0.3.0 (visible body has empty inline-code spans).
- GitHub Actions security guide: [using an intermediate environment variable](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable) — the documented mitigation for exactly this class of bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)