### PR TITLE
Release 0.3.1 — kanban/sidebar visibility sync

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "threadhop",
       "source": "./plugin",
       "description": "Persistent, searchable, cross-session memory for Claude Code — browse sessions, extract TODOs/decisions, produce handoff briefs.",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "author": {
         "name": "parzival1l"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to ThreadHop are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions
 follow `major.minor.patch`.
 
+## [0.3.1] — 2026-04-26
+
+### Fixed
+- Sidebar and Kanban board now show the same set of sessions. Previously
+  with more than 50 sessions, the sidebar's global cap could slice
+  later-status buckets (`in_review`, `done`, `archived`) off the bottom
+  of the sorted list while the Kanban board still rendered them. The
+  symptom: clicking a card on the board that wasn't in the sidebar did
+  nothing — `_on_kanban_dismissed` walks the sidebar's `ListView` to
+  drive selection and silently bailed when the session was missing.
+- Both views now read from a single `_visible_sessions()` helper that
+  applies `MAX_SESSIONS` per status bucket (so each column gets its own
+  budget) and honors the `_show_archived` toggle uniformly. Manual
+  reorder (`shift+j`/`shift+k`) reuses the same helper so swap-with-
+  neighbor matches what's on screen.
+- `_on_kanban_dismissed` now flips `_show_archived` on and rebuilds when
+  an archived card is clicked from the board with the archived view
+  hidden, so the navigation always lands instead of silently failing.
+
+### Notes
+- Added `pyrightconfig.json` so basedpyright/pyright can resolve
+  third-party imports (`textual`, `rich`, `watchdog`, `pydantic`) from
+  a local `.venv/`. Editor-only — runtime still uses PEP 723 inline
+  metadata via `uv run --script`. Contributors who want red-squiggle-
+  free editor support should run `uv venv && uv pip install textual
+  watchdog pydantic pytest` once after cloning.
+
 ## [0.3.0] — 2026-04-26
 
 ### Added

--- a/docs/task-054-transcript-harness-adapters.md
+++ b/docs/task-054-transcript-harness-adapters.md
@@ -1,0 +1,171 @@
+# Task 054 — Transcript harness adapters
+
+**Reference:** [ADR-028 in `DESIGN-DECISIONS.md`](./DESIGN-DECISIONS.md#adr-028-harness-adapter-seam-single-concrete-adapter)
+
+Read ADR-028 first, then read this doc. ADR-028 is about the existing
+`threadhop_core/harness/` seam for invoking `claude -p` during
+observation, reflection, and handoff generation. This task is about a
+different problem: ingesting session transcripts from multiple external
+harnesses such as Claude Code, Codex CLI, Gemini CLI, Cline, Cursor,
+Aider, and OpenCode. The naming overlap is real, so this plan uses the
+phrase **transcript harness adapter** deliberately to keep the scope
+clear.
+
+---
+
+## Objective
+
+Move ThreadHop from a Claude Code transcript browser into a
+multi-harness transcript system without rewriting search, observation,
+handoff, or the UI for each provider. The goal is not to make every
+harness behave identically at the storage layer. The goal is to let each
+harness keep its own file format and storage path while ThreadHop owns a
+single normalized session and message model above that layer.
+
+At the end of this task, ThreadHop should be able to discover sessions
+from more than one harness, parse them through harness-specific adapter
+code, normalize them into the same SQLite-backed model, and present them
+through the same TUI, CLI, and future local web UI. A user should be
+able to search across Claude Code and another supported harness in one
+query, browse both in one session list, and use the same bookmarks,
+observations, and handoff workflows wherever the source transcript shape
+contains enough information to support them.
+
+---
+
+## Intention
+
+The intention of the transcript harness adapter work is to isolate the
+parts of ThreadHop that are truly provider-specific. Those parts are
+session discovery, transcript parsing, tool-call normalization,
+message-role mapping, and any per-provider cleaning rules needed to turn
+raw transcript bytes into the cleaned conversation view that ThreadHop
+indexes and renders. Everything above that seam should become
+provider-agnostic. Search should not know whether a row came from Claude
+Code or OpenCode. The observer should not need a second implementation
+for Codex. The future fork and merge-back work should attach to the
+normalized session graph, not to one vendor's raw JSONL shape.
+
+This task is also meant to stop provider growth from spreading conditionals
+through the codebase. Right now the repo is still shaped around Claude
+Code as the one source of truth. If multi-harness support is added by
+sprinkling `if provider == ...` checks through the indexer, TUI, CLI,
+and observation pipeline, the product will become harder to reason about
+with every new source. The adapter boundary exists to keep that entropy
+contained. Adding a new harness should feel like adding one new module
+and wiring it into discovery, not reopening every feature layer.
+
+---
+
+## End Product
+
+The end product is a ThreadHop core with two clear levels. The lower
+level consists of one transcript harness adapter per source system.
+Each adapter knows where that harness stores sessions, how to enumerate
+them, how to parse its transcript format, how to identify the session
+and project, and how to map raw records into ThreadHop's canonical
+session and message shapes. The upper level consists of the existing
+ThreadHop features operating only on canonical data: SQLite indexing,
+FTS search, observation extraction, handoff generation, bookmarking,
+status tagging, export, and UI rendering.
+
+In the finished system, every indexed session row carries enough source
+metadata to stay explainable. Users should be able to tell which harness
+produced a session, where it came from on disk, and which features are
+fully supported for that source. The app should degrade honestly when a
+harness does not provide something Claude Code does provide. For
+example, if a harness lacks stable tool-result structure or active
+session detection hooks, ThreadHop should still index and display the
+conversation while marking advanced capabilities as unavailable rather
+than faking parity.
+
+The end product is therefore not just “more parsers.” It is a provider-
+agnostic data model, a stable adapter seam, and a capability-aware user
+experience that can grow to multiple harnesses without diluting the core
+product.
+
+---
+
+## What This Task Includes
+
+This task includes extracting the existing Claude Code transcript logic
+behind a formal transcript adapter seam and treating Claude as the first
+real implementation of that seam. It includes defining the canonical
+session and message model that all adapters must produce, including the
+minimum metadata required by the existing ThreadHop surfaces: session
+id, provider, project, cwd when known, timestamps, role, text, tool
+artifacts when available, and enough stable identity to support
+incremental indexing and bookmarks.
+
+It also includes deciding how ThreadHop expresses harness capabilities.
+Some features are universal, such as transcript browsing and text
+search. Some are conditional, such as active-session detection,
+reply-in-place, or exact tool-call rendering. The adapter layer needs a
+small capability surface so the rest of the app can ask what is safe to
+offer for a given session instead of inferring it from provider names.
+
+This task includes a migration path for the current Claude-only code.
+The Claude parser and discovery logic should become the baseline adapter
+without changing user-visible Claude behavior. Multi-harness support
+should begin by proving that the seam can hold Claude cleanly, then add
+the second adapter that makes the abstraction real.
+
+---
+
+## What This Task Does Not Include
+
+This task does not require a language port, a UI rewrite, or an OpenCode
+integration inside their repository. It does not require every harness
+to support every ThreadHop feature on day one. It also does not require
+live multi-user collaboration, LAN-hosted shared editing, or two-person
+continuation of a single active chat session. Those are separate product
+problems and should be evaluated after the transcript model is stable.
+
+It also does not replace ADR-028's existing `threadhop_core/harness/`
+module. That module remains the outbound LLM invocation seam for
+observer, reflector, and handoff prompts. This task introduces a second
+seam on the inbound side: transcript discovery and normalization.
+
+---
+
+## Proposed Shape
+
+The clean shape for this work is a new transcript-facing adapter layer
+owned by ThreadHop itself. Each adapter should expose three responsibilities
+in practice: discover sessions, describe session metadata, and parse a
+session into canonical messages. The rest of the application should stop
+reading provider-specific transcript formats directly. The indexer, TUI,
+CLI queries, and future web server should all consume the normalized
+result.
+
+The first milestone is not “support all providers.” The first milestone
+is “Claude Code now goes through the same adapter contract that future
+providers will use.” Once that is true, the second milestone is to add a
+second concrete adapter, because that is the point where the seam stops
+being hypothetical. Codex CLI and OpenCode are good candidates for that
+second adapter because they are structurally close to the use case that
+already made ThreadHop valuable: local coding-agent transcripts with
+tool activity and persistent session files.
+
+After the second adapter exists, the rest of the roadmap becomes much
+clearer. Search improvements, fork lineage, merge-back summaries, and a
+local web UI all benefit from one normalized session graph more than
+from any one provider-specific integration.
+
+---
+
+## Acceptance Criteria
+
+This task is complete when ThreadHop has an explicit transcript harness
+adapter seam, Claude Code is migrated onto it with no user-facing
+regression, and adding a second harness no longer requires changes
+across unrelated feature layers. At that point, the codebase should have
+one place to add provider-specific discovery, one place to add
+provider-specific parsing, and one normalized model that the rest of the
+app trusts.
+
+From a user perspective, the feature is successful when ThreadHop can
+show sessions from multiple harnesses in one product, search across them
+with the same interface, and surface the origin of each session clearly.
+From a maintainer perspective, the feature is successful when adding the
+next harness feels incremental instead of architectural.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "threadhop",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Browse, search, and carry context across Claude Code sessions. Exposes /threadhop:handoff, /threadhop:observe, /threadhop:tag.",
   "author": {
     "name": "ThreadHop",

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,27 @@
+{
+  "//": "Editor-only config for basedpyright/pyright. Runtime is uv-script (PEP 723 metadata in ./threadhop). The local .venv is created with `uv venv && uv pip install textual watchdog pydantic pytest` purely so the type-checker can resolve third-party imports — it is NOT used to launch the app.",
+  "venvPath": ".",
+  "venv": ".venv",
+  "pythonVersion": "3.12",
+  "pythonPlatform": "Darwin",
+  "include": [
+    "threadhop_core",
+    "tests",
+    "threadhop"
+  ],
+  "exclude": [
+    "**/__pycache__",
+    ".venv",
+    ".pytest_cache",
+    "plugin",
+    "prompts",
+    "themes",
+    "assets",
+    "docs"
+  ],
+  "extraPaths": [
+    "."
+  ],
+  "reportMissingImports": "error",
+  "reportMissingTypeStubs": "none"
+}

--- a/threadhop_core/__init__.py
+++ b/threadhop_core/__init__.py
@@ -1,3 +1,3 @@
 """ThreadHop core package — version-of-truth and shared imports."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/threadhop_core/tui/app.py
+++ b/threadhop_core/tui/app.py
@@ -564,13 +564,54 @@ class ClaudeSessions(App):
         if isinstance(top, KanbanScreen):
             try:
                 top.update_sessions(
-                    self.sessions,
+                    self._visible_sessions(),
                     self.config.get("session_names", {}) or {},
                 )
             except Exception:
                 # A render hiccup in the modal must not break the 5s
                 # refresh loop for the rest of the app.
                 pass
+
+    def _visible_sessions(self) -> list[dict]:
+        """Single source of truth for "which sessions are visible right now".
+
+        The sidebar and the Kanban board used to apply different filters to
+        ``self.sessions`` — the sidebar capped at ``MAX_SESSIONS`` and hid
+        archived rows, the Kanban took the full list. Past ~50 sessions the
+        global cap (combined with the ``status_rank`` sort in
+        ``_apply_stable_ordering``, which puts ``active`` first and ``done``
+        last) ate later-status buckets first, so a card visible on the
+        board could be missing from the sidebar — and clicking it did
+        nothing because ``_on_kanban_dismissed`` searches the sidebar
+        ListView to drive selection.
+
+        This helper applies the cap **per status bucket** so each column
+        keeps a reasonable budget independent of the others, and honors
+        the same ``_show_archived`` toggle the sidebar uses. Both surfaces
+        feed off this list so they never disagree on what's clickable.
+        Within-bucket ordering is preserved (the master list is already
+        sorted by ``(status_rank, manual_sort_order)``).
+        """
+        per_bucket: dict[str, list[dict]] = {}
+        for s in self.sessions:
+            status = s.get("status", "active")
+            if status == "archived" and not self._show_archived:
+                continue
+            bucket = per_bucket.setdefault(status, [])
+            if len(bucket) < MAX_SESSIONS:
+                bucket.append(s)
+
+        out: list[dict] = []
+        for status in STATUS_ORDER:
+            out.extend(per_bucket.get(status, []))
+        # Catch-all for unknown statuses (defensive — shouldn't fire given
+        # the CHECK constraint in storage/db.py, but matches the same
+        # tail-append the sidebar already does).
+        for status, bucket in per_bucket.items():
+            if status in STATUS_RANK:
+                continue
+            out.extend(bucket)
+        return out
 
     def _apply_stable_ordering(self) -> None:
         if "session_order" not in self.config:
@@ -609,16 +650,11 @@ class ClaudeSessions(App):
         )
 
     def _update_session_list(self, force_rebuild: bool = False) -> None:
-        all_sessions = self.sessions[:MAX_SESSIONS]
-
-        # Split into active (non-archived) and archived groups.
-        active_sessions = [s for s in all_sessions if s.get("status") != "archived"]
-        archived_sessions = [s for s in all_sessions if s.get("status") == "archived"]
-
-        if self._show_archived:
-            display_sessions = active_sessions + archived_sessions
-        else:
-            display_sessions = active_sessions
+        # Single source of truth for visibility — same list the Kanban
+        # board sees, so a card on the board is always reachable from
+        # the sidebar's ListView (which is what _on_kanban_dismissed
+        # walks to drive selection on click).
+        display_sessions = self._visible_sessions()
 
         # Bucket sessions by status. Preserve the in-memory order inside
         # each bucket — the sort in _apply_stable_ordering already put them
@@ -1236,7 +1272,7 @@ class ClaudeSessions(App):
             return
         custom_names = self.config.get("session_names", {}) or {}
         self.push_screen(
-            KanbanScreen(self.sessions, custom_names),
+            KanbanScreen(self._visible_sessions(), custom_names),
             self._on_kanban_dismissed,
         )
 
@@ -1247,18 +1283,47 @@ class ClaudeSessions(App):
         normal ListView.Highlighted handler drive the transcript load —
         that path also stamps last_viewed and clears the unread flag,
         which we'd otherwise have to duplicate here.
+
+        If the session isn't in the current sidebar list (e.g. it's
+        archived and ``_show_archived`` is False), we flip the toggle on
+        and force-rebuild before re-searching. Without this fallback, an
+        archived card on the Kanban board would dismiss with a valid id
+        but the sidebar would silently fail to navigate — the original
+        symptom that prompted the visible-sessions unification.
         """
         if not session_id:
             return
         list_view = self.query_one("#session-list", ListView)
-        for idx, item in enumerate(list_view.children):
-            if (
-                isinstance(item, SessionItem)
-                and item.session_data.get("session_id") == session_id
-            ):
-                list_view.index = idx
-                list_view.focus()
-                return
+
+        def _find_and_select() -> bool:
+            for idx, item in enumerate(list_view.children):
+                if (
+                    isinstance(item, SessionItem)
+                    and item.session_data.get("session_id") == session_id
+                ):
+                    list_view.index = idx
+                    list_view.focus()
+                    return True
+            return False
+
+        if _find_and_select():
+            return
+
+        # Fallback: the picked session must be in self.sessions (the Kanban
+        # was rendered from a subset of it) but is hidden from the sidebar
+        # by the archived toggle. Reveal it, rebuild, and try once more.
+        target = next(
+            (s for s in self.sessions if s.get("session_id") == session_id),
+            None,
+        )
+        if target is None:
+            return
+        if target.get("status") == "archived" and not self._show_archived:
+            self._show_archived = True
+            self._update_session_list(force_rebuild=True)
+            # Rebuild is synchronous (clear + append) so children are
+            # ready to walk immediately.
+            _find_and_select()
 
     def bookmark_toggle_selection(self) -> None:
         """Selection-mode `space`: toggle a bookmark on each selected
@@ -1812,7 +1877,10 @@ class ClaudeSessions(App):
         if session_id not in order:
             return
 
-        visible_ids = [s["session_id"] for s in self.sessions[:MAX_SESSIONS]]
+        # Use the same visibility semantics as the sidebar/Kanban so a
+        # manual reorder always swaps with the row that actually appears
+        # next to the cursor on screen.
+        visible_ids = [s["session_id"] for s in self._visible_sessions()]
         if session_id not in visible_ids:
             return
 

--- a/threadhop_core/tui/theme/vendored/README.md
+++ b/threadhop_core/tui/theme/vendored/README.md
@@ -1,6 +1,6 @@
 # Vendored themes
 
-These JSON files are copied verbatim from
+Most JSON files are copied verbatim from
 [anomalyco/opencode](https://github.com/anomalyco/opencode), MIT licensed,
 under `packages/opencode/src/cli/cmd/tui/context/theme/`.
 
@@ -9,5 +9,11 @@ Each file follows the OpenCode TUI theme schema
 plus a `theme` table mapping semantic roles to those defs. Both a `dark`
 and a `light` variant live in every file. `themes/loader.py` converts
 each into a pair of `textual.theme.Theme` objects.
+
+`cursor.json` is a hand-translation of upstream's newer `desktop-theme.json`
+(palette + overrides) at
+[`packages/ui/src/theme/themes/cursor.json`](https://github.com/anomalyco/opencode/blob/dev/packages/ui/src/theme/themes/cursor.json)
+into this older schema. The 12-step neutral ramp is synthesized between
+Cursor's `neutral` and `ink` since the upstream file does not provide one.
 
 To add another OpenCode theme, drop its JSON here and restart the app.

--- a/threadhop_core/tui/theme/vendored/cursor.json
+++ b/threadhop_core/tui/theme/vendored/cursor.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "https://opencode.ai/theme.json",
+  "_source": "translated from https://github.com/anomalyco/opencode/blob/dev/packages/ui/src/theme/themes/cursor.json (desktop-theme schema) into the opencode TUI schema",
+  "defs": {
+    "darkStep1": "#181818",
+    "darkStep2": "#1f1f1f",
+    "darkStep3": "#262626",
+    "darkStep4": "#2e2e2e",
+    "darkStep5": "#363636",
+    "darkStep6": "#404040",
+    "darkStep7": "#4a4a4a",
+    "darkStep8": "#5a5a5a",
+    "darkStep9": "#88c0d0",
+    "darkStep10": "#a0d3df",
+    "darkStep11": "#7a7a7a",
+    "darkStep12": "#e4e4e4",
+    "darkSecondary": "#82d2ce",
+    "darkAccent": "#aaa0fa",
+    "darkRed": "#e34671",
+    "darkOrange": "#efb080",
+    "darkGreen": "#3fa266",
+    "darkCyan": "#81a1c1",
+    "darkYellow": "#f8c762",
+    "darkPink": "#e394dc",
+    "lightStep1": "#fcfcfc",
+    "lightStep2": "#f6f6f6",
+    "lightStep3": "#f0f0f0",
+    "lightStep4": "#e8e8e8",
+    "lightStep5": "#dedede",
+    "lightStep6": "#d0d0d0",
+    "lightStep7": "#b6b6b6",
+    "lightStep8": "#9e9e9e",
+    "lightStep9": "#6f9ba6",
+    "lightStep10": "#5a8590",
+    "lightStep11": "#757575",
+    "lightStep12": "#141414",
+    "lightSecondary": "#206595",
+    "lightAccent": "#b8448b",
+    "lightRed": "#cf2d56",
+    "lightOrange": "#db704b",
+    "lightGreen": "#1f8a65",
+    "lightCyan": "#3c7cab",
+    "lightYellow": "#b0851f",
+    "lightPink": "#9e94d5"
+  },
+  "theme": {
+    "primary": {
+      "dark": "darkStep9",
+      "light": "lightStep9"
+    },
+    "secondary": {
+      "dark": "darkSecondary",
+      "light": "lightSecondary"
+    },
+    "accent": {
+      "dark": "darkAccent",
+      "light": "lightAccent"
+    },
+    "error": {
+      "dark": "darkRed",
+      "light": "lightRed"
+    },
+    "warning": {
+      "dark": "darkOrange",
+      "light": "lightOrange"
+    },
+    "success": {
+      "dark": "darkGreen",
+      "light": "lightGreen"
+    },
+    "info": {
+      "dark": "darkCyan",
+      "light": "lightCyan"
+    },
+    "text": {
+      "dark": "darkStep12",
+      "light": "lightStep12"
+    },
+    "textMuted": {
+      "dark": "darkStep11",
+      "light": "lightStep11"
+    },
+    "background": {
+      "dark": "darkStep1",
+      "light": "lightStep1"
+    },
+    "backgroundPanel": {
+      "dark": "darkStep2",
+      "light": "lightStep2"
+    },
+    "backgroundElement": {
+      "dark": "darkStep3",
+      "light": "lightStep3"
+    },
+    "border": {
+      "dark": "darkStep7",
+      "light": "lightStep7"
+    },
+    "borderActive": {
+      "dark": "darkStep8",
+      "light": "lightStep8"
+    },
+    "borderSubtle": {
+      "dark": "darkStep6",
+      "light": "lightStep6"
+    },
+    "diffAdded": {
+      "dark": "#70b489",
+      "light": "#55a583"
+    },
+    "diffRemoved": {
+      "dark": "#fc6b83",
+      "light": "#e75e78"
+    },
+    "diffAddedBg": {
+      "dark": "#1f2b25",
+      "light": "#dceee3"
+    },
+    "diffRemovedBg": {
+      "dark": "#36202a",
+      "light": "#f7d6dc"
+    },
+    "markdownText": {
+      "dark": "darkStep12",
+      "light": "lightStep12"
+    },
+    "markdownHeading": {
+      "dark": "darkAccent",
+      "light": "lightSecondary"
+    },
+    "markdownLink": {
+      "dark": "darkSecondary",
+      "light": "lightSecondary"
+    },
+    "markdownLinkText": {
+      "dark": "darkCyan",
+      "light": "lightStep11"
+    },
+    "markdownCode": {
+      "dark": "darkPink",
+      "light": "lightGreen"
+    },
+    "markdownBlockQuote": {
+      "dark": "darkStep11",
+      "light": "lightStep11"
+    },
+    "markdownEmph": {
+      "dark": "darkSecondary",
+      "light": "lightStep12"
+    },
+    "markdownStrong": {
+      "dark": "darkYellow",
+      "light": "lightStep12"
+    },
+    "markdownHorizontalRule": {
+      "dark": "darkStep11",
+      "light": "lightStep11"
+    },
+    "markdownListItem": {
+      "dark": "darkStep12",
+      "light": "lightStep12"
+    },
+    "markdownListEnumeration": {
+      "dark": "darkStep9",
+      "light": "lightStep11"
+    },
+    "markdownImage": {
+      "dark": "darkStep9",
+      "light": "lightStep9"
+    },
+    "markdownImageText": {
+      "dark": "darkCyan",
+      "light": "lightStep11"
+    },
+    "markdownCodeBlock": {
+      "dark": "darkStep12",
+      "light": "lightStep12"
+    },
+    "syntaxComment": {
+      "dark": "darkStep11",
+      "light": "lightStep11"
+    },
+    "syntaxKeyword": {
+      "dark": "darkSecondary",
+      "light": "#b3003f"
+    },
+    "syntaxFunction": {
+      "dark": "darkStep9",
+      "light": "lightStep9"
+    },
+    "syntaxVariable": {
+      "dark": "darkStep12",
+      "light": "lightStep12"
+    },
+    "syntaxString": {
+      "dark": "darkPink",
+      "light": "lightPink"
+    },
+    "syntaxNumber": {
+      "dark": "darkOrange",
+      "light": "lightOrange"
+    },
+    "syntaxType": {
+      "dark": "darkOrange",
+      "light": "lightSecondary"
+    },
+    "syntaxOperator": {
+      "dark": "darkStep12",
+      "light": "lightStep12"
+    },
+    "syntaxPunctuation": {
+      "dark": "darkStep12",
+      "light": "lightStep12"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Releases 0.3.1 covering a sidebar/Kanban visibility-sync fix that made cards on the board un-clickable when the sidebar's `MAX_SESSIONS` cap sliced them out of the rendered list.
- Bumps `__version__`, `marketplace.json`, `plugin.json` to `0.3.1`; adds matching `CHANGELOG.md` entry.

## What's in this release

- **Sidebar/Kanban now share a single visible-sessions helper.** With more than 50 sessions, the global cap used to starve later-status buckets (`in_review`, `done`) from the sidebar while the Kanban board still rendered them, so clicking a board-only card was a silent no-op (`_on_kanban_dismissed` walks the sidebar's `ListView` to drive selection and bailed when the session was missing). Both views now consume a new `_visible_sessions()` helper that applies `MAX_SESSIONS` per status bucket and honors `_show_archived` uniformly.
- **`_on_kanban_dismissed` hardened** to auto-flip `_show_archived` on and rebuild the sidebar when an archived card is clicked from the board with the archived view hidden, so the navigation always lands instead of silently failing.
- **Manual reorder (`shift+j`/`shift+k`)** now uses the same `_visible_sessions()` helper, so swap-with-neighbor matches what is actually drawn on screen.
- **Editor type-checker config** (`pyrightconfig.json`) added so basedpyright/pyright can resolve `textual`, `rich`, `watchdog`, `pydantic` from a local `.venv/`. Editor-only — runtime still uses PEP 723 inline metadata via `uv run --script`. Contributors who want red-squiggle-free editor support should run `uv venv && uv pip install textual watchdog pydantic pytest` once after cloning.

## Test plan

- [x] `validate` workflow passes (version parity + CHANGELOG entry)
- [x] All 201 pytest tests still pass locally
- [ ] Manual: open TUI on a project with more than 50 sessions, confirm `in_review`/`done` cards on the Kanban board are also visible in the sidebar and clicking them navigates
- [ ] Manual: with archived view off, click an archived card on the board — the toggle flips on and the session becomes selected
- [ ] On merge: `release.yml` creates `v0.3.1` tag + GitHub Release
- [ ] After merge: `gh api /repos/parzival1l/threadhop/releases/latest --jq .tag_name` returns `"v0.3.1"`
- [ ] After merge: `./threadhop update --check` from a `0.3.0` install prints the 3-line nudge

## References

- Commits in this release (since `v0.3.0`):
  - `4a00c11` fix: kanban-session-list reflect the same chats
  - `0d4d9be` chore: editor type-checker config (`pyrightconfig.json`)
  - `ee1e389` Bump to 0.3.1