### PR TITLE
Release 0.3.2 — session digest bar

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "threadhop",
       "source": "./plugin",
       "description": "Persistent, searchable, cross-session memory for Claude Code — browse sessions, extract TODOs/decisions, produce handoff briefs.",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "author": {
         "name": "parzival1l"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to ThreadHop are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions
 follow `major.minor.patch`.
 
+## [0.3.2] — 2026-05-07
+
+### Added
+- Per-session digest bar pinned to the right of the transcript pane.
+  Surfaces the highlighted session's title, custom name, working
+  directory, recent activity, and turn count at a glance — no need
+  to open the transcript to see what a session is about. Refreshes
+  on highlight and on selection, and reads the same JSONL view the
+  transcript uses (`extract_digest`) so what you see in the bar
+  always matches what's about to render.
+- TUI grid widened from 2 columns to 3 to host the digest bar; the
+  reply input now spans all three columns so the existing input
+  experience is unchanged.
+
 ## [0.3.1] — 2026-04-26
 
 ### Fixed

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "threadhop",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Browse, search, and carry context across Claude Code sessions. Exposes /threadhop:handoff, /threadhop:observe, /threadhop:tag.",
   "author": {
     "name": "ThreadHop",

--- a/tests/test_session_digest.py
+++ b/tests/test_session_digest.py
@@ -1,0 +1,599 @@
+"""Unit tests for ``threadhop_core.session.digest.extract_digest``.
+
+The extractor is the data layer behind the right-hand SessionDigestBar.
+Tests use synthetic JSONL fixtures rather than live transcripts so each
+line type is exercised in isolation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from threadhop_core.session.digest import (
+    RecapEntry,
+    SessionDigest,
+    _clean_first_prompt,
+    _model_context_window,
+    extract_digest,
+)
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> Path:
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    return path
+
+
+def _user(text: str, ts: str, **extra) -> dict:
+    return {
+        "type": "user",
+        "uuid": extra.pop("uuid", f"user-{ts}"),
+        "timestamp": ts,
+        "message": {"role": "user", "content": text},
+        **extra,
+    }
+
+
+def _assistant(
+    text: str,
+    ts: str,
+    *,
+    msg_id: str,
+    model: str = "claude-opus-4-7",
+    usage: dict | None = None,
+    tool_uses: list[dict] | None = None,
+    **extra,
+) -> dict:
+    content: list[dict] = [{"type": "text", "text": text}]
+    if tool_uses:
+        content.extend(tool_uses)
+    return {
+        "type": "assistant",
+        "uuid": extra.pop("uuid", f"asst-{ts}"),
+        "timestamp": ts,
+        "message": {
+            "id": msg_id,
+            "role": "assistant",
+            "model": model,
+            "content": content,
+            **({"usage": usage} if usage else {}),
+        },
+        **extra,
+    }
+
+
+# ---------- Identity & ambient fields ----------
+
+
+def test_extract_digest_picks_up_titles_slug_branch_version(tmp_path: Path):
+    path = _write_jsonl(
+        tmp_path / "s.jsonl",
+        [
+            {"type": "ai-title", "sessionId": "s", "aiTitle": "Auto title"},
+            {"type": "custom-title", "sessionId": "s", "customTitle": "My title"},
+            _user("hello", "2026-01-01T00:00:00Z", slug="brave-otter",
+                  gitBranch="dev", version="2.1.131", cwd="/tmp/proj"),
+        ],
+    )
+    d = extract_digest(path)
+    assert d.custom_title == "My title"
+    assert d.ai_title == "Auto title"
+    assert d.title == "My title"  # custom > ai
+    assert d.slug == "brave-otter"
+    assert d.branch == "dev"
+    assert d.client_version == "2.1.131"
+    assert d.cwd == "/tmp/proj"
+
+
+def test_title_falls_back_to_ai_then_slug(tmp_path: Path):
+    path = _write_jsonl(
+        tmp_path / "s.jsonl",
+        [
+            {"type": "ai-title", "sessionId": "s", "aiTitle": "AI only"},
+            _user("hi", "2026-01-01T00:00:00Z", slug="brave-otter"),
+        ],
+    )
+    assert extract_digest(path).title == "AI only"
+
+    path2 = _write_jsonl(
+        tmp_path / "s2.jsonl",
+        [_user("hi", "2026-01-01T00:00:00Z", slug="lucky-fox")],
+    )
+    assert extract_digest(path2).title == "lucky-fox"
+
+
+# ---------- PR / outputs ----------
+
+
+def test_extract_digest_captures_pr_link(tmp_path: Path):
+    path = _write_jsonl(
+        tmp_path / "s.jsonl",
+        [
+            _user("hi", "2026-01-01T00:00:00Z"),
+            {
+                "type": "pr-link",
+                "sessionId": "s",
+                "prNumber": 73,
+                "prUrl": "https://github.com/foo/bar/pull/73",
+                "prRepository": "foo/bar",
+                "timestamp": "2026-01-01T00:05:00Z",
+            },
+        ],
+    )
+    d = extract_digest(path)
+    assert d.pr_number == 73
+    assert d.pr_url == "https://github.com/foo/bar/pull/73"
+    assert d.pr_repository == "foo/bar"
+
+
+def test_extract_digest_collects_files_touched(tmp_path: Path):
+    path = _write_jsonl(
+        tmp_path / "s.jsonl",
+        [
+            _user("change app.py", "2026-01-01T00:00:00Z"),
+            _assistant(
+                "ok",
+                "2026-01-01T00:00:01Z",
+                msg_id="m1",
+                tool_uses=[
+                    {"type": "tool_use", "id": "t1", "name": "Edit",
+                     "input": {"file_path": "/repo/app.py"}},
+                    {"type": "tool_use", "id": "t2", "name": "Write",
+                     "input": {"file_path": "/repo/new.py"}},
+                    # Bash should NOT count as a file touch.
+                    {"type": "tool_use", "id": "t3", "name": "Bash",
+                     "input": {"command": "ls"}},
+                ],
+            ),
+            _assistant(
+                "again",
+                "2026-01-01T00:00:02Z",
+                msg_id="m2",
+                tool_uses=[
+                    {"type": "tool_use", "id": "t4", "name": "Edit",
+                     "input": {"file_path": "/repo/app.py"}},  # dedupe
+                ],
+            ),
+        ],
+    )
+    d = extract_digest(path)
+    assert d.files_touched == {"/repo/app.py", "/repo/new.py"}
+    assert d.files_touched_count == 2
+
+
+# ---------- Tokens / models ----------
+
+
+def test_extract_digest_sums_tokens_and_dedupes_chunked_assistant(tmp_path: Path):
+    # Two chunks share message.id m1 — usage on the final chunk is what
+    # sticks (last-write-wins). m2 is a separate message with its own usage.
+    path = _write_jsonl(
+        tmp_path / "s.jsonl",
+        [
+            _user("hi", "2026-01-01T00:00:00Z"),
+            _assistant("partial", "2026-01-01T00:00:01Z", msg_id="m1"),
+            _assistant(
+                "final",
+                "2026-01-01T00:00:02Z",
+                msg_id="m1",
+                usage={
+                    "input_tokens": 100,
+                    "output_tokens": 200,
+                    "cache_read_input_tokens": 5000,
+                    "cache_creation_input_tokens": 50,
+                },
+            ),
+            _assistant(
+                "second turn",
+                "2026-01-01T00:00:03Z",
+                msg_id="m2",
+                usage={
+                    "input_tokens": 50,
+                    "output_tokens": 75,
+                    "cache_read_input_tokens": 1000,
+                    "cache_creation_input_tokens": 25,
+                },
+            ),
+        ],
+    )
+    d = extract_digest(path)
+    assert d.total_input_tokens == 150
+    assert d.total_output_tokens == 275
+    assert d.total_cache_read_tokens == 6000
+    assert d.total_cache_creation_tokens == 75
+    # Cache hit: 6000 / (6000 + 75)
+    assert d.cache_hit_ratio is not None
+    assert 0.985 < d.cache_hit_ratio < 0.99
+
+
+def test_extract_digest_tracks_models_in_first_seen_order(tmp_path: Path):
+    path = _write_jsonl(
+        tmp_path / "s.jsonl",
+        [
+            _user("hi", "2026-01-01T00:00:00Z"),
+            _assistant("a", "2026-01-01T00:00:01Z", msg_id="m1",
+                       model="claude-opus-4-7"),
+            _assistant("b", "2026-01-01T00:00:02Z", msg_id="m2",
+                       model="claude-haiku-4-5"),
+            _assistant("c", "2026-01-01T00:00:03Z", msg_id="m3",
+                       model="claude-opus-4-7"),  # already seen
+        ],
+    )
+    d = extract_digest(path)
+    assert d.models_used == ["claude-opus-4-7", "claude-haiku-4-5"]
+
+
+def test_cache_hit_ratio_is_none_when_no_cache_activity(tmp_path: Path):
+    path = _write_jsonl(tmp_path / "s.jsonl", [_user("hi", "2026-01-01T00:00:00Z")])
+    assert extract_digest(path).cache_hit_ratio is None
+
+
+# ---------- Recap timeline ----------
+
+
+def test_recap_has_started_only_for_short_session(tmp_path: Path):
+    """The recap deliberately drops a "Last asked" band — the most recent
+    exchange is already visible in the transcript pane next door, so the
+    bar focuses on what's NOT visible there.
+    """
+    path = _write_jsonl(
+        tmp_path / "s.jsonl",
+        [
+            _user("redesign the kanban", "2026-01-01T00:00:00Z"),
+            _assistant("ok", "2026-01-01T00:00:01Z", msg_id="m1"),
+            _user("show me the diff", "2026-01-01T00:05:00Z"),
+        ],
+    )
+    d = extract_digest(path)
+    labels = [r.label for r in d.recap]
+    assert labels == ["Started"]
+    assert d.recap[0].text == "redesign the kanban"
+    assert "Last asked" not in {r.label for r in d.recap}
+
+
+def test_recap_collapses_to_just_started_when_session_is_one_prompt(tmp_path: Path):
+    path = _write_jsonl(
+        tmp_path / "s.jsonl",
+        [_user("only prompt", "2026-01-01T00:00:00Z")],
+    )
+    d = extract_digest(path)
+    assert [r.label for r in d.recap] == ["Started"]
+
+
+def test_recap_includes_away_summary_as_recently(tmp_path: Path):
+    path = _write_jsonl(
+        tmp_path / "s.jsonl",
+        [
+            _user("design something", "2026-01-01T00:00:00Z"),
+            _assistant("ok", "2026-01-01T00:00:01Z", msg_id="m1"),
+            {
+                "type": "system",
+                "subtype": "away_summary",
+                "content": "Just finished Task 1. Next: Task 2.",
+                "timestamp": "2026-01-01T01:00:00Z",
+            },
+            _user("continue", "2026-01-01T02:00:00Z"),
+        ],
+    )
+    d = extract_digest(path)
+    labels = [r.label for r in d.recap]
+    assert labels == ["Started", "Recently"]
+    recently = next(r for r in d.recap if r.label == "Recently")
+    assert "Task 1" in recently.text
+
+
+def test_recap_includes_compact_summary_as_earlier(tmp_path: Path):
+    path = _write_jsonl(
+        tmp_path / "s.jsonl",
+        [
+            _user("kick off", "2026-01-01T00:00:00Z"),
+            {
+                "type": "system",
+                "subtype": "compact_boundary",
+                "content": "Conversation compacted",
+                "timestamp": "2026-01-01T01:00:00Z",
+                "compactMetadata": {"trigger": "manual", "preTokens": 100, "postTokens": 50},
+            },
+            {
+                "type": "user",
+                "uuid": "user-summary",
+                "timestamp": "2026-01-01T01:00:01Z",
+                "isCompactSummary": True,
+                "summarizeMetadata": {"messagesSummarized": 12, "direction": "from"},
+                "message": {"role": "user", "content": (
+                    "Summary:\n1. Primary intent: ship it.\n2. Key changes: X.\n"
+                    "3. Files touched: app.py.\n4. Next steps: review.\n"
+                    "5. More context.\n6. Even more.\n7. Yet more.\n8. Final.\n"
+                    "9. Overflow line — should be truncated."
+                )},
+            },
+            _user("after compaction", "2026-01-01T01:30:00Z"),
+        ],
+    )
+    d = extract_digest(path)
+    labels = [r.label for r in d.recap]
+    assert "Earlier" in labels
+    earlier = next(r for r in d.recap if r.label == "Earlier")
+    # Truncation cap is 8 lines; the source had 9.
+    assert "…" in earlier.text
+    assert earlier.text.count("\n") <= 8
+
+
+def test_recap_three_band_when_all_pre_history_sources_present(tmp_path: Path):
+    """All three pre-history bands (Started + Earlier + Recently) when every
+    source is available. Note: no "Last asked" — it was deliberately removed.
+    """
+    path = _write_jsonl(
+        tmp_path / "s.jsonl",
+        [
+            _user("first ask", "2026-01-01T00:00:00Z"),
+            {
+                "type": "system",
+                "subtype": "compact_boundary",
+                "content": "Conversation compacted",
+                "timestamp": "2026-01-01T00:30:00Z",
+            },
+            {
+                "type": "user",
+                "uuid": "u-summary",
+                "timestamp": "2026-01-01T00:30:01Z",
+                "isCompactSummary": True,
+                "message": {"role": "user", "content": "Compaction digest body."},
+            },
+            {
+                "type": "system",
+                "subtype": "away_summary",
+                "content": "Idle recap text.",
+                "timestamp": "2026-01-01T01:00:00Z",
+            },
+            # The "last-prompt" line type is intentionally ignored now;
+            # this test confirms it does not produce a recap band.
+            {
+                "type": "last-prompt",
+                "lastPrompt": "show me the file",
+                "sessionId": "s",
+            },
+        ],
+    )
+    d = extract_digest(path)
+    assert [r.label for r in d.recap] == ["Started", "Earlier", "Recently"]
+
+
+# ---------- Footer + duration ----------
+
+
+def test_extract_digest_picks_latest_permission_mode(tmp_path: Path):
+    path = _write_jsonl(
+        tmp_path / "s.jsonl",
+        [
+            {"type": "permission-mode", "sessionId": "s", "permissionMode": "default"},
+            _user("hi", "2026-01-01T00:00:00Z"),
+            {"type": "permission-mode", "sessionId": "s", "permissionMode": "acceptEdits"},
+        ],
+    )
+    assert extract_digest(path).permission_mode == "acceptEdits"
+
+
+def test_duration_seconds_spans_first_user_to_last_event(tmp_path: Path):
+    path = _write_jsonl(
+        tmp_path / "s.jsonl",
+        [
+            _user("start", "2026-01-01T00:00:00Z"),
+            _assistant("end", "2026-01-01T00:30:00Z", msg_id="m1"),
+        ],
+    )
+    d = extract_digest(path)
+    assert d.duration_seconds == 1800
+
+
+# ---------- Robustness ----------
+
+
+def test_extractor_skips_malformed_lines(tmp_path: Path):
+    path = tmp_path / "s.jsonl"
+    path.write_text(
+        "{not json}\n"
+        + json.dumps(_user("hi", "2026-01-01T00:00:00Z"))
+        + "\n"
+        + "[1, 2, 3]\n"
+    )
+    d = extract_digest(path)
+    assert d.recap[0].text == "hi"
+
+
+def test_missing_file_returns_empty_digest(tmp_path: Path):
+    d = extract_digest(tmp_path / "does-not-exist.jsonl", session_id="abc")
+    assert d.session_id == "abc"
+    assert d.recap == []
+    assert d.total_tokens == 0
+
+
+# ---------- "Started" prompt cleaning ----------
+
+
+def test_clean_first_prompt_strips_task_notification_envelope():
+    raw = (
+        "<task-notification>"
+        "<task-id>abc</task-id>"
+        "<output-file>/tmp/x</output-file>"
+        "</task-notification>\n"
+        "Actually do the work please."
+    )
+    assert _clean_first_prompt(raw) == "Actually do the work please."
+
+
+def test_clean_first_prompt_strips_from_preview_prefix():
+    raw = '[From "code block excerpt" — ~/path/file — 2026-04-26 01:06] Refactor this.'
+    assert _clean_first_prompt(raw) == "Refactor this."
+
+
+def test_clean_first_prompt_takes_first_sentence():
+    raw = "Redesign the kanban card title fallback chain. Also fix the spinner alignment."
+    assert _clean_first_prompt(raw) == "Redesign the kanban card title fallback chain."
+
+
+def test_clean_first_prompt_truncates_long_prompts_at_word_boundary():
+    raw = (
+        "I want to do a sort of mock-up of a Kanban UI toggle for the ThreadHop "
+        "application so we have four categories already that line up with what "
+        "we already have"
+    )
+    cleaned = _clean_first_prompt(raw)
+    assert cleaned.endswith("…")
+    assert len(cleaned) <= 141  # cap + ellipsis
+    # No mid-word break.
+    assert " " in cleaned[-30:] or cleaned.endswith("…")
+
+
+def test_clean_first_prompt_passes_short_prompts_unchanged():
+    assert _clean_first_prompt("What is this app?") == "What is this app?"
+
+
+def test_started_band_is_cleaned_in_extracted_digest(tmp_path: Path):
+    raw = (
+        "<task-notification><task-id>x</task-id></task-notification>\n"
+        "Audit the release runbook. Extra noise after the period."
+    )
+    path = _write_jsonl(
+        tmp_path / "s.jsonl",
+        [_user(raw, "2026-01-01T00:00:00Z")],
+    )
+    d = extract_digest(path)
+    assert d.recap[0].label == "Started"
+    assert d.recap[0].text == "Audit the release runbook."
+
+
+# ---------- Context window detection ----------
+
+
+def test_model_context_window_default_is_200k():
+    assert _model_context_window(None) == 200_000
+    assert _model_context_window("claude-opus-4-7") == 200_000
+    assert _model_context_window("claude-haiku-4-5") == 200_000
+    assert _model_context_window("claude-sonnet-4-6") == 200_000
+
+
+def test_model_context_window_detects_1m_suffix():
+    assert _model_context_window("claude-opus-4-7[1m]") == 1_000_000
+    assert _model_context_window("claude-opus-4-7-1m") == 1_000_000
+
+
+# ---------- Context fill calculation ----------
+
+
+def test_latest_turn_input_tokens_includes_cache(tmp_path: Path):
+    path = _write_jsonl(
+        tmp_path / "s.jsonl",
+        [
+            _user("hi", "2026-01-01T00:00:00Z"),
+            _assistant(
+                "first",
+                "2026-01-01T00:00:01Z",
+                msg_id="m1",
+                usage={
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "cache_read_input_tokens": 1000,
+                    "cache_creation_input_tokens": 0,
+                },
+            ),
+            _assistant(
+                "latest",
+                "2026-01-01T00:00:02Z",
+                msg_id="m2",
+                usage={
+                    "input_tokens": 200,
+                    "output_tokens": 75,
+                    "cache_read_input_tokens": 5000,
+                    "cache_creation_input_tokens": 100,
+                },
+            ),
+        ],
+    )
+    d = extract_digest(path)
+    # The latest turn's prompt = 200 + 5000 + 100 = 5300.
+    assert d.latest_turn_input_tokens == 5300
+
+
+def test_context_fill_ratio_uses_latest_model_window(tmp_path: Path):
+    path = _write_jsonl(
+        tmp_path / "s.jsonl",
+        [
+            _user("hi", "2026-01-01T00:00:00Z"),
+            _assistant(
+                "x",
+                "2026-01-01T00:00:01Z",
+                msg_id="m1",
+                model="claude-opus-4-7[1m]",
+                usage={
+                    "input_tokens": 50_000,
+                    "output_tokens": 1_000,
+                    "cache_read_input_tokens": 50_000,
+                    "cache_creation_input_tokens": 0,
+                },
+            ),
+        ],
+    )
+    d = extract_digest(path)
+    assert d.context_window == 1_000_000
+    assert d.latest_turn_input_tokens == 100_000
+    # 100k / 1M = 0.1
+    assert d.context_fill_ratio == pytest.approx(0.1)
+
+
+def test_context_fill_ratio_caps_at_one(tmp_path: Path):
+    path = _write_jsonl(
+        tmp_path / "s.jsonl",
+        [
+            _user("hi", "2026-01-01T00:00:00Z"),
+            _assistant(
+                "x",
+                "2026-01-01T00:00:01Z",
+                msg_id="m1",
+                usage={
+                    "input_tokens": 250_000,
+                    "output_tokens": 100,
+                    "cache_read_input_tokens": 0,
+                    "cache_creation_input_tokens": 0,
+                },
+            ),
+        ],
+    )
+    d = extract_digest(path)
+    assert d.context_fill_ratio == 1.0  # 250k / 200k clamped to 1.0
+
+
+def test_context_fill_ratio_is_none_when_no_assistant_turns(tmp_path: Path):
+    path = _write_jsonl(
+        tmp_path / "s.jsonl",
+        [_user("hi", "2026-01-01T00:00:00Z")],
+    )
+    d = extract_digest(path)
+    assert d.context_fill_ratio is None
+
+
+def test_total_input_tokens_billed_combines_input_and_cache(tmp_path: Path):
+    path = _write_jsonl(
+        tmp_path / "s.jsonl",
+        [
+            _user("hi", "2026-01-01T00:00:00Z"),
+            _assistant(
+                "x",
+                "2026-01-01T00:00:01Z",
+                msg_id="m1",
+                usage={
+                    "input_tokens": 100,
+                    "output_tokens": 200,
+                    "cache_read_input_tokens": 5000,
+                    "cache_creation_input_tokens": 50,
+                },
+            ),
+        ],
+    )
+    d = extract_digest(path)
+    # 100 (uncached) + 5000 (read) + 50 (created) = 5150
+    assert d.total_input_tokens_billed == 5150
+    # output unchanged
+    assert d.total_output_tokens == 200

--- a/tests/test_tui_session_digest_bar.py
+++ b/tests/test_tui_session_digest_bar.py
@@ -1,0 +1,196 @@
+"""Pilot-driven tests for ``SessionDigestBar``.
+
+The widget's job is to render whatever it's handed via ``set_digest``,
+full stop. The extractor that produces those digests is exercised
+separately in ``test_session_digest.py``.
+
+Tests are sync and drive Textual's async ``run_test()`` harness via
+``asyncio.run`` so we don't pull in ``pytest-asyncio`` for the suite.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+from threadhop_core.session.digest import RecapEntry, SessionDigest
+from threadhop_core.tui.widgets.session_digest_bar import SessionDigestBar
+
+
+class _Harness(App):
+    def compose(self) -> ComposeResult:
+        yield SessionDigestBar(id="bar")
+
+
+def _texts(bar: SessionDigestBar) -> list[str]:
+    out: list[str] = []
+    for s in bar.query(Static):
+        r = s.render()
+        out.append(r.plain if hasattr(r, "plain") else str(r))
+    return out
+
+
+def _run(coro):
+    """Run an async test body under asyncio without pytest-asyncio."""
+    return asyncio.run(coro)
+
+
+def test_bar_starts_with_placeholder():
+    async def body():
+        async with _Harness().run_test() as pilot:
+            bar = pilot.app.query_one("#bar", SessionDigestBar)
+            assert "Select a session" in " ".join(_texts(bar))
+
+    _run(body())
+
+
+def test_bar_renders_full_digest():
+    digest = SessionDigest(
+        session_id="abc12345-deadbeef",
+        custom_title="Workshop tag: feedback",
+        slug="brave-otter",
+        branch="dev",
+        duration_seconds=2 * 3600 + 14 * 60,  # 2h 14m
+        recap=[
+            RecapEntry(label="Started", timestamp=None, text="redesign kanban"),
+            RecapEntry(
+                label="Recently",
+                timestamp=None,
+                text="just finished input box restyle",
+            ),
+        ],
+        pr_number=73,
+        pr_repository="parzival1l/threadhop",
+        files_touched={"a.py", "b.py", "c.py"},
+        total_input_tokens=47_200,
+        total_output_tokens=12_000,
+        total_cache_read_tokens=3_500_000,
+        total_cache_creation_tokens=180_000,
+        latest_turn_input_tokens=50_000,  # latest prompt was ~50k tokens
+        context_window=1_000_000,         # opus-4-7[1m]
+        models_used=["claude-opus-4-7", "claude-haiku-4-5"],
+        permission_mode="acceptEdits",
+        client_version="2.1.131",
+    )
+
+    async def body():
+        async with _Harness().run_test() as pilot:
+            bar = pilot.app.query_one("#bar", SessionDigestBar)
+            bar.set_digest(digest)
+            await pilot.pause()
+            rendered = "\n".join(_texts(bar))
+
+            # Identity
+            assert "Workshop tag: feedback" in rendered
+            assert "brave-otter" in rendered
+            assert "⎇ dev" in rendered
+            assert "2h 14m" in rendered
+
+            # Recap (no "Last asked" — the most recent turn is in the
+            # transcript pane right next to the bar).
+            assert "Recap" in rendered
+            assert "Started" in rendered
+            assert "redesign kanban" in rendered
+            assert "Recently" in rendered
+            assert "Last asked" not in rendered
+
+            # Outputs
+            assert "PR #73" in rendered
+            assert "3 files" in rendered
+
+            # Context: fill headline + cumulative totals + cache + models.
+            assert "Context" in rendered
+            # Latest turn fill: 50.0k / 1.0M · 5% used
+            assert "50.0k" in rendered
+            assert "1.0M" in rendered
+            assert "5% used" in rendered
+            # Cumulative billed input = 47.2k + 3.5M + 180k = 3.7M.
+            # Output cumulative = 12.0k.
+            assert "input 3.7M" in rendered
+            assert "output 12.0k" in rendered
+            # Cache hit = 3.5M / (3.5M + 180k) ≈ 95%
+            assert "cache 95% hit" in rendered
+            # Models stay as friendly labels.
+            assert "Opus 4.7" in rendered
+            assert "Haiku 4.5" in rendered
+
+            # Footer
+            assert "acceptEdits" in rendered
+            assert "v2.1.131" in rendered
+            assert "claude -r abc12345" in rendered
+
+    _run(body())
+
+
+def test_bar_collapses_empty_sections():
+    digest = SessionDigest(
+        session_id="short-session",
+        recap=[RecapEntry(label="Started", timestamp=None, text="quick question")],
+    )
+
+    async def body():
+        async with _Harness().run_test() as pilot:
+            bar = pilot.app.query_one("#bar", SessionDigestBar)
+            bar.set_digest(digest)
+            await pilot.pause()
+            rendered = "\n".join(_texts(bar))
+
+            assert "Started" in rendered
+            assert "quick question" in rendered
+            # Section headers should not appear when their sources are empty.
+            assert "Outputs" not in rendered
+            assert "Context" not in rendered
+
+    _run(body())
+
+
+def test_bar_replaces_old_digest_on_set():
+    first = SessionDigest(
+        session_id="first",
+        custom_title="First session",
+        recap=[RecapEntry(label="Started", timestamp=None, text="alpha")],
+    )
+    second = SessionDigest(
+        session_id="second",
+        custom_title="Second session",
+        recap=[RecapEntry(label="Started", timestamp=None, text="beta")],
+    )
+
+    async def body():
+        async with _Harness().run_test() as pilot:
+            bar = pilot.app.query_one("#bar", SessionDigestBar)
+            bar.set_digest(first)
+            await pilot.pause()
+            bar.set_digest(second)
+            await pilot.pause()
+            rendered = "\n".join(_texts(bar))
+
+            assert "Second session" in rendered
+            assert "First session" not in rendered
+            assert "beta" in rendered
+            assert "alpha" not in rendered
+
+    _run(body())
+
+
+def test_bar_set_digest_none_resets_to_placeholder():
+    digest = SessionDigest(
+        session_id="x",
+        custom_title="X",
+        recap=[RecapEntry(label="Started", timestamp=None, text="hi")],
+    )
+
+    async def body():
+        async with _Harness().run_test() as pilot:
+            bar = pilot.app.query_one("#bar", SessionDigestBar)
+            bar.set_digest(digest)
+            await pilot.pause()
+            bar.set_digest(None)
+            await pilot.pause()
+            rendered = " ".join(_texts(bar))
+            assert "Select a session" in rendered
+            assert "X" not in rendered
+
+    _run(body())

--- a/threadhop_core/__init__.py
+++ b/threadhop_core/__init__.py
@@ -1,3 +1,3 @@
 """ThreadHop core package — version-of-truth and shared imports."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/threadhop_core/session/digest.py
+++ b/threadhop_core/session/digest.py
@@ -1,0 +1,475 @@
+"""Per-session digest extracted from a Claude Code JSONL transcript.
+
+The digest is the data shape behind the right-hand sidebar in the TUI
+(``SessionDigestBar``). It is a single read-only snapshot of everything
+the bar wants to show, computed in one pass over the JSONL.
+
+Why a separate module rather than extending the indexer:
+
+- The indexer's job is the FTS view of conversation lines. It deliberately
+  drops every non-message line type (``_NON_MESSAGE_TYPES`` in ``models.py``).
+  The digest reads exactly those dropped lines (``ai-title``, ``custom-title``,
+  ``pr-link``, ``last-prompt``, ``permission-mode``, ``system`` subtypes),
+  plus a few ambient fields on user/assistant lines (``slug``, ``gitBranch``,
+  ``version``, ``message.model``, ``message.usage``).
+- Keeping the extractor outside ``tui/`` lets the HTTP sidecar reuse it
+  later without pulling Textual into ``server/app.py``.
+
+The four-band recap timeline (Started → Earlier → Recently → Last asked)
+is built here too, because it depends on the same single-pass read.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+log = logging.getLogger("threadhop.session.digest")
+
+
+# Which tool_use names imply a file was touched. Edit/Write/MultiEdit cover
+# the common cases; NotebookEdit is rare but cheap to include.
+_FILE_TOUCH_TOOLS = frozenset({"Edit", "Write", "MultiEdit", "NotebookEdit"})
+
+# Default context window when we can't infer one from the model id.
+# Every Claude 4.x model is ≥200k; the [1m] suffix on opus-4-7 lifts it
+# to 1M. We don't try to enumerate every model — just spot the one
+# distinguishing flag and let the rest fall through to the safe default.
+_DEFAULT_CONTEXT_WINDOW = 200_000
+
+
+def _model_context_window(model: str | None) -> int:
+    """Return the context window size in tokens for a given model id."""
+    if not model:
+        return _DEFAULT_CONTEXT_WINDOW
+    if "[1m]" in model.lower() or model.lower().endswith("-1m"):
+        return 1_000_000
+    return _DEFAULT_CONTEXT_WINDOW
+
+
+# Regexes for cleaning the first user prompt before it becomes the
+# "Started" recap band. The patterns target the agent-injected
+# envelopes that show up in real transcripts (system reminders,
+# task-notification XML, "[From …]" previews) — they stay anchored
+# at start-of-string so they only fire on prefix noise, never on
+# legitimate body text.
+_NOISE_PREFIX_PATTERNS = [
+    re.compile(r"^\s*<task-notification>.*?</task-notification>\s*", re.DOTALL),
+    re.compile(r"^\s*<system-reminder>.*?</system-reminder>\s*", re.DOTALL),
+    re.compile(r"^\s*\[From\s+\".*?\"\s*[—-]\s*[^\]]*\]\s*"),
+]
+
+# Maximum length of the cleaned Started band. Long enough for a real
+# question, short enough that the body never overflows two visual rows
+# at the bar's 36-cell width.
+_STARTED_MAX_CHARS = 140
+
+
+def _clean_first_prompt(text: str) -> str:
+    """Strip agent-injected envelope noise and take a single-sentence headline.
+
+    Real transcripts often start with ``<task-notification>`` XML, a
+    ``[From "..." — path]`` preview, or other agent scaffolding. Those
+    prefixes don't read as a useful "what did the user originally ask"
+    headline; they're just framing. We strip the known patterns, then
+    take the first non-empty line, then truncate at the first sentence
+    boundary or 140 chars — whichever comes first.
+    """
+    cleaned = text.strip()
+    for pattern in _NOISE_PREFIX_PATTERNS:
+        cleaned = pattern.sub("", cleaned, count=1).strip()
+
+    # First non-empty line.
+    for line in cleaned.splitlines():
+        if line.strip():
+            cleaned = line.strip()
+            break
+
+    # First sentence — split on the earliest of '.', '?', '!' if it ends
+    # with whitespace (so URLs and version numbers don't trigger).
+    match = re.search(r"[.!?](?:\s|$)", cleaned)
+    if match and match.start() < _STARTED_MAX_CHARS:
+        cleaned = cleaned[: match.end()].rstrip()
+    if len(cleaned) > _STARTED_MAX_CHARS:
+        # Cut at the last word boundary before the cap so we don't
+        # truncate mid-word.
+        snippet = cleaned[:_STARTED_MAX_CHARS]
+        space = snippet.rfind(" ")
+        if space > _STARTED_MAX_CHARS - 30:
+            snippet = snippet[:space]
+        cleaned = snippet.rstrip(" ,;:.") + "…"
+    return cleaned
+
+
+@dataclass
+class RecapEntry:
+    """One band of the recap timeline.
+
+    ``label`` is the band name shown in the bar (``"Started"``,
+    ``"Earlier"``, ``"Recently"``, ``"Last asked"``). ``timestamp`` is the
+    line's ISO timestamp where available — used for the small relative
+    age suffix. ``text`` is the recap body, untruncated; the widget
+    decides how many lines to show.
+    """
+
+    label: str
+    timestamp: str | None
+    text: str
+
+
+@dataclass
+class SessionDigest:
+    """One session, summarized for the sidebar in a single pass."""
+
+    session_id: str
+
+    # Identity / context line
+    custom_title: str | None = None
+    ai_title: str | None = None
+    slug: str | None = None
+    branch: str | None = None
+    cwd: str | None = None
+
+    # Wall-clock duration in seconds, computed from first to last
+    # message timestamps observed in the JSONL.
+    duration_seconds: int | None = None
+
+    # Recap bands, in display order. Empty when nothing is available.
+    recap: list[RecapEntry] = field(default_factory=list)
+
+    # Outputs
+    pr_number: int | None = None
+    pr_url: str | None = None
+    pr_repository: str | None = None
+    files_touched: set[str] = field(default_factory=set)
+
+    # Token usage (sums across the session). Cache hit ratio is computed
+    # by the consumer from cache_read / (cache_read + cache_creation).
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_cache_read_tokens: int = 0
+    total_cache_creation_tokens: int = 0
+
+    # The size of the prompt at the *latest* assistant turn — the
+    # number that drives the "context fill" gauge in the bar.
+    # Computed as latest_usage.input_tokens + cache_read + cache_creation
+    # because all three are part of the prompt the model saw on that
+    # turn. Cumulative session totals live in the ``total_*`` fields
+    # above and are independent of context-window pressure.
+    latest_turn_input_tokens: int = 0
+
+    # Context window in tokens for the *latest* assistant model.
+    # Defaults to 200k; bumped to 1M when the model id carries the
+    # ``[1m]`` suffix (opus-4-7 long-context). The bar uses this as
+    # the denominator of the context-fill ratio.
+    context_window: int = _DEFAULT_CONTEXT_WINDOW
+
+    # Models actually used in this session, in first-seen order. Useful
+    # when a session has both Opus turns (chat) and Haiku turns
+    # (observer/skill subcalls).
+    models_used: list[str] = field(default_factory=list)
+
+    # Footer
+    permission_mode: str | None = None
+    client_version: str | None = None
+
+    @property
+    def files_touched_count(self) -> int:
+        return len(self.files_touched)
+
+    @property
+    def cache_hit_ratio(self) -> float | None:
+        denom = self.total_cache_read_tokens + self.total_cache_creation_tokens
+        if denom == 0:
+            return None
+        return self.total_cache_read_tokens / denom
+
+    @property
+    def total_tokens(self) -> int:
+        return (
+            self.total_input_tokens
+            + self.total_output_tokens
+            + self.total_cache_read_tokens
+            + self.total_cache_creation_tokens
+        )
+
+    @property
+    def total_input_tokens_billed(self) -> int:
+        """Cumulative TOTAL input billed across the session.
+
+        ``total_input_tokens`` alone is just the new (uncached) input;
+        the cache-read and cache-creation tokens are also part of every
+        turn's prompt. The headline "input" number on the bar should
+        be all three combined so the user sees the real input weight,
+        not just the uncached slice.
+        """
+        return (
+            self.total_input_tokens
+            + self.total_cache_read_tokens
+            + self.total_cache_creation_tokens
+        )
+
+    @property
+    def context_fill_ratio(self) -> float | None:
+        """Latest turn's prompt size as a fraction of the context window.
+
+        ``None`` when no assistant turn has reported usage yet. Capped
+        at 1.0 — sessions that touch compaction can briefly exceed the
+        window before the compactor lands, and a "103%" reading is
+        more confusing than informative on a passive bar.
+        """
+        if self.latest_turn_input_tokens <= 0 or self.context_window <= 0:
+            return None
+        ratio = self.latest_turn_input_tokens / self.context_window
+        return min(ratio, 1.0)
+
+    @property
+    def title(self) -> str:
+        """Best display title: custom > ai > slug > truncated session id."""
+        if self.custom_title:
+            return self.custom_title
+        if self.ai_title:
+            return self.ai_title
+        if self.slug:
+            return self.slug
+        return self.session_id[:8]
+
+
+def _parse_iso(ts: str | None) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def _truncate_lines(text: str, max_lines: int) -> str:
+    lines = text.splitlines()
+    if len(lines) <= max_lines:
+        return text
+    return "\n".join(lines[:max_lines]).rstrip() + "\n…"
+
+
+def extract_digest(jsonl_path: Path, *, session_id: str | None = None) -> SessionDigest:
+    """Single-pass extractor. Returns a partial digest if the file errors mid-read.
+
+    ``session_id`` defaults to the file stem when not provided. Lines that
+    fail to decode are skipped silently (matches indexer behavior); lines
+    with shapes we don't recognize are simply ignored.
+    """
+    sid = session_id or jsonl_path.stem
+    digest = SessionDigest(session_id=sid)
+
+    first_user_text: str | None = None
+    first_user_ts: str | None = None
+    last_event_ts: str | None = None
+
+    away_summary_text: str | None = None
+    away_summary_ts: str | None = None
+    compact_summary_text: str | None = None
+    compact_summary_ts: str | None = None
+
+    # Dedupe assistant usage by message.id (chunks share an id; usage
+    # lives on the final chunk and last-write-wins gives us the totals).
+    usage_by_msg_id: dict[str, dict] = {}
+    seen_models: list[str] = []
+    seen_models_set: set[str] = set()
+
+    # Track the latest assistant turn to compute context fill against
+    # that model's window. ``latest_usage`` mirrors the final usage
+    # block we saw; ``latest_model`` is whichever model id rode that
+    # final assistant message.
+    latest_usage: dict | None = None
+    latest_model: str | None = None
+
+    try:
+        with jsonl_path.open() as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(obj, dict):
+                    continue
+
+                t = obj.get("type")
+
+                # Ambient fields present on most line types.
+                if obj.get("slug") and not digest.slug:
+                    digest.slug = str(obj["slug"])
+                if obj.get("gitBranch"):
+                    digest.branch = str(obj["gitBranch"])
+                if obj.get("version"):
+                    digest.client_version = str(obj["version"])
+                if obj.get("cwd") and not digest.cwd:
+                    digest.cwd = str(obj["cwd"])
+                ts = obj.get("timestamp")
+                if isinstance(ts, str):
+                    last_event_ts = ts
+
+                if t == "custom-title":
+                    val = obj.get("customTitle")
+                    if val:
+                        digest.custom_title = str(val)
+                elif t == "ai-title":
+                    val = obj.get("aiTitle")
+                    if val:
+                        digest.ai_title = str(val)
+                elif t == "pr-link":
+                    pr_num = obj.get("prNumber")
+                    if pr_num is not None:
+                        try:
+                            digest.pr_number = int(pr_num)
+                        except (TypeError, ValueError):
+                            pass
+                    if obj.get("prUrl"):
+                        digest.pr_url = str(obj["prUrl"])
+                    if obj.get("prRepository"):
+                        digest.pr_repository = str(obj["prRepository"])
+                elif t == "permission-mode":
+                    val = obj.get("permissionMode")
+                    if val:
+                        digest.permission_mode = str(val)
+                elif t == "system":
+                    subtype = obj.get("subtype")
+                    content = obj.get("content")
+                    if subtype == "away_summary" and isinstance(content, str) and content:
+                        away_summary_text = content
+                        away_summary_ts = ts if isinstance(ts, str) else away_summary_ts
+                    elif subtype == "compact_boundary":
+                        cm = obj.get("compactMetadata") or {}
+                        # The compact_boundary line itself only carries
+                        # "Conversation compacted" — the actual digest is
+                        # written as the next user line with
+                        # isCompactSummary=true. We capture the timestamp
+                        # here; the text is filled in below.
+                        if isinstance(ts, str):
+                            compact_summary_ts = ts
+                        # Fallback: if a future schema ever inlines the
+                        # summary on the boundary line, take it.
+                        if isinstance(content, str) and len(content) > 30:
+                            compact_summary_text = content
+                elif t == "user":
+                    msg = obj.get("message") or {}
+                    content = msg.get("content")
+                    is_compact = bool(obj.get("isCompactSummary"))
+                    is_tool_result = bool(obj.get("toolUseResult"))
+                    if is_compact and isinstance(content, str):
+                        compact_summary_text = content
+                        if isinstance(ts, str):
+                            compact_summary_ts = ts
+                    elif not is_tool_result and isinstance(content, str) and content:
+                        if first_user_text is None:
+                            first_user_text = content
+                            if isinstance(ts, str):
+                                first_user_ts = ts
+                elif t == "assistant":
+                    msg = obj.get("message") or {}
+                    model = msg.get("model")
+                    if isinstance(model, str) and model:
+                        if model not in seen_models_set:
+                            seen_models.append(model)
+                            seen_models_set.add(model)
+                        latest_model = model
+                    msg_id = msg.get("id")
+                    usage = msg.get("usage")
+                    if isinstance(msg_id, str) and isinstance(usage, dict):
+                        usage_by_msg_id[msg_id] = usage
+                        latest_usage = usage
+                    content = msg.get("content")
+                    if isinstance(content, list):
+                        for block in content:
+                            if not isinstance(block, dict):
+                                continue
+                            if block.get("type") != "tool_use":
+                                continue
+                            if block.get("name") not in _FILE_TOUCH_TOOLS:
+                                continue
+                            inp = block.get("input") or {}
+                            if not isinstance(inp, dict):
+                                continue
+                            fp = inp.get("file_path") or inp.get("notebook_path")
+                            if isinstance(fp, str) and fp:
+                                digest.files_touched.add(fp)
+    except FileNotFoundError:
+        log.debug("digest extractor: %s not found", jsonl_path)
+        return digest
+    except Exception as e:
+        log.warning("digest extractor: partial read of %s — %s", jsonl_path, e)
+
+    # Sum token usage across deduped messages.
+    for u in usage_by_msg_id.values():
+        digest.total_input_tokens += int(u.get("input_tokens") or 0)
+        digest.total_output_tokens += int(u.get("output_tokens") or 0)
+        digest.total_cache_read_tokens += int(u.get("cache_read_input_tokens") or 0)
+        digest.total_cache_creation_tokens += int(
+            u.get("cache_creation_input_tokens") or 0
+        )
+
+    digest.models_used = seen_models
+
+    # Latest assistant turn → context fill. Sum input + cache_read +
+    # cache_creation because all three count against the prompt size
+    # the model saw. The model id picks the context window denominator.
+    if isinstance(latest_usage, dict):
+        digest.latest_turn_input_tokens = (
+            int(latest_usage.get("input_tokens") or 0)
+            + int(latest_usage.get("cache_read_input_tokens") or 0)
+            + int(latest_usage.get("cache_creation_input_tokens") or 0)
+        )
+    digest.context_window = _model_context_window(latest_model)
+
+    # Wall-clock duration: first user prompt → last event seen.
+    start = _parse_iso(first_user_ts)
+    end = _parse_iso(last_event_ts)
+    if start and end and end >= start:
+        digest.duration_seconds = int((end - start).total_seconds())
+
+    # Build the recap timeline. Each band is included only if its
+    # source exists; "Last asked" is *not* a band — the user can read
+    # the most recent turn directly in the transcript pane next door,
+    # so the bar focuses on what's not visible there: the session's
+    # earlier history.
+    recap: list[RecapEntry] = []
+    if first_user_text:
+        recap.append(
+            RecapEntry(
+                label="Started",
+                timestamp=first_user_ts,
+                text=_clean_first_prompt(first_user_text),
+            )
+        )
+    if compact_summary_text:
+        recap.append(
+            RecapEntry(
+                label="Earlier",
+                timestamp=compact_summary_ts,
+                text=_truncate_lines(compact_summary_text.strip(), 8),
+            )
+        )
+    if away_summary_text:
+        recap.append(
+            RecapEntry(
+                label="Recently",
+                timestamp=away_summary_ts,
+                text=away_summary_text.strip(),
+            )
+        )
+    digest.recap = recap
+
+    return digest
+
+
+__all__ = [
+    "RecapEntry",
+    "SessionDigest",
+    "extract_digest",
+]

--- a/threadhop_core/tui/app.py
+++ b/threadhop_core/tui/app.py
@@ -45,6 +45,7 @@ from threadhop_core.session.detection import (
     detect_project_from_cwd,
     get_active_claude_session_ids,
 )
+from threadhop_core.session.digest import extract_digest
 from threadhop_core.storage import db
 
 from .constants import (
@@ -84,6 +85,7 @@ from .utils import (
 )
 from .widgets.contextual_footer import ContextualFooter
 from .widgets.find_bar import FindBar
+from .widgets.session_digest_bar import SessionDigestBar
 from .widgets.session_list import SessionItem, SessionStatusHeader
 from .widgets.transcript import TranscriptView
 
@@ -100,6 +102,7 @@ _TUI_CSS_FILES = [
     str(_TUI_CSS_DIR / "help.tcss"),
     str(_TUI_CSS_DIR / "contextual_footer.tcss"),
     str(_TUI_CSS_DIR / "kanban.tcss"),
+    str(_TUI_CSS_DIR / "session_digest.tcss"),
 ]
 
 
@@ -202,6 +205,7 @@ class ClaudeSessions(App):
             TranscriptView(id="transcript-scroll"),
             id="transcript-column",
         )
+        yield SessionDigestBar(id="session-digest")
         yield Vertical(TextArea(id="reply-input"), id="input-container")
         yield ContextualFooter(id="contextual-footer")
 
@@ -802,6 +806,7 @@ class ClaudeSessions(App):
                 transcript._find_current = -1
 
             await transcript.load_transcript(event.item.session_data["path"])
+            self._refresh_digest(event.item.session_data)
 
     async def on_list_view_highlighted(self, event: ListView.Highlighted) -> None:
         if isinstance(event.item, SessionItem):
@@ -828,6 +833,7 @@ class ClaudeSessions(App):
                 transcript._find_current = -1
 
             await transcript.load_transcript(event.item.session_data["path"])
+            self._refresh_digest(event.item.session_data)
 
             if "last_viewed" not in self.config:
                 self.config["last_viewed"] = {}
@@ -981,6 +987,40 @@ class ClaudeSessions(App):
         if isinstance(item, SessionItem):
             return item
         return None
+
+    def _refresh_digest(self, session_data: dict | None) -> None:
+        """Recompute the per-session digest and push it to the right-hand bar.
+
+        Called from the highlight/select handlers and from the periodic
+        auto-refresh. JSONL extraction runs on the main thread today —
+        a 1MB transcript parses in ~30ms, well under the 5s refresh
+        cadence; if this ever shows up in profiles, move it to a worker
+        with ``self.run_worker``.
+        """
+        try:
+            bar = self.query_one("#session-digest", SessionDigestBar)
+        except Exception:
+            return
+        if not session_data:
+            bar.set_digest(None)
+            return
+        path_str = session_data.get("path")
+        sid = session_data.get("session_id")
+        if not path_str or not sid:
+            bar.set_digest(None)
+            return
+        try:
+            digest = extract_digest(Path(path_str), session_id=str(sid))
+        except Exception:
+            bar.set_digest(None)
+            return
+        # Prefer the title the App already computed (it knows about
+        # the SQLite custom_name column, which the JSONL doesn't see)
+        # by overlaying it on the digest's own title cascade.
+        custom_name = session_data.get("custom_name") or session_data.get("custom_title")
+        if custom_name and not digest.custom_title:
+            digest.custom_title = str(custom_name)
+        bar.set_digest(digest)
 
     def _spawn_observer(self, session_id: str) -> bool:
         try:

--- a/threadhop_core/tui/css/app.tcss
+++ b/threadhop_core/tui/css/app.tcss
@@ -1,7 +1,7 @@
 Screen {
     layout: grid;
-    grid-size: 2 2;
-    grid-columns: 36 1fr;
+    grid-size: 3 2;
+    grid-columns: 36 1fr 36;
     grid-rows: 1fr auto;
     grid-gutter: 0;
     /* Thin, muted scrollbars — Textual's default is 2 cells wide
@@ -110,7 +110,7 @@ FindBar {
    — the outer box uses border={["left"]} with backgroundElement fill
    and paddingLeft/Right=2 paddingTop=1, exactly mirrored here. */
 #input-container {
-    column-span: 2;
+    column-span: 3;
     border: none;
     border-left: thick $border-blurred;
     background: $surface;

--- a/threadhop_core/tui/css/session_digest.tcss
+++ b/threadhop_core/tui/css/session_digest.tcss
@@ -1,0 +1,136 @@
+/* SessionDigestBar — right-hand passive context column.
+
+   The bar mirrors the muted-border idiom shared by #session-list
+   and #transcript-scroll so the three top-row panels read as a
+   matched set. Idle border is $panel (recessive); focus-within
+   uses $accent — but the bar isn't focusable, so it stays muted
+   and only acts as a visual anchor. */
+
+#session-digest {
+    height: 100%;
+    border: solid $panel;
+    border-title-color: $text;
+    padding: 0 1;
+    scrollbar-size-vertical: 1;
+}
+
+/* Sections share a common vertical-rhythm rule: 1-row top margin so
+   each block is clearly separated, no per-section border (boxes
+   would compete with the panel's own border). */
+.digest-block {
+    height: auto;
+    margin-top: 1;
+}
+
+/* The first block (identity) has no top margin — it sits flush at
+   the top of the panel, mirroring how the session-list label sits
+   flush. */
+#session-digest > Vertical:first-of-type {
+    margin-top: 0;
+}
+
+.digest-placeholder {
+    color: $text-muted;
+    padding: 1 0 0 0;
+}
+
+/* ------------------------------ Identity */
+
+.digest-title {
+    color: $text;
+    text-style: bold;
+}
+
+.digest-slug {
+    color: $text-muted;
+}
+
+.digest-chips {
+    color: $text-muted;
+    margin-top: 1;
+}
+
+/* ------------------------------ Section headers
+
+   Bold, color $text (not muted) so each section has a clear
+   anchor — the muted-italic version we use for the kanban
+   subheader was tried and read as "barely there" in the right
+   column where there's already a lot of dim content. */
+.digest-section-header {
+    color: $text;
+    text-style: bold;
+    margin-bottom: 1;
+}
+
+/* ------------------------------ Recap bands
+
+   Each band is a label row + body text. The label gets a single
+   left-edge accent bar (OpenCode-style) so the timeline reads as
+   four ordered chunks without needing a divider between them. */
+.digest-recap-band {
+    height: auto;
+    margin-bottom: 1;
+    padding-left: 1;
+    border-left: thick $border-blurred;
+}
+
+.digest-band-label {
+    color: $text-muted;
+    text-style: italic;
+}
+
+.digest-band-body {
+    color: $text;
+    margin-top: 0;
+}
+
+/* ------------------------------ Outputs */
+
+.digest-output-row {
+    color: $text;
+}
+
+.digest-pr {
+    color: $accent;
+}
+
+/* ------------------------------ Context
+
+   Token rows are normal text; the model line is dimmed because
+   it's reference info (which models the session has used), not
+   primary content. */
+.digest-context-row {
+    color: $text;
+}
+
+/* The context-fill headline is the actionable single number on the
+   bar — promote it slightly via bold so the eye lands there first. */
+.digest-context-fill {
+    color: $text;
+    text-style: bold;
+}
+
+.digest-models {
+    color: $text-muted;
+}
+
+/* ------------------------------ Footer
+
+   The footer is dim by design — it's chrome, not content. The
+   resume command is a single dim line at the bottom of the bar;
+   no button, no border, just a copy-able string the user can
+   read off. */
+.digest-divider {
+    color: $border-blurred;
+    margin-top: 1;
+}
+
+.digest-footer-chips {
+    color: $text-muted;
+}
+
+.digest-footer-resume {
+    color: $text-muted;
+    text-style: italic;
+    margin-top: 1;
+}

--- a/threadhop_core/tui/widgets/session_digest_bar.py
+++ b/threadhop_core/tui/widgets/session_digest_bar.py
@@ -1,0 +1,265 @@
+"""Right-hand SessionDigestBar — passive context column for the focused session.
+
+The bar mirrors OpenCode's right-side info column (header → context →
+LSP → footer) but with ThreadHop-specific content: identity, recap
+timeline, outputs, token usage, and a small footer with model + perm
+mode + resume command.
+
+The bar is *passive*: it never holds focus, it only updates when the
+sidebar selection or the digest data changes. The owning App calls
+``set_digest(SessionDigest | None)`` whenever:
+
+  - the user highlights / selects a different session row, or
+  - the 5-second auto-refresh re-reads the active session's JSONL.
+
+When ``set_digest(None)`` is called the bar shows a muted placeholder.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from textual.app import ComposeResult
+from textual.containers import Vertical, VerticalScroll
+from textual.widgets import Static
+
+from ...session.digest import RecapEntry, SessionDigest
+from ..utils import format_age
+
+
+def _fmt_tokens(n: int) -> str:
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k"
+    return str(n)
+
+
+def _fmt_duration(seconds: int | None) -> str:
+    if seconds is None or seconds <= 0:
+        return ""
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        h = seconds // 3600
+        m = (seconds % 3600) // 60
+        return f"{h}h {m}m" if m else f"{h}h"
+    d = seconds // 86400
+    h = (seconds % 86400) // 3600
+    return f"{d}d {h}h" if h else f"{d}d"
+
+
+def _short_model(model: str) -> str:
+    """Render long model identifiers as compact display labels.
+
+    ``claude-opus-4-7[1m]`` → ``Opus 4.7 1m``; ``claude-haiku-4-5`` →
+    ``Haiku 4.5``. Unrecognized strings are passed through with a
+    length cap so a single odd model name can't blow the column width.
+    """
+    raw = model.strip()
+    if not raw:
+        return raw
+    lower = raw.lower()
+    suffix = ""
+    body = raw
+    if "[" in lower and lower.endswith("]"):
+        body, _, tail = raw.rpartition("[")
+        suffix = " " + tail.rstrip("]")
+        lower = body.lower()
+    for family, label in (
+        ("opus", "Opus"),
+        ("sonnet", "Sonnet"),
+        ("haiku", "Haiku"),
+    ):
+        if family in lower:
+            digits = "".join(ch for ch in lower.split(family, 1)[1] if ch.isdigit() or ch == "-")
+            digits = digits.strip("-").replace("--", "-")
+            version = ""
+            if digits:
+                parts = digits.split("-")
+                if parts[0]:
+                    version = parts[0]
+                if len(parts) > 1 and parts[1]:
+                    version = f"{version}.{parts[1]}"
+            return f"{label}{(' ' + version) if version else ''}{suffix}"
+    if len(raw) > 18:
+        return raw[:17] + "…"
+    return raw
+
+
+def _iso_to_age(ts: str | None) -> str:
+    if not ts:
+        return ""
+    try:
+        dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+    except Exception:
+        return ""
+    return format_age(dt.timestamp())
+
+
+class SessionDigestBar(VerticalScroll):
+    """Right-hand bar with identity / recap / outputs / context / footer."""
+
+    DEFAULT_CSS = ""  # all styling lives in css/session_digest.tcss
+
+    def __init__(self, *, id: str | None = None) -> None:
+        super().__init__(id=id)
+        self._digest: SessionDigest | None = None
+        self.can_focus = False
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="digest-empty"):
+            yield Static(
+                "Select a session to see its digest.",
+                classes="digest-placeholder",
+            )
+
+    def set_digest(self, digest: SessionDigest | None) -> None:
+        """Replace the bar contents with a fresh digest (or empty state)."""
+        self._digest = digest
+        # Tear down whatever was there and re-mount.
+        for child in list(self.children):
+            child.remove()
+        if digest is None:
+            self.mount(Static("Select a session to see its digest.",
+                              classes="digest-placeholder"))
+            return
+        self._mount_identity(digest)
+        if digest.recap:
+            self._mount_recap(digest.recap)
+        if self._has_outputs(digest):
+            self._mount_outputs(digest)
+        if self._has_context(digest):
+            self._mount_context(digest)
+        self._mount_footer(digest)
+
+    # ------------------------------------------------------------------ helpers
+
+    @staticmethod
+    def _has_outputs(d: SessionDigest) -> bool:
+        return bool(d.pr_number or d.files_touched)
+
+    @staticmethod
+    def _has_context(d: SessionDigest) -> bool:
+        return d.total_tokens > 0 or bool(d.models_used)
+
+    def _mount_identity(self, d: SessionDigest) -> None:
+        block = Vertical(classes="digest-block digest-identity")
+        self.mount(block)
+        block.mount(Static(d.title, classes="digest-title"))
+        meta_bits: list[str] = []
+        if d.slug:
+            meta_bits.append(d.slug)
+        if meta_bits:
+            block.mount(Static(" · ".join(meta_bits), classes="digest-slug"))
+        chip_parts: list[str] = []
+        if d.branch:
+            chip_parts.append(f"⎇ {d.branch}")
+        dur = _fmt_duration(d.duration_seconds)
+        if dur:
+            chip_parts.append(dur)
+        if chip_parts:
+            block.mount(Static("  ·  ".join(chip_parts), classes="digest-chips"))
+
+    def _mount_recap(self, recap: list[RecapEntry]) -> None:
+        block = Vertical(classes="digest-block digest-recap")
+        self.mount(block)
+        block.mount(Static("Recap", classes="digest-section-header"))
+        for entry in recap:
+            band = Vertical(classes="digest-recap-band")
+            block.mount(band)
+            label = entry.label
+            age = _iso_to_age(entry.timestamp)
+            if age:
+                label = f"{label} · {age} ago"
+            band.mount(Static(label, classes="digest-band-label"))
+            band.mount(Static(entry.text, classes="digest-band-body"))
+
+    def _mount_outputs(self, d: SessionDigest) -> None:
+        block = Vertical(classes="digest-block digest-outputs")
+        self.mount(block)
+        block.mount(Static("Outputs", classes="digest-section-header"))
+        if d.pr_number:
+            line = f"↗ PR #{d.pr_number}"
+            if d.pr_repository:
+                line += f"  {d.pr_repository}"
+            block.mount(Static(line, classes="digest-output-row digest-pr"))
+        if d.files_touched_count:
+            label = f"✎ {d.files_touched_count} file"
+            if d.files_touched_count != 1:
+                label += "s"
+            block.mount(Static(label, classes="digest-output-row"))
+
+    def _mount_context(self, d: SessionDigest) -> None:
+        block = Vertical(classes="digest-block digest-context")
+        self.mount(block)
+        block.mount(Static("Context", classes="digest-section-header"))
+
+        # Headline: latest turn's prompt size against the model's
+        # context window. This is the single most actionable token
+        # number — it tells the user how close they are to a compact.
+        fill_ratio = d.context_fill_ratio
+        if fill_ratio is not None:
+            fill_pct = fill_ratio * 100
+            block.mount(Static(
+                f"{_fmt_tokens(d.latest_turn_input_tokens)} / "
+                f"{_fmt_tokens(d.context_window)}  ·  {fill_pct:.0f}% used",
+                classes="digest-context-row digest-context-fill",
+            ))
+
+        # Cumulative session totals — independent of context-window
+        # pressure. ``total_input_tokens_billed`` includes cached reads
+        # and cache-creation so the user sees the real input weight,
+        # not just the uncached slice.
+        in_total = d.total_input_tokens_billed
+        out_total = d.total_output_tokens
+        if in_total or out_total:
+            block.mount(Static(
+                f"input {_fmt_tokens(in_total)}  ·  output {_fmt_tokens(out_total)}",
+                classes="digest-context-row",
+            ))
+
+        # Cache effectiveness as a single ratio line; the cached/uncached
+        # split is implicit in this number (95% hit ⇒ most input was
+        # cached).
+        if d.cache_hit_ratio is not None:
+            block.mount(Static(
+                f"cache {d.cache_hit_ratio * 100:.0f}% hit",
+                classes="digest-context-row",
+            ))
+
+        if d.models_used:
+            labels = [_short_model(m) for m in d.models_used]
+            # Filter out the synthetic placeholder so the model line stays useful.
+            labels = [l for l in labels if l and l != "<synthetic>"]
+            if labels:
+                block.mount(Static(
+                    " · ".join(labels),
+                    classes="digest-context-row digest-models",
+                ))
+
+    def _mount_footer(self, d: SessionDigest) -> None:
+        block = Vertical(classes="digest-block digest-footer")
+        self.mount(block)
+        block.mount(Static("─" * 8, classes="digest-divider"))
+        chip_parts: list[str] = []
+        if d.permission_mode:
+            chip_parts.append(d.permission_mode)
+        if d.client_version:
+            chip_parts.append(f"v{d.client_version}")
+        if chip_parts:
+            block.mount(Static("  ·  ".join(chip_parts), classes="digest-footer-chips"))
+        # Resume command — copy-able mental affordance even though the
+        # bar itself isn't focusable. Always show it; it's the one
+        # action-shaped artifact the bar carries.
+        sid = d.session_id
+        short = sid[:8] if len(sid) > 8 else sid
+        block.mount(Static(
+            f"claude -r {short}…",
+            classes="digest-footer-resume",
+        ))
+
+
+__all__ = ["SessionDigestBar"]


### PR DESCRIPTION
## Summary

- Releases 0.3.2, which ships the per-session digest bar — a right-hand panel that summarizes the highlighted session (title, custom name, working directory, recent activity, turn count) so you can scan the sidebar without opening transcripts.
- Bumps `__version__`, `marketplace.json`, `plugin.json` to 0.3.2; adds matching `CHANGELOG.md` entry.

## What's in this release

### Added
- Per-session digest bar pinned to the right of the transcript pane. Refreshes on highlight and on selection, and reuses `extract_digest` (the same JSONL view the transcript uses) so the bar and the transcript stay consistent.
- TUI grid widened from 2 columns to 3 to host the digest bar; the reply input now spans all three columns so the existing input experience is unchanged.

Commits in this release:
- `c1534d1` Add session digest bar to TUI
- `11f6edb` Bump to 0.3.2

## Test plan

- [x] 34 digest unit tests pass (`tests/test_session_digest.py`, `tests/test_tui_session_digest_bar.py`)
- [x] TUI imports cleanly with no t3 sidecar coupling
- [x] `validate` workflow passes (version parity + CHANGELOG entry)
- [ ] On merge: `release.yml` creates `v0.3.2` tag + GitHub Release
- [ ] After merge: `gh api /repos/parzival1l/threadhop/releases/latest --jq .tag_name` returns `"v0.3.2"`
- [ ] After merge: `./threadhop update --check` from a `v0.3.1` install prints the 3-line nudge
- [ ] Manual TUI smoke: launch `./threadhop`, highlight several sessions, confirm digest bar updates and reply input still spans the bottom

## References

- Compare: https://github.com/parzival1l/threadhop/compare/v0.3.1...dev