### PR TITLE
Fix search-jump session targeting and worktree CLI detection

### DIFF
--- a/tests/test_search_jump_session.py
+++ b/tests/test_search_jump_session.py
@@ -1,0 +1,98 @@
+"""Regression tests for cross-session search jump targeting (issue #76).
+
+Jumping to an FTS hit used to load the right transcript while leaving
+the sidebar highlight, `g` (copy resume command), and Enter (reply) on
+the previously selected session. These helpers are the canonical
+"current session" resolution those actions now share.
+"""
+
+from __future__ import annotations
+
+from threadhop_core.tui.utils import (
+    compute_visible_sessions,
+    resolve_action_session,
+)
+
+
+def _session(sid: str, status: str = "active", **extra) -> dict:
+    row = {
+        "session_id": sid,
+        "status": status,
+        "path": f"/tmp/{sid}.jsonl",
+        "project": "demo",
+        "modified": 0,
+        "title": sid,
+    }
+    row.update(extra)
+    return row
+
+
+def test_resolve_action_session_prefers_selected_id_over_highlight():
+    sessions = [_session("aaa"), _session("bbb")]
+    highlighted = sessions[0]
+    current = resolve_action_session(
+        selected_session_id="bbb",
+        sessions=sessions,
+        highlighted_session_data=highlighted,
+    )
+    assert current is not None
+    assert current["session_id"] == "bbb"
+
+
+def test_resolve_action_session_does_not_fall_back_to_a_different_highlight():
+    """If the jumped-to session isn't in the list yet, don't silently
+    target the old highlight — that's how replies were misdirected."""
+    sessions = [_session("aaa")]
+    current = resolve_action_session(
+        selected_session_id="bbb",
+        sessions=sessions,
+        highlighted_session_data=sessions[0],
+    )
+    assert current is None
+
+
+def test_resolve_action_session_falls_back_to_highlight_when_unselected():
+    sessions = [_session("aaa")]
+    current = resolve_action_session(
+        selected_session_id=None,
+        sessions=sessions,
+        highlighted_session_data=sessions[0],
+    )
+    assert current is sessions[0]
+
+
+def test_visible_sessions_injects_pinned_session_not_in_window():
+    """A search jump to a session outside the days/cap window still
+    gets a sidebar row so `g` and reply can target it."""
+    in_window = [_session(f"s{i}") for i in range(3)]
+    pinned = _session("old-session")
+    visible = compute_visible_sessions(
+        in_window, show_archived=False, pinned_session=pinned
+    )
+    ids = [s["session_id"] for s in visible]
+    assert ids[0] == "old-session"
+    assert "s0" in ids
+
+
+def test_visible_sessions_does_not_duplicate_pinned_session():
+    sessions = [_session("aaa"), _session("bbb")]
+    visible = compute_visible_sessions(
+        sessions, show_archived=False, pinned_session=sessions[1]
+    )
+    ids = [s["session_id"] for s in visible]
+    assert ids.count("bbb") == 1
+
+
+def test_visible_sessions_pins_archived_session_without_showing_all_archived():
+    active = _session("live")
+    archived_other = _session("other-archived", status="archived")
+    pinned = _session("jumped-archived", status="archived")
+    visible = compute_visible_sessions(
+        [active, archived_other, pinned],
+        show_archived=False,
+        pinned_session=pinned,
+    )
+    ids = [s["session_id"] for s in visible]
+    assert "jumped-archived" in ids
+    assert "live" in ids
+    assert "other-archived" not in ids

--- a/tests/test_session_detection.py
+++ b/tests/test_session_detection.py
@@ -1,0 +1,63 @@
+"""Unit tests for Claude process-arg parsing and session auto-detection."""
+
+from __future__ import annotations
+
+from threadhop_core.session.detection import _parse_claude_process_args
+
+SID = "11111111-1111-1111-1111-111111111111"
+
+
+def test_parse_bare_claude_is_interactive():
+    assert _parse_claude_process_args("claude") == (True, None)
+
+
+def test_parse_pathed_claude_is_interactive():
+    assert _parse_claude_process_args("/usr/local/bin/claude") == (True, None)
+
+
+def test_parse_resume_uuid_is_explicit():
+    assert _parse_claude_process_args(f"claude --resume {SID}") == (True, SID)
+    assert _parse_claude_process_args(f"claude -r {SID}") == (True, SID)
+
+
+def test_parse_print_mode_is_not_interactive():
+    assert _parse_claude_process_args("claude -p --resume " + SID) == (False, None)
+    assert _parse_claude_process_args("claude --print do something")[0] is False
+
+
+def test_parse_worktree_without_resume_is_interactive():
+    """`claude --worktree <name>` is a live interactive session (issue #70).
+
+    The binary name is the bare token `claude`, which does not end with
+    `/claude`, and the last arg is the worktree name — so the old fallback
+    treated this as a non-session process and `threadhop tag` failed to
+    auto-detect.
+    """
+    is_interactive, explicit = _parse_claude_process_args(
+        "claude --worktree mutable-crunching-snowflake"
+    )
+    assert is_interactive is True
+    assert explicit is None
+
+
+def test_parse_worktree_with_resume_uuid():
+    is_interactive, explicit = _parse_claude_process_args(
+        f"claude --worktree mutable-crunching-snowflake --resume {SID}"
+    )
+    assert is_interactive is True
+    assert explicit == SID
+
+
+def test_parse_equals_form_worktree_is_interactive():
+    is_interactive, explicit = _parse_claude_process_args(
+        "claude --worktree=mutable-crunching-snowflake"
+    )
+    assert is_interactive is True
+    assert explicit is None
+
+
+def test_parse_pathed_worktree_is_interactive():
+    is_interactive, _ = _parse_claude_process_args(
+        "/opt/homebrew/bin/claude --worktree mutable-crunching-snowflake"
+    )
+    assert is_interactive is True

--- a/threadhop_core/session/detection.py
+++ b/threadhop_core/session/detection.py
@@ -48,6 +48,14 @@ def _parse_claude_process_args(args: str) -> tuple[bool, str | None]:
                     explicit_id = candidate
         elif a in ("-c", "--continue") and "-p" not in arg_parts:
             is_interactive = True
+        elif (a == "--worktree" or a.startswith("--worktree=")) and "-p" not in arg_parts:
+            # `claude --worktree <name>` is an interactive session. The
+            # live argv often has no `--resume`, last-arg is the worktree
+            # name (not `claude`), and the binary token is the bare word
+            # `claude` which does not end with `/claude` — so the fallback
+            # below used to miss it and `threadhop tag` failed to detect
+            # the current session (issue #70).
+            is_interactive = True
     if not is_interactive:
         if arg_parts[-1] == "claude" or (
             arg_parts[0].endswith("/claude")

--- a/threadhop_core/tui/app.py
+++ b/threadhop_core/tui/app.py
@@ -81,7 +81,9 @@ from .theme import get_available_themes
 from .utils import (
     app_bindings_from_registry,
     build_observe_command,
+    compute_visible_sessions,
     copy_to_clipboard,
+    resolve_action_session,
 )
 from .widgets.contextual_footer import ContextualFooter
 from .widgets.find_bar import FindBar
@@ -151,6 +153,10 @@ class ClaudeSessions(App):
         self.days_filter = days
         self.sessions = []
         self._selected_session_id = None
+        # Search-jump pin: a session the user jumped to that isn't in
+        # the current days/cap/archive window. Survives the 5s refresh
+        # until they highlight a different sidebar row (issue #76).
+        self._pinned_session: dict | None = None
         self._spinner_frame = 0
         self._renaming_session_id = None
         self._show_archived = False
@@ -596,26 +602,61 @@ class ClaudeSessions(App):
         Within-bucket ordering is preserved (the master list is already
         sorted by ``(status_rank, manual_sort_order)``).
         """
-        per_bucket: dict[str, list[dict]] = {}
-        for s in self.sessions:
-            status = s.get("status", "active")
-            if status == "archived" and not self._show_archived:
-                continue
-            bucket = per_bucket.setdefault(status, [])
-            if len(bucket) < MAX_SESSIONS:
-                bucket.append(s)
+        return compute_visible_sessions(
+            self.sessions,
+            show_archived=self._show_archived,
+            pinned_session=self._pinned_session,
+        )
 
-        out: list[dict] = []
-        for status in STATUS_ORDER:
-            out.extend(per_bucket.get(status, []))
-        # Catch-all for unknown statuses (defensive — shouldn't fire given
-        # the CHECK constraint in storage/db.py, but matches the same
-        # tail-append the sidebar already does).
-        for status, bucket in per_bucket.items():
-            if status in STATUS_RANK:
-                continue
-            out.extend(bucket)
-        return out
+    def _session_dict_from_db(
+        self, session_id: str, session_path: Path, row: dict
+    ) -> dict:
+        """Build a sidebar session dict for a DB row outside the current scan."""
+        try:
+            stat = session_path.stat()
+            created = stat.st_ctime
+            modified = stat.st_mtime
+        except OSError:
+            created = row.get("created_at") or 0
+            modified = row.get("modified_at") or 0
+        custom = row.get("custom_name") or ""
+        return {
+            "path": session_path,
+            "project": row.get("project") or session_path.parent.name,
+            "cwd": row.get("cwd"),
+            "session_id": session_id,
+            "created": created,
+            "modified": modified,
+            "title": custom or session_id[:8],
+            "custom_title": custom,
+            "ai_title": "",
+            "first_user_msg": None,
+            "is_active": False,
+            "is_working": False,
+            "turn_count": 0,
+            "status": row.get("status") or "active",
+            "has_observations": False,
+        }
+
+    def _current_session_data(self) -> dict | None:
+        """Session that copy-resume / reply / observe should act on.
+
+        Prefers ``_selected_session_id`` (search jump, explicit pick)
+        over the sidebar highlight so actions follow the transcript
+        the user is looking at (issue #76).
+        """
+        highlighted = None
+        try:
+            list_view = self.query_one("#session-list", ListView)
+            if isinstance(list_view.highlighted_child, SessionItem):
+                highlighted = list_view.highlighted_child.session_data
+        except Exception:
+            highlighted = None
+        return resolve_action_session(
+            selected_session_id=self._selected_session_id,
+            sessions=self._visible_sessions(),
+            highlighted_session_data=highlighted,
+        )
 
     def _apply_stable_ordering(self) -> None:
         if "session_order" not in self.config:
@@ -812,6 +853,11 @@ class ClaudeSessions(App):
         if isinstance(event.item, SessionItem):
             session_id = event.item.session_data.get("session_id")
             self._selected_session_id = session_id
+            if (
+                self._pinned_session
+                and session_id != self._pinned_session.get("session_id")
+            ):
+                self._pinned_session = None
             transcript = self.query_one("#transcript-scroll", TranscriptView)
 
             # Manual sidebar navigation ends any in-progress search-jump
@@ -947,13 +993,9 @@ class ClaudeSessions(App):
         if self._find_is_active():
             self.action_find_next()
             return
-        list_view = self.query_one("#session-list", ListView)
-        if not list_view.highlighted_child or not isinstance(
-            list_view.highlighted_child, SessionItem
-        ):
+        session = self._current_session_data()
+        if not session:
             return
-
-        session = list_view.highlighted_child.session_data
         session_id = session.get("session_id", "")
         current_name = self.config.get("session_names", {}).get(session_id, "")
 
@@ -966,12 +1008,10 @@ class ClaudeSessions(App):
 
     def action_copy_session_id(self) -> None:
         """Copy 'claude -r <session_id>' to clipboard"""
-        list_view = self.query_one("#session-list", ListView)
-        if not list_view.highlighted_child or not isinstance(
-            list_view.highlighted_child, SessionItem
-        ):
+        session = self._current_session_data()
+        if not session:
             return
-        session_id = list_view.highlighted_child.session_data.get("session_id", "")
+        session_id = session.get("session_id", "")
         cmd = f"claude -r {session_id}"
         try:
             if not copy_to_clipboard(cmd):
@@ -982,7 +1022,22 @@ class ClaudeSessions(App):
             self.notify(f"Resume: {cmd}", timeout=10)
 
     def _highlighted_session_item(self) -> SessionItem | None:
-        list_view = self.query_one("#session-list", ListView)
+        """Sidebar row for the session actions should target.
+
+        Looks up ``_selected_session_id`` first so observe/copy/reply
+        follow a search jump even when the highlight was stale.
+        """
+        data = self._current_session_data()
+        if not data:
+            return None
+        sid = data.get("session_id")
+        try:
+            list_view = self.query_one("#session-list", ListView)
+        except Exception:
+            return None
+        for item in list_view.children:
+            if isinstance(item, SessionItem) and item.session_data.get("session_id") == sid:
+                return item
         item = list_view.highlighted_child
         if isinstance(item, SessionItem):
             return item
@@ -1246,13 +1301,6 @@ class ClaudeSessions(App):
         """Focus the reply input"""
         text_area = self.query_one("#reply-input", TextArea)
         if not text_area.has_focus:
-            list_view = self.query_one("#session-list", ListView)
-            if list_view.highlighted_child and isinstance(
-                list_view.highlighted_child, SessionItem
-            ):
-                self._selected_session_id = (
-                    list_view.highlighted_child.session_data.get("session_id")
-                )
             text_area.focus()
 
     def action_open_search(self) -> None:
@@ -1687,28 +1735,24 @@ class ClaudeSessions(App):
             return
 
         self._selected_session_id = session_id
-        # Lock the foreign session in so the 5s refresh tick doesn't
-        # reload the sidebar's selection over the top of this panel.
-        # Cleared by the user selecting anything in the sidebar.
-        transcript._foreign_session_path = session_path
-        transcript.queue_scroll_to_uuid(message_uuid, search_terms)
-        # load_transcript is async; schedule and let the pending scroll
-        # fire at the end of the load.
-        self.call_later(transcript.load_transcript, session_path)
-
-        # Put the foreign session's identity in the transcript border
-        # title so the user knows the panel is showing a session that
-        # isn't in their sidebar. Gets reset to "Transcript" by the
-        # normal selection-exit flow when they click back into a
-        # sidebar session.
-        name = row.get("custom_name") or row.get("project") or session_id[:8]
-        project = row.get("project") or ""
-        label = f"Transcript ── [{project}] {name}" if project else f"Transcript ── {name}"
-        transcript.border_title = label + "  (from search — not in sidebar)"
-        self.notify(
-            f"Jumped to out-of-view session: {name}",
-            timeout=4,
+        self._pinned_session = self._session_dict_from_db(
+            session_id, session_path, row
         )
+        # Sidebar now owns this session, so the 5s refresh can follow
+        # the highlight instead of needing the foreign-session lock.
+        transcript._foreign_session_path = None
+        transcript.queue_scroll_to_uuid(message_uuid, search_terms)
+        self._update_session_list(force_rebuild=True)
+        for idx, item in enumerate(list_view.children):
+            if (
+                isinstance(item, SessionItem)
+                and item.session_data.get("session_id") == session_id
+            ):
+                list_view.index = idx
+                break
+        list_view.focus()
+        name = row.get("custom_name") or row.get("project") or session_id[:8]
+        self.notify(f"Jumped to {name}", timeout=4)
 
     def check_action(self, action: str, parameters):
         """Disable the priority Enter binding while a modal is up OR the
@@ -1734,13 +1778,6 @@ class ClaudeSessions(App):
         if text_area.has_focus:
             self._submit_reply()
         else:
-            list_view = self.query_one("#session-list", ListView)
-            if list_view.highlighted_child and isinstance(
-                list_view.highlighted_child, SessionItem
-            ):
-                self._selected_session_id = (
-                    list_view.highlighted_child.session_data.get("session_id")
-                )
             text_area.focus()
 
     def action_insert_newline(self) -> None:
@@ -1820,17 +1857,17 @@ class ClaudeSessions(App):
         if not input_text:
             return
 
-        # Find the selected session
-        list_view = self.query_one("#session-list", ListView)
-        if not list_view.highlighted_child or not isinstance(
-            list_view.highlighted_child, SessionItem
-        ):
+        # Find the selected session — prefer the jumped-to / explicitly
+        # selected id over the sidebar highlight (issue #76).
+        session = self._current_session_data()
+        if not session:
             self.notify("No session selected", severity="error")
             return
 
-        session = list_view.highlighted_child.session_data
         session_id = session.get("session_id", "")
         session_cwd = session.get("cwd")
+        list_view = self.query_one("#session-list", ListView)
+        current_item = self._highlighted_session_item()
 
         # Clear input and show sending state
         text_area.clear()
@@ -1839,12 +1876,12 @@ class ClaudeSessions(App):
 
         # Mark session as working immediately
         session["is_working"] = True
-        if isinstance(list_view.highlighted_child, SessionItem):
-            list_view.highlighted_child.session_data["is_working"] = True
+        if isinstance(current_item, SessionItem):
+            current_item.session_data["is_working"] = True
             try:
-                label = list_view.highlighted_child.query_one(".session-label", Static)
+                label = current_item.query_one(".session-label", Static)
                 label.add_class("working")
-                list_view.highlighted_child.update_spinner(self._spinner_frame)
+                current_item.update_spinner(self._spinner_frame)
             except:
                 pass
 

--- a/threadhop_core/tui/utils.py
+++ b/threadhop_core/tui/utils.py
@@ -20,9 +20,12 @@ from threadhop_core import indexer
 
 from .constants import (
     DISPLAY_NAME_WIDTH,
+    MAX_SESSIONS,
     OBSERVATION_MARKER,
     OBSERVATION_MARKER_FALLBACK,
     SPINNER_FRAMES,
+    STATUS_ORDER,
+    STATUS_RANK,
 )
 from .keybindings import COMMAND_REGISTRY, Command, format_key
 
@@ -65,6 +68,64 @@ def app_bindings_from_registry() -> list[Binding]:
     # it doubles as "close find bar" when the bar is up (see
     # action_cancel_reply). Registered via the SCOPE_REPLY entry above.
     return bindings
+
+
+def compute_visible_sessions(
+    sessions: list[dict],
+    *,
+    show_archived: bool = False,
+    pinned_session: dict | None = None,
+) -> list[dict]:
+    """Filter and cap sessions the same way the sidebar and Kanban do.
+
+    Applies the per-status ``MAX_SESSIONS`` budget and the archived
+    toggle. ``pinned_session`` is prepended when a search jump lands on
+    a session that would otherwise be filtered out of the window, so
+    copy-resume and reply still have a row to target (issue #76).
+    """
+    per_bucket: dict[str, list[dict]] = {}
+    for s in sessions:
+        status = s.get("status", "active")
+        if status == "archived" and not show_archived:
+            continue
+        bucket = per_bucket.setdefault(status, [])
+        if len(bucket) < MAX_SESSIONS:
+            bucket.append(s)
+
+    out: list[dict] = []
+    for status in STATUS_ORDER:
+        out.extend(per_bucket.get(status, []))
+    for status, bucket in per_bucket.items():
+        if status in STATUS_RANK:
+            continue
+        out.extend(bucket)
+
+    if pinned_session:
+        pid = pinned_session.get("session_id")
+        if pid and not any(s.get("session_id") == pid for s in out):
+            out.insert(0, pinned_session)
+    return out
+
+
+def resolve_action_session(
+    *,
+    selected_session_id: str | None,
+    sessions: list[dict],
+    highlighted_session_data: dict | None,
+) -> dict | None:
+    """Pick the session that copy-resume / reply / observe should act on.
+
+    ``selected_session_id`` (search jump, explicit pick) wins. If that
+    id is not in ``sessions``, return None rather than the stale
+    sidebar highlight — sending a reply to the previously highlighted
+    thread is worse than refusing.
+    """
+    if selected_session_id:
+        for s in sessions:
+            if s.get("session_id") == selected_session_id:
+                return s
+        return None
+    return highlighted_session_data
 
 
 def format_age(timestamp: float) -> str:
@@ -208,11 +269,13 @@ __all__ = [
     "app_bindings_from_registry",
     "build_observe_command",
     "commands_for_scope",
+    "compute_visible_sessions",
     "copy_to_clipboard",
     "format_age",
     "format_command_keys",
     "format_msg_clock",
     "render_session_label_text",
+    "resolve_action_session",
     "_observation_marker_text",
     "_session_display_name",
     "_supports_observation_emoji",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Patches two unpatched Python bugs:

**[#76](https://github.com/parzival1l/threadhop/issues/76) — Cross-session search jump targeted the old session.** Jumping to an FTS hit in a session that was not in the sidebar loaded the right transcript, but `g` (copy resume), Enter (reply), and observe still used the previously highlighted row. Replies could silently go to the wrong session.

- Pin the jumped-to session into the sidebar (even if it is outside the days/cap/archive window).
- Resolve copy/reply/observe from `_selected_session_id`, not the stale highlight.
- If that id is missing from the visible list, refuse rather than acting on the old highlight.

**[#70](https://github.com/parzival1l/threadhop/issues/70) — `threadhop tag` failed inside `--worktree` sessions.** `claude --worktree <name>` is an interactive session, but the process parser only treated `--resume` / `--continue` / `*/claude` as interactive. Bare `claude --worktree …` has last-arg = the worktree name and argv0 = `claude` (which does not end with `/claude`), so auto-detect returned nothing.

Left alone on purpose (not correctness bugs):
- [#59](https://github.com/parzival1l/threadhop/issues/59) Option+Backspace in inputs (macOS papercut)
- [#58](https://github.com/parzival1l/threadhop/issues/58) turn-as-unit rendering (design follow-up)

## Test plan

- [x] `tests/test_search_jump_session.py` — pinned-session visibility + action targeting
- [x] `tests/test_session_detection.py` — `--worktree` process parsing
- [x] Full suite: 249 passed
- [ ] In the TUI: search-jump to a session outside `--days`, confirm sidebar highlights it, `g` copies that id, Enter replies to it
- [ ] From a `claude --worktree …` terminal: `threadhop tag in_progress` auto-detects the session

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03539-e6ab-77ee-ad8c-fdadd17b1afb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03539-e6ab-77ee-ad8c-fdadd17b1afb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

